### PR TITLE
docs: remove Ollama, route all AI through external LiteLLM at llm.k4jda.net

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,9 @@ Self-hosted personal AI knowledge infrastructure. Ingests from voice memos, Slac
 
 - **Runtime**: TypeScript, Hono framework, Drizzle ORM
 - **Database**: Postgres 16 + pgvector (pgvector/pgvector:pg16 image, no Supabase)
-- **LLM Gateway**: LiteLLM proxy for all LLM requests (not embeddings). Model aliases: fast, synthesis, governance, intent.
-- **Embeddings**: Configurable model via Ollama (evaluating nomic-embed-text vs Qwen3-Embedding). NO fallback — queue and retry if Ollama is down.
+- **LLM Gateway**: LiteLLM at https://llm.k4jda.net for ALL AI requests — both embeddings and LLM inference. No Ollama container in Open Brain stack.
+- **Embeddings**: Qwen3-Embedding-4B-Q4_K_M via `jetson-embeddings` alias on LiteLLM (Jetson device). OpenAI embeddings API. NO fallback — queue and retry if LiteLLM/Jetson is down.
+- **LLM Inference**: Model aliases fast, synthesis, governance, intent — all through LiteLLM. Backing providers TBD (configure on llm.k4jda.net before Phase 6).
 - **Schema**: `vector(768)` everywhere. Do not use 1536.
 - **Search**: Hybrid retrieval (FTS + vector with RRF) + ACT-R temporal decay scoring. Default temporal_weight: 0.0 (cold start), ramp up as search history builds.
 - **MCP Auth**: Authorization: Bearer header (not URL query parameter)

--- a/IMPLEMENTATION_PLAN-PHASE2.md
+++ b/IMPLEMENTATION_PLAN-PHASE2.md
@@ -803,6 +803,27 @@
 
 ---
 
+### 14.5 AI Budget Monitoring ($30 Soft Alert)
+
+**Description**: Scheduled daily job that checks monthly LiteLLM spend via `AIRouterService.getMonthlySpend()`. Fires a Pushover alert when spend exceeds the $30 soft threshold. The $50 hard limit is enforced by LiteLLM itself — this catches it early while there's still budget headroom.
+
+**Complexity**: S
+
+**Files to Create/Modify**:
+- `packages/workers/src/jobs/budget-check.ts` — BudgetCheckJob: calls `GET https://llm.k4jda.net/spend/logs` with LITELLM_API_KEY. Parses current month total spend. If spend > $30 (BUDGET_SOFT_LIMIT env var, default 30): send Pushover alert (normal priority) with "AI spend is $X.XX this month ($30 soft limit)". Logs spend regardless. No alert if under threshold.
+- `packages/workers/src/scheduler.ts` — Update: add budget-check to daily schedule (runs at 8:00 AM, cron: `0 8 * * *`).
+
+**Acceptance Criteria**:
+- Runs daily at 8:00 AM
+- Fetches current month spend from LiteLLM `/spend/logs`
+- Pushover alert fires when spend > $30 (configurable via BUDGET_SOFT_LIMIT)
+- No alert when under threshold (just logs)
+- BUDGET_SOFT_LIMIT defaults to 30, overridable via env var
+
+**Requirement Refs**: PRD §AI budget ($30 soft alert, $50 hard limit), TDD §8.7 (LiteLLM spend tracking)
+
+---
+
 ## Phase 15: Web Dashboard
 
 **Goal**: Vite + React PWA for browsing, searching, and viewing skill outputs. Installable on iPhone home screen.
@@ -826,7 +847,7 @@
 - `packages/web/tailwind.config.ts` — Tailwind config with shadcn/ui preset
 - `packages/web/src/main.tsx` — React entry point
 - `packages/web/src/App.tsx` — Root component with React Router (lazy-loaded pages)
-- `packages/web/src/lib/api.ts` — API client for Core API (evaluate reuse of existing packages/web-ui/src/lib/api-client.ts, update to match v0.6 schema)
+- `packages/web/src/lib/api.ts` — API client for Core API: typed fetch wrappers for all Core API endpoints, matching v0.6 schema
 - `packages/web/src/lib/types.ts` — Frontend type definitions (import from @open-brain/shared where possible)
 - `packages/web/index.html` — HTML entry
 - `packages/web/src/index.css` — Tailwind directives
@@ -937,14 +958,14 @@
 - `packages/web/src/lib/sse.ts` — SSE client connecting to Core API /api/v1/events. Listens for: capture_created, pipeline_complete, skill_complete, bet_expiring. Updates Zustand store.
 - `packages/core-api/src/routes/events.ts` — GET /api/v1/events (SSE endpoint). Uses Postgres LISTEN/NOTIFY for capture_created and pipeline_complete events. Keeps connection alive with heartbeat.
 - `packages/core-api/src/lib/pg-notify.ts` — Postgres LISTEN/NOTIFY helper: subscribe to channels, emit events to SSE connections.
-- `docker-compose.yml` — Add web-ui service (build from packages/web, nginx, port 3002, depends on core-api). Update cloudflared routing: brain.k4jda.net/ → web-ui:80.
+- `docker-compose.yml` — Add web service (build from packages/web, nginx, port 3002, service name: web, depends on core-api). Update cloudflared routing: brain.k4jda.net/ → web:80.
 - `packages/web/Dockerfile` — Nginx-based: build Vite → copy to nginx, proxy /api to core-api
 
 **Acceptance Criteria**:
 - PWA installable on iPhone home screen
 - SSE updates dashboard in real-time (new captures appear, pipeline status updates)
 - Docker container serves static assets via nginx
-- Cloudflare Tunnel routes brain.k4jda.net/ to web-ui
+- Cloudflare Tunnel routes brain.k4jda.net/ to web (nginx)
 
 **Requirement Refs**: PRD F19 (PWA), TDD §13.1 (SSE), TDD §14.2 (PWA config), TDD §16.1 (web-ui Docker)
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -309,12 +309,12 @@
 
 ### 3.2 Health Endpoint
 
-**Description**: GET /health endpoint that checks connectivity to Postgres and Redis (and later Ollama, LiteLLM). Returns overall status and per-service status.
+**Description**: GET /health endpoint that checks connectivity to Postgres, Redis, and LiteLLM. Returns overall status and per-service status.
 
 **Complexity**: S
 
 **Files to Create**:
-- `packages/core-api/src/routes/health.ts` — GET /health: checks Postgres (SELECT 1), Redis (PING). Returns `{ status: "healthy"|"degraded"|"unhealthy", services: { postgres: "up"|"down", redis: "up"|"down", ollama: "unconfigured", litellm: "unconfigured" }, version: string, uptime: number }`
+- `packages/core-api/src/routes/health.ts` — GET /health: checks Postgres (SELECT 1), Redis (PING), LiteLLM (GET https://llm.k4jda.net/health). Returns `{ status: "healthy"|"degraded"|"unhealthy", services: { postgres: "up"|"down", redis: "up"|"down", litellm: "up"|"down" }, version: string, uptime: number }`
 
 **Acceptance Criteria**:
 - Returns 200 with status "healthy" when all services are up
@@ -508,36 +508,37 @@
 
 ## Phase 5: Embedding + Search
 
-**Goal**: Semantic search works. Ollama generates embeddings. Hybrid search (FTS + vector + RRF) with ACT-R temporal scoring returns ranked results.
+**Goal**: Semantic search works. LiteLLM routes embeddings to Jetson (Qwen3-Embedding-4B-Q4_K_M). Hybrid search (FTS + vector + RRF) with ACT-R temporal scoring returns ranked results.
 
 **Dependencies**: Phase 4 (captures exist in database)
 
-**Test Gate (PRD 1B)**: Insert 20-30 test captures, generate embeddings, vector search returns relevant results (>0.7 similarity), hybrid search improves recall on paraphrased queries, FTS catches exact keywords. CPU embedding throughput documented.
+**Test Gate (PRD 1B)**: Insert 20-30 test captures, generate embeddings, vector search returns relevant results (>0.7 similarity), hybrid search improves recall on paraphrased queries, FTS catches exact keywords. Embedding throughput via LiteLLM documented.
 
 ---
 
 ### 5.1 EmbeddingService
 
-**Description**: Service that generates 768-dimensional embeddings via Ollama. Supports instruction prefixes for Qwen3-Embedding. No fallback — throws OllamaUnavailableError if Ollama is down.
+**Description**: Service that generates 768-dimensional embeddings via LiteLLM (external at https://llm.k4jda.net). Uses the `jetson-embeddings` alias which routes to Qwen3-Embedding-4B-Q4_K_M on the Jetson. OpenAI-compatible embeddings API. No fallback — throws EmbeddingUnavailableError if LiteLLM/Jetson is unreachable; BullMQ retries with patient backoff.
 
 **Complexity**: M
 
 **Files to Create**:
 - `packages/shared/src/services/embedding.ts` — EmbeddingService class:
-  - constructor(ollamaBaseUrl, configService)
-  - embed(text, type: 'document'|'query'): POST to Ollama /api/embeddings, truncate to 768d if Matryoshka model, return number[]. Applies instruction prefix for query vs document if model supports it.
-  - embedBatch(texts, type): Sequential embed calls (Ollama doesn't batch)
-  - getModelInfo(): Returns model name, dimensions, context length, instruction support
-  - Throws OllamaUnavailableError on connection failure
-- `packages/shared/src/__tests__/embedding.test.ts` — Unit tests with mocked Ollama: correct API call, dimension truncation, error on unavailable
+  - constructor(litellmBaseUrl, litellmApiKey, configService)
+  - Uses OpenAI SDK: `new OpenAI({ baseURL: litellmUrl, apiKey: litellmApiKey })`
+  - embed(text, type: 'document'|'query'): `openai.embeddings.create({ model: 'jetson-embeddings', input: text })` → returns number[768]. Applies instruction prefix for Qwen3 query vs document type if supported.
+  - embedBatch(texts, type): Sequential embed calls, returns number[][768]
+  - getModelInfo(): Returns model alias, dimensions (768), source from ai-routing.yaml
+  - Throws EmbeddingUnavailableError on connection failure or non-200 response
+- `packages/shared/src/__tests__/embedding.test.ts` — Unit tests with mocked OpenAI client: correct API call, correct model alias, error on unavailable
 
 **Acceptance Criteria**:
-- Generates 768-dim embeddings from Ollama
-- Handles Matryoshka truncation (if model returns >768 dims, truncate)
-- Model configurable via ai-routing.yaml (configService)
-- OllamaUnavailableError thrown cleanly on failure (no hanging)
+- Generates 768-dim embeddings via LiteLLM `jetson-embeddings` alias
+- Model alias configurable via ai-routing.yaml (no hardcoding)
+- EmbeddingUnavailableError thrown cleanly on failure (no hanging, timeout 30s)
+- Same LITELLM_URL/LITELLM_API_KEY env vars as AIRouterService (no separate OLLAMA_URL)
 
-**Requirement Refs**: TDD §6.2 (EmbeddingService), PRD F07 (Ollama), TDD §8.2 (Ollama integration)
+**Requirement Refs**: TDD §6.2 (EmbeddingService), TDD §8.7 (LiteLLM integration)
 
 ---
 
@@ -623,24 +624,23 @@
 
 ---
 
-### 5.6 Search Tests + Docker Ollama
+### 5.6 Search Tests
 
-**Description**: Search integration tests and Ollama container in Docker Compose.
+**Description**: Search integration and unit tests. Embeddings go through LiteLLM (`jetson-embeddings` alias) — no local Ollama container needed in the Open Brain stack.
 
 **Complexity**: M
 
-**Files to Create/Modify**:
-- `docker-compose.yml` — Add ollama service (ollama/ollama:latest, 16GB memory, volume, healthcheck, open-brain network)
-- `packages/core-api/src/__tests__/search.test.ts` — Integration tests: insert captures with embeddings → vector search returns relevant results, hybrid search improves recall, FTS catches keywords, temporal_weight affects ranking, filters work
-- `packages/core-api/src/__tests__/search-service.test.ts` — Unit tests with mocked embedding: search modes, access stats enqueue
+**Files to Create**:
+- `packages/core-api/src/__tests__/search.test.ts` — Integration tests (Testcontainers for Postgres): pre-insert captures with known embeddings → vector search returns relevant results, hybrid search improves recall, FTS catches keywords, temporal_weight affects ranking, filters work. Use pre-computed embedding vectors (no live LiteLLM call in tests).
+- `packages/core-api/src/__tests__/search-service.test.ts` — Unit tests with mocked EmbeddingService: search modes, access stats enqueue
 
 **Acceptance Criteria**:
-- Ollama container starts and loads embedding model
-- Search returns results with >0.7 similarity for known matches
+- Search returns results with >0.7 similarity for known embedding matches
 - Hybrid search outperforms vector-only on paraphrased queries
-- Tests pass with Testcontainers
+- All three search modes (hybrid, vector, fts) tested
+- Tests pass without external LiteLLM dependency (embeddings mocked or pre-computed)
 
-**Requirement Refs**: PRD Phase 1B test gate, TDD §8.2 (Ollama integration)
+**Requirement Refs**: PRD Phase 1B test gate, TDD §6.2 (SearchService)
 
 ---
 
@@ -650,7 +650,7 @@
 
 **Dependencies**: Phase 5 (embeddings work, search works)
 
-**Test Gate (PRD 1C)**: Insert capture via API → automatically embedded, metadata extracted, pipeline_status = 'complete'. pipeline_events shows all stages with timing. Simulate Ollama failure → capture queues, retries on recovery. LiteLLM routes aliases correctly. Bull Board accessible.
+**Test Gate (PRD 1C)**: Insert capture via API → automatically embedded, metadata extracted, pipeline_status = 'complete'. pipeline_events shows all stages with timing. Simulate LiteLLM embedding failure → capture queues, retries on recovery. LiteLLM routes aliases correctly. Bull Board accessible.
 
 ---
 
@@ -709,16 +709,17 @@
 - `packages/shared/src/services/ai-router.ts` — AIRouterService class:
   - constructor(configService, db, litellmBaseUrl, litellmApiKey)
   - complete(taskType, prompt, options?): lookup model alias from ai-routing.yaml → call OpenAI SDK pointed at LiteLLM → log to ai_audit_log → return response
-  - getMonthlySpend(): GET LiteLLM /spend/logs endpoint
-  - Uses OpenAI SDK (`new OpenAI({ baseURL: litellmUrl, apiKey })`)
-- `config/ai-routing.yaml` — Full config: embedding (provider: ollama, model: nomic-embed-text, dimensions: 768), task_models (metadata_extraction: fast, intent_classification: intent, synthesis: synthesis, governance: governance, career_signals: synthesis, weekly_brief: synthesis, drift_detection: fast), litellm (base_url), ollama (base_url)
-- `config/litellm-config.yaml` — Model list: fast (ollama/llama3.1:8b), synthesis (anthropic/claude-sonnet-4-6, fallback: openai/gpt-4o), governance (anthropic/claude-opus-4-6, fallback: claude-sonnet), intent (ollama/llama3.1:8b). Budget: $50/month hard, alerting webhook.
+  - getMonthlySpend(): GET LiteLLM /spend/logs endpoint — returns { total, by_model }
+  - Uses OpenAI SDK (`new OpenAI({ baseURL: litellmUrl, apiKey })`) — same client as EmbeddingService
+- `config/ai-routing.yaml` — Full config: embedding (model: jetson-embeddings, dimensions: 768, note: Qwen3-Embedding-4B-Q4_K_M via Jetson through LiteLLM), task_models (metadata_extraction: fast, intent_classification: intent, synthesis: synthesis, governance: governance, career_signals: synthesis, weekly_brief: synthesis, drift_detection: fast). Note: all aliases resolve on external LiteLLM at https://llm.k4jda.net. LLM provider for fast/intent/synthesis/governance is TBD — configure aliases on server before Phase 6.
+
+**NOTE — no `config/litellm-config.yaml` in this repo**: LiteLLM is an external shared service at https://llm.k4jda.net. Its model list, provider config, and budget are managed on that server. Required aliases that must be pre-configured there before Phase 6: `jetson-embeddings` (Qwen3-Embedding-4B-Q4_K_M on Jetson), `fast` (TBD local LLM), `intent` (TBD local LLM), `synthesis` (cloud LLM TBD), `governance` (cloud LLM TBD).
 
 **Acceptance Criteria**:
-- Task type → LiteLLM alias mapping works from config
+- Task type → LiteLLM alias mapping works from ai-routing.yaml config
 - ai_audit_log entries created for every LLM call
 - OpenAI SDK calls route through LiteLLM correctly
-- Monthly spend queryable
+- Monthly spend queryable via getMonthlySpend()
 
 **Requirement Refs**: TDD §6.2 (AIRouterService), PRD F08 (AI Router), TDD §8.7 (LiteLLM)
 
@@ -752,14 +753,14 @@
 
 **Files to Create/Modify**:
 - `packages/core-api/src/routes/admin.ts` — Mount @bull-board/hono at /admin/queues. Register all queues.
-- `docker-compose.yml` — Add core-api service definition (build target, ports, env_file .env.secrets, env vars for DATABASE_URL/REDIS_URL/OLLAMA_URL/LITELLM_URL=https://llm.k4jda.net/MCP_API_KEY, config volume, depends on postgres+redis, healthcheck)
-- `docker-compose.yml` — Add workers service definition (build target, env vars including LITELLM_URL=https://llm.k4jda.net, config volume, depends on postgres+redis)
+- `docker-compose.yml` — Add core-api service definition (build target, ports, env_file .env.secrets, env vars for DATABASE_URL/REDIS_URL/LITELLM_URL=https://llm.k4jda.net/LITELLM_API_KEY/MCP_API_KEY, config volume, depends on postgres+redis, healthcheck). No OLLAMA_URL — embeddings and LLM inference both route through LiteLLM.
+- `docker-compose.yml` — Add workers service definition (build target, env vars for DATABASE_URL/REDIS_URL/LITELLM_URL=https://llm.k4jda.net/LITELLM_API_KEY/CORE_API_URL, config volume, depends on postgres+redis)
 
 **Acceptance Criteria**:
 - Bull Board UI accessible at /admin/queues
 - Core API and Workers containers build and start
 - `curl https://llm.k4jda.net/health` returns healthy from within containers
-- LiteLLM routes "fast" alias to Ollama, "synthesis" to Claude
+- LiteLLM routes `jetson-embeddings` and inference aliases correctly
 
 **Requirement Refs**: PRD F03 (Bull Board), PRD F07a (LiteLLM), TDD §16.1 (Docker Compose)
 
@@ -786,6 +787,27 @@
 - Pipeline health visible at /admin/queues
 
 **Requirement Refs**: PRD Phase 1C test gate, TDD §6.2 (PipelineService)
+
+---
+
+### 6.7 Daily Sweep Worker
+
+**Description**: Scheduled BullMQ job that runs at 3:00 AM daily, finds captures stuck in `received` or `processing` status, and re-enqueues them for pipeline processing. Catches transient failures (LiteLLM blip, Redis restart) that outlasted the initial retry window.
+
+**Complexity**: S
+
+**Files to Create**:
+- `packages/workers/src/jobs/daily-sweep.ts` — DailySweepJob: queries `SELECT id FROM captures WHERE pipeline_status IN ('received', 'processing') AND created_at < NOW() - INTERVAL '1 hour'`. For each found capture, enqueue a capture-pipeline job (idempotent — BullMQ deduplicates by jobId=captureId). Log count of captures re-queued.
+- `packages/workers/src/scheduler.ts` — BullMQ repeatable job setup: `dailySweepQueue.add('daily-sweep', {}, { repeat: { cron: '0 3 * * *' }, jobId: 'daily-sweep-recurring' })`. Called on worker startup.
+
+**Acceptance Criteria**:
+- Repeatable job registered at startup with cron `0 3 * * *`
+- Queries captures older than 1 hour stuck in received/processing
+- Re-enqueues each as a capture-pipeline job with jobId=captureId (dedup safe)
+- Logs number of captures swept
+- No-op when all captures are complete
+
+**Requirement Refs**: PRD F03 (daily auto-retry sweep), TDD §2376 (daily auto-retry sweep), TDD §12.2 (daily-sweep job)
 
 ---
 
@@ -1005,7 +1027,7 @@
 **Complexity**: S
 
 **Files to Create/Modify**:
-- `docker-compose.yml` — Add cloudflared service (cloudflare/cloudflared:latest, restart: unless-stopped, TUNNEL_TOKEN env, open-brain network, depends on core-api). Routing: brain.k4jda.net/mcp → core-api:3000/mcp, brain.k4jda.net/ → core-api:3000 (web-ui in Phase 15)
+- `docker-compose.yml` — Add cloudflared service (cloudflare/cloudflared:latest, restart: unless-stopped, TUNNEL_TOKEN env, open-brain network, depends on core-api). Routing: brain.k4jda.net/mcp → core-api:3000/mcp, brain.k4jda.net/ → core-api:3000 (updated to web:80 in Phase 15)
 
 **Acceptance Criteria**:
 - Cloudflared container starts and connects to Cloudflare
@@ -1066,9 +1088,9 @@
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| Ollama embedding model performance on CPU | Medium | Medium | Phase 5 includes benchmarking step. nomic-embed-text (137M) should be fast. Qwen3-Embedding:8b may be too slow for real-time. |
+| LiteLLM embedding latency (Jetson) | Low | Medium | Qwen3-Embedding-4B-Q4_K_M on Jetson via llm.k4jda.net. If latency is too high, embeddings queue asynchronously — no user-facing impact. |
 | pgvector HNSW index build time | Low | Low | <100K captures at launch. Default params sufficient. |
-| LiteLLM proxy stability | Low | Medium | External shared service at llm.k4jda.net — managed independently. Failure degrades LLM tasks but not ingestion/embedding. |
+| LiteLLM proxy stability | Low | High | External shared service at llm.k4jda.net — manages all embeddings AND inference. Failure queues captures for retry (patient backoff). Daily sweep recovers any stragglers. |
 | Drizzle ORM limitations with custom SQL | Medium | Low | Custom SQL migrations for search functions and FTS index. Well-documented pattern. |
 | BullMQ job loss on Redis restart | Low | Medium | Redis persistence (RDB snapshots). Pipeline retries recover from lost jobs. |
 
@@ -1094,7 +1116,8 @@
 | Pipeline (BullMQ) | PRD F03, TDD §12 | 6 | 6.1-6.6 |
 | LiteLLM proxy | PRD F07a, TDD §8.7 | External | 6.3 (integration), 6.5 (env config) |
 | AI Router | PRD F08, TDD §6.2 | 6 | 6.3 |
-| Ollama embeddings | PRD F07, TDD §8.2 | 5, 6 | 5.1, 5.6 |
+| LiteLLM embeddings (Jetson) | TDD §8.7, TDD §6.2 | 5, 6 | 5.1, 5.6 |
+| Daily sweep recovery | PRD F03, TDD §12.2 | 6 | 6.7 |
 | Slack capture | PRD F04, TDD §8.1 | 7 | 7.1-7.5 |
 | Slack query | PRD F05, TDD §8.1 | 7 | 7.2, 7.4 |
 | MCP endpoint | PRD F06, TDD §8.8 | 8 | 8.1-8.5 |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -58,7 +58,7 @@ The document describes a lightweight Slack → cloud Postgres → MCP setup. Thi
 - Async processing pipeline with configurable stages (not synchronous Edge Functions)
 - Rich output skills (weekly briefs, governance sessions, pattern detection) inherited from board-journal
 - Bidirectional Slack interface (capture + query + commands + interactive sessions)
-- Local AI (Ollama for embeddings, faster-whisper for transcription)
+- Local AI (LiteLLM/Jetson for embeddings, faster-whisper for transcription)
 - Entity graph (people, projects, decisions) on top of vector search
 - Web dashboard for browsing, searching, and viewing skill outputs
 
@@ -192,7 +192,7 @@ This is a single-user personal tool. The sole user is a senior technology execut
 | F04 | Slack bot — capture (text) | Must Have | Phase 1D |
 | F05 | Slack bot — query (semantic search) | Must Have | Phase 1D |
 | F06 | MCP endpoint (embedded in Core API, Streamable HTTP) | Must Have | Phase 1E |
-| F07 | Ollama container (local embeddings) | Must Have | Phase 1B |
+| F07 | EmbeddingService via LiteLLM (jetson-embeddings alias) | Must Have | Phase 1B |
 | F07a | LiteLLM proxy (unified LLM gateway) | Must Have | Phase 1C |
 | F08 | AI router service (LiteLLM-based provider routing) | Must Have | Phase 1C |
 | F09 | Voice-capture integration (adapter to ingest API) | Must Have | Phase 2A |
@@ -294,7 +294,7 @@ The `pre_extracted` field allows input adapters (like voice-capture) to pass the
 - Ingest endpoint accepts captures and returns capture ID + status within 500ms (queues async processing)
 - Search endpoint returns results within 5 seconds
 - API is unauthenticated (single user, network-level security via Tailscale/LAN)
-- Health endpoint returns status of all dependent services (DB, Redis, Ollama)
+- Health endpoint returns status of all dependent services (DB, Redis, LiteLLM)
 
 ---
 
@@ -551,11 +551,11 @@ The primary search function combines pgvector cosine similarity with Postgres fu
 | Stage | Purpose | Default AI | Skips When |
 |-------|---------|-----------|------------|
 | `transcribe` | Audio → text via faster-whisper | Local faster-whisper | Input is already text |
-| `embed` | Generate vector embedding | Local Ollama (configurable model — see F07) | — |
+| `embed` | Generate vector embedding | LiteLLM jetson-embeddings alias (see F07) | — |
 | `check_triggers` | Match against active semantic triggers (separate BullMQ job, not inline) | Cosine similarity (in-memory) | No active triggers (Phase 2) |
 | `extract_metadata` | Extract people, topics, type, action_items, dates, brain_views | Configurable (default: local via LiteLLM) | — |
 | `classify` | Domain classification (career signals, etc.) | Configurable via LiteLLM | No matching brain_view pipeline |
-| `link_entities` | Match and link to known entities | Local Ollama or rule-based | Phase 3 |
+| `link_entities` | Match and link to known entities | LiteLLM or rule-based | Phase 3 |
 | `evaluate_triggers` | Check trigger rules (drift, bet expiration, etc.) | Rule-based + AI | Phase 3 |
 | `notify` | Send confirmation to source (Slack reply, Pushover) | — | — |
 
@@ -565,8 +565,8 @@ pipelines:
   default:
     stages:
       - name: embed
-        provider: ollama           # Embeddings always go direct to Ollama (bypass LiteLLM)
-        model: ${EMBEDDING_MODEL}  # Configured in ai-routing.yaml
+        provider: litellm          # Embeddings route through LiteLLM (jetson-embeddings alias)
+        model: ${EMBEDDING_MODEL}  # Configured in ai-routing.yaml (jetson-embeddings)
 
       # check_triggers runs as a separate BullMQ job after embed completes (not an inline stage)
       # Enqueued automatically by the embed stage handler — see TDD §12.2a
@@ -736,139 +736,97 @@ When the user asks for a summary or synthesis (not just a search), the bot:
 
 ---
 
-#### F07: Ollama Container
+#### F07: Embedding Service (via LiteLLM)
 
-**Description**: Local embedding service for vector generation. Runs on Unraid in Docker. LLM chat/completion tasks (metadata extraction, intent classification, synthesis) route through LiteLLM instead — see F07a and F08.
+**Description**: Vector embedding generation for all captures, triggers, and search queries. Routes through external LiteLLM at `https://llm.k4jda.net` via the `jetson-embeddings` alias, which runs Qwen3-Embedding-4B-Q4_K_M on a Jetson device. LLM inference also routes through the same external LiteLLM — see F07a and F08.
 
-**Embedding Model** (configurable via `ai-routing.yaml`):
+**Embedding Model**: Qwen3-Embedding-4B-Q4_K_M (selected, configured on external LiteLLM)
 
-The schema uses `vector(768)` throughout. The embedding model must produce 768-dimensional vectors, either natively or via Matryoshka dimension truncation.
+The schema uses `vector(768)` throughout. Qwen3-Embedding-4B-Q4_K_M is configured via Matryoshka dimension truncation to produce 768d vectors.
 
-| Candidate | Params | Native Dim | 768d Quality | Context | Status |
-|-----------|--------|-----------|-------------|---------|--------|
-| `nomic-embed-text` | 137M | 768 (native) | Baseline | 8K tokens | Proven, low resource |
-| `qwen3-embedding:0.6b` | 0.6B | 1024 | Good (Matryoshka → 768) | 32K tokens | Evaluating |
-| `qwen3-embedding:4b` | 4B | 2048 | Very good (Matryoshka → 768) | 32K tokens | Evaluating |
-| `qwen3-embedding:8b` | 8B | 4096 | Excellent (Matryoshka → 768, MTEB #1 at release) | 32K tokens | Evaluating |
+**Qwen3-Embedding advantages**: Matryoshka dimensions (truncate to any power-of-2 with minimal quality loss), 32K context (significant for document ingestion in Phase 4), instruction-following support (`Instruct: ...` prefixes for asymmetric query/document embedding), and MTEB top performance at release.
 
-**Qwen3-Embedding advantages**: Matryoshka dimensions (truncate to any power-of-2 with minimal quality loss), 32K context (vs 8K for nomic — significant for document ingestion in Phase 4), and instruction-following support (`Instruct: ...` prefixes for asymmetric query/document embedding).
+**No embedding fallback** — if LiteLLM or Jetson is unreachable, captures queue in BullMQ and retry when service recovers. This prevents mixing embedding models which would degrade search quality.
 
-**Decision**: Final model selection after benchmarking with real capture data. Schema uses `vector(768)` regardless. Switching models requires a one-time re-embedding migration (see TDD §4.5).
-
-**No embedding fallback** — if Ollama is down, captures queue in BullMQ and retry when Ollama recovers. This prevents mixing embedding models which would degrade search quality.
-
-**API**: Ollama exposes OpenAI-compatible API on port 11434
+**API**: OpenAI embeddings API (`POST /v1/embeddings`) via LiteLLM — same client as LLM inference, using `jetson-embeddings` model alias.
 
 **Acceptance Criteria**:
-- Ollama container starts and loads embedding model on Unraid
-- Embedding generation <1 second per capture
-- GPU acceleration used if NVIDIA GPU available, CPU fallback otherwise
-- Container auto-restarts on failure
+- `jetson-embeddings` alias on external LiteLLM returns 768d vectors
+- Embedding generation <2 seconds per capture (network + Jetson inference)
+- EmbeddingUnavailableError thrown on failure → BullMQ retry
+- Embeddings queue gracefully when LiteLLM/Jetson unreachable
 
 ---
 
 #### F07a: LiteLLM Proxy
 
-**Description**: Self-hosted LLM gateway that provides a unified OpenAI-compatible API for all LLM providers (local Ollama models, Anthropic Claude, OpenAI GPT, OpenRouter). All LLM requests (not embeddings) route through LiteLLM. This replaces the need for a custom provider routing implementation.
+**Description**: External shared LLM gateway at `https://llm.k4jda.net` that provides a unified OpenAI-compatible API for all AI requests — both embeddings (jetson-embeddings alias → Qwen3-Embedding-4B-Q4_K_M on Jetson) and all LLM inference. Managed independently of Open Brain's Docker stack. Model aliases, provider routing, fallbacks, and budget limits are configured on the external server.
 
 **Key Capabilities**:
-- **Unified API**: Single `http://litellm:4000` endpoint for all LLM calls
-- **Model aliasing**: Define logical names (`fast`, `synthesis`, `governance`) that map to specific provider/model combinations
+- **Unified API**: Single `https://llm.k4jda.net` endpoint for all AI calls (embeddings + LLM)
+- **Model aliasing**: Logical names (`jetson-embeddings`, `fast`, `synthesis`, `governance`, `intent`) configured on external server
 - **Automatic fallback**: Primary → fallback routing per model alias
-- **Budget tracking**: Built-in monthly spend tracking with soft/hard limits
-- **Request logging**: All LLM calls logged with tokens, latency, cost
+- **Budget tracking**: Built-in monthly spend tracking with soft/hard limits ($30 soft alert, $50 hard limit)
+- **Request logging**: All AI calls logged with tokens, latency, cost
 
-**Configuration** (`config/litellm-config.yaml`):
-```yaml
-model_list:
-  - model_name: "fast"
-    litellm_params:
-      model: ollama/llama3.1:8b
-      api_base: http://ollama:11434
+**Required model aliases** (configured on external LiteLLM server — not managed by this project):
 
-  - model_name: "synthesis"
-    litellm_params:
-      model: anthropic/claude-sonnet-4-6
-
-  - model_name: "synthesis"      # fallback
-    litellm_params:
-      model: openai/gpt-4o
-
-  - model_name: "governance"
-    litellm_params:
-      model: anthropic/claude-opus-4-6
-
-  - model_name: "governance"     # fallback
-    litellm_params:
-      model: anthropic/claude-sonnet-4-6
-
-  - model_name: "intent"
-    litellm_params:
-      model: ollama/llama3.1:8b
-      api_base: http://ollama:11434
-
-litellm_settings:
-  max_budget: 50             # Hard limit: $50/month
-  budget_duration: "1mo"
-  alerting:
-    - webhook                # Alert on budget thresholds
-
-general_settings:
-  master_key: "sk-ob-master" # From Bitwarden
-```
+| Alias | Purpose | Fallback |
+|-------|---------|---------|
+| `jetson-embeddings` | Qwen3-Embedding-4B-Q4_K_M on Jetson (768d) | None — queue and retry |
+| `fast` | Local LLM inference (TBD) | — |
+| `intent` | Intent classification (TBD) | — |
+| `synthesis` | Anthropic Claude Sonnet | openai/gpt-4o |
+| `governance` | Anthropic Claude Opus | claude-sonnet |
 
 **Acceptance Criteria**:
-- LiteLLM container starts and proxies requests to configured providers
-- Model aliases resolve correctly (fast → Ollama, synthesis → Claude Sonnet)
+- External LiteLLM reachable at `https://llm.k4jda.net/health`
+- Model aliases resolve correctly (jetson-embeddings → 768d vectors, synthesis → Claude Sonnet)
 - Fallback triggers automatically on provider failure
-- Monthly spend tracked and hard limit enforced at $50
-- Health endpoint at `http://litellm:4000/health`
+- Monthly spend tracked and hard limit enforced at $50 (configured on external server)
 
 ---
 
 #### F08: AI Router Service
 
-**Description**: A thin application-layer service that maps task types to LiteLLM model aliases and handles embedding requests directly via Ollama. LiteLLM handles the heavy lifting (provider routing, fallback, budget tracking, request logging). The AI Router in the application code is responsible for: (1) mapping task types to LiteLLM model aliases, (2) routing embedding requests directly to Ollama (bypassing LiteLLM), and (3) logging usage to the `ai_audit_log` table from LiteLLM response metadata.
+**Description**: A thin application-layer service that maps task types to LiteLLM model aliases. LiteLLM handles all AI requests — both embeddings (jetson-embeddings alias) and LLM inference. The AI Router in application code is responsible for: (1) mapping task types to LiteLLM model aliases, (2) routing embedding requests to the `jetson-embeddings` alias through the same LiteLLM client, and (3) logging usage to the `ai_audit_log` table from LiteLLM response metadata.
 
 **Configuration** (`config/ai-routing.yaml`):
 ```yaml
 ai_routing:
-  # Embedding config — goes direct to Ollama, NOT through LiteLLM
+  # Embedding config — routes through LiteLLM (jetson-embeddings alias)
   embedding:
-    provider: ollama
-    model: nomic-embed-text     # Configurable — may switch to qwen3-embedding:8b after benchmarking
-    dimensions: 768             # Schema dimension — model must produce this (native or Matryoshka-truncated)
-    # NO fallback. Queue and retry if Ollama is down.
+    provider: litellm
+    model: jetson-embeddings    # Alias on external LiteLLM → Qwen3-Embedding-4B-Q4_K_M on Jetson
+    dimensions: 768             # Schema dimension — model produces 768d vectors
+    # NO fallback. Queue and retry if LiteLLM/Jetson is unreachable.
 
   # LLM task → LiteLLM model alias mapping
   # LiteLLM handles provider routing and fallback internally
   task_models:
-    metadata_extraction: fast        # → ollama/llama3.1:8b (via LiteLLM)
-    intent_classification: intent    # → ollama/llama3.1:8b (via LiteLLM); degrades to prefix-only if LiteLLM/Ollama down
+    metadata_extraction: fast        # → TBD local LLM (via LiteLLM)
+    intent_classification: intent    # → TBD local LLM (via LiteLLM); degrades to prefix-only if LiteLLM down
     synthesis: synthesis             # → anthropic/claude-sonnet (via LiteLLM, fallback: openai/gpt-4o)
     governance: governance           # → anthropic/claude-opus (via LiteLLM, fallback: claude-sonnet)
     career_signals: synthesis        # → same as synthesis
     weekly_brief: synthesis          # → same as synthesis
-    drift_detection: fast            # → local model
+    drift_detection: fast            # → TBD local model
 
   litellm:
-    base_url: http://litellm:4000
-    # API key, budget, fallback config all in config/litellm-config.yaml
-
-  ollama:
-    base_url: http://ollama:11434
+    base_url: https://llm.k4jda.net
+    # API key stored in Bitwarden as open-brain-litellm-api-key (ai-work project)
 ```
 
 **Behavior**:
-- All LLM calls route through LiteLLM proxy; all embedding calls go direct to Ollama
+- All AI calls (embeddings + LLM inference) route through external LiteLLM at llm.k4jda.net
 - Task type → model alias mapping is config-driven (change aliases without touching code)
 - LiteLLM handles fallback, budget tracking, and request logging natively
 - Application logs usage to `ai_audit_log` table for operational audit
 - **Monthly budget caps** (enforced by LiteLLM): Soft limit at $30/month triggers Pushover alert. Hard limit at $50/month triggers circuit breaker. Expected normal usage: ~$15-30/month.
-- Intent classification degrades gracefully: if LiteLLM/Ollama unavailable, fall back to prefix-only detection (`?` = query, `!` = command, default = capture)
+- Intent classification degrades gracefully: if LiteLLM unavailable, fall back to prefix-only detection (`?` = query, `!` = command, default = capture)
 
 **Acceptance Criteria**:
-- All LLM calls route through LiteLLM; embeddings go direct to Ollama
+- All AI calls (embeddings + LLM) route through external LiteLLM at llm.k4jda.net
 - Task-to-model mapping configurable via YAML
 - Fallback triggers automatically via LiteLLM (within 5 seconds)
 - Usage logging captures all calls with token counts
@@ -1005,7 +963,7 @@ ai_routing:
 | Drift alert | Normal (0) | When drift monitor detects gaps |
 | Bet expiring | High (1) | When a bet is within 7 days of due date |
 | Pipeline failure | High (1) | When a capture fails processing after all retries |
-| System health issue | Emergency (2) | When a critical service (DB, Ollama) is unreachable |
+| System health issue | Emergency (2) | When a critical service (DB, LiteLLM) is unreachable |
 
 **Tech**: Reuse Pushover integration pattern from voice-capture project
 
@@ -1139,7 +1097,7 @@ Phase 1A:
 F02 (Postgres) ──► F01 (Core API — CRUD, stats, health)
 
 Phase 1B:
-F07 (Ollama) ──► Search endpoints + match_captures functions
+F07 (EmbeddingService/LiteLLM) ──► Search endpoints + match_captures functions
 
 Phase 1C:
 F07a (LiteLLM) ──► F08 (AI Router) ──► F03 (Pipeline)
@@ -1213,16 +1171,12 @@ F13 (Pushover), F14 (Email)
 │              │   (BullMQ)     │  │  (LLM     │              │
 │              └───────┬────────┘  │  gateway)  │              │
 │                      │           └─────┬─────┘              │
-│              ┌───────▼────────┐        │  ┌───────────┐     │
-│              │   Postgres     │        ├──│  Ollama   │     │
-│              │  (pgvector/    │        │  │(embeddings│     │
-│              │   pgvector:    │        │  │  + local  │     │
-│              │   pg16)        │        │  │  LLMs)    │     │
-│              └────────────────┘        │  └───────────┘     │
-│                                        │                     │
-│                                        ├──► Anthropic API    │
-│                                        ├──► OpenAI API       │
-│                                        └──► OpenRouter       │
+│              ┌───────▼────────┐        │                     │
+│              │   Postgres     │        ├──► Anthropic API    │
+│              │  (pgvector/    │        ├──► OpenAI API       │
+│              │   pgvector:    │        ├──► OpenRouter       │
+│              │   pg16)        │        └──► Jetson(embeddings)│
+│              └────────────────┘                              │
 │                                                              │
 │              ┌───────────┐                                   │
 │              │  faster-  │                                   │
@@ -1245,7 +1199,7 @@ F13 (Pushover), F14 (Email)
 ### Docker Network Topology
 
 Single Docker network:
-- **`open-brain`** — All containers (Core API, Slack bot, Workers, Postgres, Ollama, faster-whisper, Redis, voice-capture, Web UI). Simple DNS resolution between containers (`http://ollama:11434`, `http://redis:6379`, `http://postgres:5432`).
+- **`open-brain`** — All containers (Core API, Slack bot, Workers, Postgres, faster-whisper, Redis, voice-capture, Web UI). Simple DNS resolution between containers (`http://redis:6379`, `http://postgres:5432`). LiteLLM is external at `https://llm.k4jda.net` — not in this network.
 - **Host port exposure**: Core API (port 3000, also serves MCP at `/mcp` via Cloudflare Tunnel), Slack bot (Socket Mode — no inbound port needed), and Web UI (Phase 4).
 
 ### Configuration File Structure
@@ -1258,7 +1212,6 @@ open-brain/
 │   ├── pipelines.yaml              # Processing pipeline definitions
 │   ├── skills.yaml                 # Output skill definitions + schedules
 │   ├── ai-routing.yaml             # Embedding config + task-to-LiteLLM-alias mapping
-│   ├── litellm-config.yaml         # LiteLLM proxy config: model list, fallbacks, budget
 │   ├── notifications.yaml          # Notification preferences + targets
 │   ├── brain-views.yaml            # Brain view definitions + pipeline routing rules (5 views: career, personal, technical, work-internal, client)
 │   └── prompts/                    # AI prompt templates
@@ -1373,7 +1326,7 @@ Smaller build/test cycles with explicit test gates at each sub-phase. Each sub-p
 
 | Feature | Description |
 |---------|-------------|
-| F07 | Ollama with embedding model (benchmark nomic-embed-text vs Qwen3-Embedding here) |
+| F07 | EmbeddingService via LiteLLM (jetson-embeddings alias → Qwen3-Embedding-4B-Q4_K_M) |
 | F01 (partial) | Search endpoint: POST /api/v1/search (all three modes: hybrid, vector, fts) |
 | — | match_captures + match_captures_hybrid SQL functions deployed |
 | — | FTS GIN index on captures.content |
@@ -1381,7 +1334,7 @@ Smaller build/test cycles with explicit test gates at each sub-phase. Each sub-p
 
 **Test Gate**:
 - Insert 20-30 test captures with known content via Phase 1A API
-- Generate embeddings via script or manual Ollama calls
+- Generate embeddings via EmbeddingService (calls LiteLLM jetson-embeddings alias)
 - Vector search returns relevant results (similarity > 0.7 for known matches)
 - Hybrid search improves recall on paraphrased queries vs. vector-only
 - FTS catches exact keyword matches that vector misses
@@ -1397,15 +1350,15 @@ Smaller build/test cycles with explicit test gates at each sub-phase. Each sub-p
 |---------|-------------|
 | F03 | Pipeline — BullMQ + Redis, stage executor, retry logic |
 | F07a | LiteLLM proxy with model aliases and budget tracking |
-| F08 | AI Router (thin LiteLLM wrapper + direct Ollama for embeddings) |
+| F08 | AI Router (thin LiteLLM wrapper — embeddings + LLM all through external LiteLLM) |
 | — | Pipeline stages: embed → extract_metadata → notify (stub) |
 | — | Bull Board at /admin/queues |
 
 **Test Gate**:
 - Insert capture via API → automatically embedded, metadata extracted, pipeline_status = 'complete'
 - pipeline_events shows all stages with timing
-- Simulate Ollama failure → capture queues, retries on recovery
-- LiteLLM routes "fast" alias to Ollama, "synthesis" to Claude
+- Simulate LiteLLM/Jetson unavailability → capture queues, retries on recovery
+- LiteLLM routes "fast" alias to local LLM (TBD), "synthesis" to Claude
 - Bull Board shows job history and queue health
 - Budget tracking shows cost for LLM calls
 
@@ -1565,7 +1518,7 @@ The system has features that require accumulated data before they become useful.
 | Unraid server with Docker | Everything | Low — already operational |
 | Tailscale | Remote access to all services | Low — already in use |
 | Slack free workspace (K4JDA) | Capture + query interface | Low — already created |
-| Ollama Docker image | Local embeddings (+ local LLM via LiteLLM) | Low — well-maintained |
+| External LiteLLM (llm.k4jda.net) | Embeddings (jetson-embeddings) + all LLM inference | Low — already running, shared service |
 | LiteLLM Docker image | Unified LLM proxy for all providers | Low — actively maintained, wide adoption |
 | faster-whisper Docker image | Local transcription | Low — multiple maintained images |
 | Postgres 16 + pgvector Docker image | Database + vector search | Low — standard Docker image (pgvector/pgvector:pg16) |
@@ -1577,15 +1530,15 @@ The system has features that require accumulated data before they become useful.
 | Apple Watch + Just Press Record | Voice capture origin | Low — existing workflow |
 
 ### Assumptions
-- Unraid server: Intel Core i7-9700 (8C/8T, 3.0GHz/4.7GHz turbo), 128GB DDR4 RAM, no dedicated GPU, 32TB array (~26TB free). Memory limits on heavy containers: Ollama 16GB, faster-whisper 8GB, Postgres 8GB. Lightweight containers unconstrained. Total estimated footprint ~20-25GB.
+- Unraid server: Intel Core i7-9700 (8C/8T, 3.0GHz/4.7GHz turbo), 128GB DDR4 RAM, no dedicated GPU, 32TB array (~26TB free). Memory limits on heavy containers: faster-whisper 8GB, Postgres 8GB. Lightweight containers unconstrained. Total estimated footprint ~10-12GB (no Ollama — embeddings and LLM via external LiteLLM).
 - Tailscale is configured and the server is accessible remotely
 - Bitwarden Secrets Manager is accessible for API key retrieval
-- The user's daily capture volume will be <50 captures/day (affects pipeline queue sizing and Ollama load)
+- The user's daily capture volume will be <50 captures/day (affects pipeline queue sizing and LiteLLM/Jetson embedding load)
 
 ### Constraints
 - Slack free plan: 90-day message history (not a problem — data lives in Postgres)
 - Slack free plan: 10 app integrations (only need 1)
-- Ollama on CPU is slower — may need to batch-process if many captures arrive simultaneously
+- Jetson embedding throughput may be slower than local CPU for burst ingestion — BullMQ queue handles this gracefully
 - No multi-user support — single user by design, simplifies everything
 
 ---
@@ -1635,14 +1588,14 @@ All open questions from the initial draft have been resolved. Decisions are capt
 | Schema migrations | Drizzle ORM + drizzle-kit. TypeScript-native, schema-as-code. |
 | AI cost management | Monthly budget: soft $30 (Pushover alert), hard $50 (circuit breaker → local only). |
 | Synthesis endpoint | Top-20 captures, 50K token budget. Skills handle own context assembly. |
-| Container resources | Memory limits on Ollama (16GB), faster-whisper (8GB), Postgres (8GB) only. |
+| Container resources | Memory limits on faster-whisper (8GB), Postgres (8GB) only. No Ollama container — embeddings via external LiteLLM. |
 | Capture types | 8 types: decision, idea, observation, task, win, blocker, question, reflection. Extensible via prompt. |
 | Config reloading | ConfigService: in-memory cache, explicit reload via `/api/v1/admin/config/reload`, workers re-read per job. |
 | Thread context | Redis with 1-hour TTL, keyed by thread_ts. |
 | Session persistence | Postgres + transcript replay on resume. 30-day max pause. |
 | Deduplication | Source-level only: slack_ts, filename, content hash + 60s window. No cross-source. |
 | Docker networking | Single `open-brain` network. All containers including Postgres. |
-| Embedding consistency | No fallback. Queue and retry if Ollama down. Model configurable (nomic-embed-text or Qwen3-Embedding). |
+| Embedding consistency | No fallback. Queue and retry if LiteLLM/Jetson unreachable. Model: Qwen3-Embedding-4B-Q4_K_M via jetson-embeddings alias. |
 | LLM routing | LiteLLM proxy. Budget via LiteLLM. App logs task-level audit (not cost) to ai_audit_log table. |
 | Search strategy | Hybrid retrieval (FTS + vector with RRF) + ACT-R temporal decay. Default temporal_weight: 0.0 at launch (cold start), ramp up as search history builds. |
 | Semantic triggers | Persistent semantic patterns. Separate BullMQ job (not inline pipeline stage). Max 20 triggers, in-memory comparison. Phase 2C. |
@@ -1683,8 +1636,8 @@ All open questions from the initial draft have been resolved. Decisions are capt
 | **Output Skill** | A scheduled or triggered process that queries the brain, performs AI synthesis, and delivers results (weekly brief, board session, drift alert) |
 | **Entity** | A known person, project, decision, bet, or concept that appears across multiple captures |
 | **Intent Router** | The component in the Slack bot that determines whether an incoming message is a capture, query, command, or conversation |
-| **AI Router** | Thin application-layer service that maps task types to LiteLLM model aliases (for LLM) and Ollama (for embeddings) |
-| **LiteLLM** | Self-hosted proxy that provides a unified OpenAI-compatible API for all LLM providers, with fallback routing and budget tracking |
+| **AI Router** | Thin application-layer service that maps task types to LiteLLM model aliases — all AI (embeddings + LLM) routes through external LiteLLM |
+| **LiteLLM** | External shared proxy at llm.k4jda.net providing unified OpenAI-compatible API for all AI requests — embeddings (jetson-embeddings) and LLM inference |
 | **Semantic Trigger** | A persistent semantic pattern that fires a notification when a new capture's embedding matches it above a threshold |
 | **Hybrid Search** | Search strategy combining full-text search (Postgres tsvector) and vector similarity (pgvector) via Reciprocal Rank Fusion (RRF) |
 | **Temporal Decay (ACT-R)** | Cognitive model that boosts search ranking for captures that are accessed recently and frequently |

--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -33,12 +33,12 @@
 
 This TDD provides implementation-ready technical specifications for Open Brain — a self-hosted personal AI knowledge infrastructure. It covers the complete system: API contracts, database schema (Drizzle ORM), async pipeline architecture, AI routing, Slack bot, MCP server, Docker Compose orchestration, and all supporting services.
 
-The system runs entirely on an Unraid home server, ingests captures from Slack and voice memos, embeds them for semantic search via local Ollama, routes all LLM requests through a self-hosted LiteLLM proxy, and surfaces insights through AI-powered skills (weekly briefs, governance sessions, drift detection). Search uses hybrid retrieval (full-text + vector with Reciprocal Rank Fusion) combined with ACT-R temporal decay scoring.
+The system runs entirely on an Unraid home server, ingests captures from Slack and voice memos, embeds them for semantic search via the external LiteLLM proxy (jetson-embeddings alias → Qwen3-Embedding-4B-Q4_K_M on Jetson), routes all LLM inference through the same external LiteLLM proxy at llm.k4jda.net, and surfaces insights through AI-powered skills (weekly briefs, governance sessions, drift detection). Search uses hybrid retrieval (full-text + vector with Reciprocal Rank Fusion) combined with ACT-R temporal decay scoring.
 
 ### 1.2 Scope
 
 **In Scope (this document)**:
-- Phase 1 (Foundation/MVP): Core API, Postgres+pgvector, Pipeline, Slack capture/query, MCP (embedded in Core API), Ollama, AI router
+- Phase 1 (Foundation/MVP): Core API, Postgres+pgvector, Pipeline, Slack capture/query, MCP (embedded in Core API), AI router (via external LiteLLM)
 - Phase 2 (Voice + Outputs): faster-whisper, voice-capture integration, weekly brief skill, notifications, email
 - Phase 3 (Intelligence): Entity graph, governance sessions, bet tracking, drift detection
 - Phase 4 (Polish): Web dashboard (Vite + React PWA), document ingestion, bookmarks, calendar
@@ -63,7 +63,7 @@ The system runs entirely on an Unraid home server, ingests captures from Slack a
 | Production Build | tsup (esbuild) | Zero-config bundler, single .mjs per service, ESM output |
 | Queue | BullMQ + Redis | Mature Node.js job queue, retries, priorities, dashboards |
 | LLM Proxy | LiteLLM | Unified OpenAI-compatible API for all LLM providers, with fallback and budget |
-| Embeddings | Configurable (default: nomic-embed-text 768d) via Ollama | Local, zero API cost, no fallback. Evaluating Qwen3-Embedding. Schema: vector(768) |
+| Embeddings | Qwen3-Embedding-4B-Q4_K_M via `jetson-embeddings` alias on LiteLLM | Runs on Jetson device, routed through llm.k4jda.net. OpenAI embeddings API. No fallback — queue and retry. Schema: vector(768) |
 | Search | Hybrid (FTS + vector + RRF) + ACT-R temporal decay | Best-of-both retrieval with recency/frequency-weighted ranking |
 | Transcription | faster-whisper (large-v3, CPU int8) | Local, accurate, no API cost |
 | Web UI | Vite + React + Tailwind + shadcn/ui | Lightweight SPA, no SSR needed |
@@ -77,7 +77,7 @@ Phase 1A: Data Layer
   F02 Postgres+pgvector → F01 Core API scaffold (CRUD, health, stats)
 
 Phase 1B: Embedding + Search
-  F07 Ollama (embedding model benchmarking) → Search endpoints (hybrid + temporal)
+  F07 EmbeddingService (via LiteLLM jetson-embeddings) → Search endpoints (hybrid + temporal)
 
 Phase 1C: Pipeline + LLM Gateway
   F07a LiteLLM → F08 AI Router → F03 Pipeline (embed + extract_metadata + notify)
@@ -121,7 +121,7 @@ Phase 4: Polish
 | Redis | 7+ | Job queues (BullMQ), thread context cache | Required |
 | Node.js | 22 LTS | Runtime for all TypeScript services | Required |
 | LiteLLM | latest | Unified LLM proxy with routing, fallback, budget | Required |
-| Ollama | latest | Local embedding inference (+ local LLMs via LiteLLM) | Required |
+| LiteLLM (external) | latest | Embeddings (jetson-embeddings) + all LLM inference — external shared service at llm.k4jda.net | Required |
 | faster-whisper | latest | Local speech-to-text | Required (Phase 2) |
 | Cloudflare Tunnel | latest | External access for brain.k4jda.net | Required (for MCP/slash commands) |
 | Tailscale | existing | Remote access to Unraid services | Required (existing) |
@@ -153,12 +153,10 @@ Phase 4: Polish
 
 | Container | Memory Limit | Notes |
 |-----------|-------------|-------|
-| Ollama | 16GB | Hosts embedding model + llama3.1:8b (Qwen3-Embedding:8b needs ~10GB if selected) |
 | faster-whisper | 8GB | large-v3 model, CPU int8 |
 | Postgres | 8GB | shared_buffers, work_mem |
-| LiteLLM | 512MB | Lightweight Python proxy |
 | All others | Unconstrained | Lightweight, typically <512MB each |
-| **Estimated total** | **~20-26GB** | Well within 128GB |
+| **Estimated total** | **~10-12GB** | Well within 128GB. Ollama not needed — embeddings and inference via external LiteLLM. |
 
 ---
 
@@ -412,7 +410,7 @@ kept (captures from different sources may have different context even with ident
 | filters.before | string | No | — | Captures before this date |
 
 **Implementation**:
-1. Generate embedding for `query` via Ollama (configured embedding model)
+1. Generate embedding for `query` via LiteLLM (jetson-embeddings alias)
 2. If search_mode = "hybrid": call `match_captures_hybrid()` with query embedding + raw query text
    If search_mode = "vector": call `match_captures()` with query embedding only
    If search_mode = "fts": execute FTS-only query with temporal scoring
@@ -830,7 +828,7 @@ If the answer triggers anti-vagueness enforcement:
 }
 ```
 
-**Implementation**: Generate embedding for `query_text` via Ollama at creation time. Store trigger with pre-computed embedding.
+**Implementation**: Generate embedding for `query_text` via LiteLLM (jetson-embeddings alias) at creation time. Store trigger with pre-computed embedding.
 
 ---
 
@@ -889,7 +887,7 @@ If the answer triggers anti-vagueness enforcement:
   "services": {
     "postgres": { "status": "up", "latency_ms": 2 },
     "redis": { "status": "up", "latency_ms": 1 },
-    "ollama": { "status": "up", "latency_ms": 15, "models_loaded": ["nomic-embed-text", "llama3.1:8b"] },
+    "litellm": { "status": "up", "latency_ms": 12, "models_available": ["jetson-embeddings", "fast", "synthesis", "governance"] },
     "litellm": { "status": "up", "latency_ms": 5, "models_available": ["fast", "synthesis", "governance"] }
   },
   "uptime_seconds": 86400,
@@ -907,7 +905,7 @@ If the answer triggers anti-vagueness enforcement:
 | PIPELINE_FAILED | 500 | Pipeline processing error | Check pipeline_events, retry via API |
 | SERVICE_UNAVAILABLE | 503 | Downstream service unreachable | Check health endpoint, wait for recovery |
 | AI_BUDGET_EXCEEDED | 429 | Monthly AI budget hard limit reached | Wait for budget reset or adjust limits |
-| OLLAMA_UNAVAILABLE | 503 | Ollama not responding | Check container, embeddings will queue |
+| EMBEDDING_UNAVAILABLE | 503 | LiteLLM/Jetson embedding unavailable | Embeddings will queue and retry via BullMQ |
 | CONFIG_ERROR | 500 | YAML config parse error | Fix config file syntax |
 
 ---
@@ -1134,7 +1132,7 @@ export const skillsLog = pgTable('skills_log', {
 // Do NOT add cost fields here — LiteLLM is the single source of truth for budget.
 export const aiAuditLog = pgTable('ai_audit_log', {
   id: uuid('id').defaultRandom().primaryKey(),
-  provider: text('provider').notNull(), // ollama | anthropic | openai | openrouter
+  provider: text('provider').notNull(), // litellm | anthropic | openai | openrouter
   model: text('model').notNull(),
   taskType: text('task_type').notNull(), // embedding | metadata_extraction | synthesis | governance | intent
   tokensIn: integer('tokens_in').default(0),
@@ -1438,7 +1436,7 @@ Switching embedding models (e.g., from nomic-embed-text to Qwen3-Embedding) requ
 ```typescript
 // Migration job: re-embed all captures with new model
 // 1. Query all captures with existing embeddings
-// 2. For each capture: generate new embedding via Ollama (new model)
+// 2. For each capture: generate new embedding via LiteLLM (jetson-embeddings alias)
 // 3. Batch update in groups of 50
 // Estimated time on CPU:
 //   nomic-embed-text (137M): ~1 capture/sec → 10K captures ≈ 3 hours
@@ -1753,31 +1751,31 @@ class SearchService {
 /**
  * EmbeddingService
  *
- * Generates embeddings via Ollama. No fallback — queue and retry.
- * Model is configurable via ai-routing.yaml (default: nomic-embed-text).
- * Supports instruction prefixes for models that use asymmetric embedding (e.g., Qwen3-Embedding).
+ * Generates embeddings via LiteLLM (https://llm.k4jda.net) using the OpenAI embeddings API.
+ * Model alias: 'jetson-embeddings' → Qwen3-Embedding-4B-Q4_K_M on Jetson device.
+ * No fallback — throws EmbeddingUnavailableError if LiteLLM/Jetson is unreachable; BullMQ retries.
+ * Uses same LITELLM_URL / LITELLM_API_KEY as AIRouterService (no separate OLLAMA_URL).
  */
 class EmbeddingService {
   constructor(
-    private ollamaClient: OllamaClient,
+    private litellmClient: OpenAI,  // OpenAI SDK pointed at https://llm.k4jda.net
     private configService: ConfigService,
   ) {}
 
   /** Generate 768-dim embedding for text.
-   *  Applies appropriate prefix if model supports instruction-following
-   *  (e.g., Qwen3-Embedding: "Instruct: ..." prefix for queries vs documents). */
+   *  Applies Qwen3 instruction prefix for query vs document type if supported. */
   async embed(text: string, type: 'document' | 'query' = 'document'): Promise<number[]>
-    // 1. Read model config from ai-routing.yaml (embedding.model, embedding.dimensions)
-    // 2. If model supports instruction prefixes, prepend appropriate prefix
-    // 3. POST to Ollama /api/embeddings with configured model
-    // 4. If model produces >768 dimensions (Matryoshka), truncate to 768
-    // 5. Throws OllamaUnavailableError if Ollama is down (caller retries)
+    // 1. Read model alias from ai-routing.yaml (embedding.model = 'jetson-embeddings')
+    // 2. If model supports instruction prefixes, prepend appropriate prefix for type
+    // 3. Call litellmClient.embeddings.create({ model: alias, input: text })
+    // 4. Return embedding vector (Qwen3-Embedding-4B configured for 768d on LiteLLM server)
+    // 5. Throws EmbeddingUnavailableError if LiteLLM is unreachable (caller/BullMQ retries)
 
   /** Batch embed multiple texts */
   async embedBatch(texts: string[], type: 'document' | 'query' = 'document'): Promise<number[][]>
 
   /** Get current embedding model info */
-  async getModelInfo(): Promise<{ model: string; dimensions: number; maxContext: number; supportsInstructions: boolean }>
+  async getModelInfo(): Promise<{ model: string; dimensions: number; supportsInstructions: boolean }>
 }
 ```
 
@@ -1787,7 +1785,7 @@ class EmbeddingService {
  *
  * Thin wrapper that maps task types to LiteLLM model aliases.
  * LiteLLM handles provider routing, fallback, and budget enforcement.
- * Embeddings go direct to Ollama (bypass LiteLLM).
+ * Embeddings go through EmbeddingService which also calls LiteLLM (jetson-embeddings alias).
  */
 class AIRouterService {
   constructor(
@@ -1913,45 +1911,45 @@ class EntityResolutionService {
 **Capture Flow (Slack → Pipeline → Stored)**:
 
 ```
-User          SlackBot       CoreAPI      CaptureService    BullMQ     PipelineWorker    Ollama    LiteLLM    Postgres
- │               │              │              │              │              │              │          │          │
- │──message──────►│              │              │              │              │              │          │          │
- │               │──POST /captures─►            │              │              │              │          │          │
- │               │              │──create()────►│              │              │              │          │          │
- │               │              │              │──dedup check────────────────────────────────────────────────────►│
- │               │              │              │◄────────────no dup──────────────────────────────────────────────│
- │               │              │              │──INSERT capture──────────────────────────────────────────────────►│
- │               │              │              │──enqueue()───►│              │              │          │          │
- │               │              │◄─201 {id}────│              │              │              │          │          │
- │               │◄─ack─────────│              │              │              │              │          │          │
- │               │              │              │              │──process()──►│              │          │          │
- │               │              │              │              │              │──embed()────►│          │          │
- │               │              │              │              │              │◄─vector[768]─│          │          │
- │               │              │              │              │              │──UPDATE embedding──────────────────►│
- │               │              │              │              │              │──check_triggers (in-memory)────────►│
- │               │              │              │              │              │──extract()───────────────►│         │
- │               │              │              │              │              │◄─metadata─────────────────│         │
- │               │              │              │              │              │──UPDATE metadata───────────────────►│
- │               │              │              │              │              │──UPDATE status=complete────────────►│
- │◄─thread reply─│◄────────────notify stage────│              │              │              │          │          │
+User          SlackBot       CoreAPI      CaptureService    BullMQ     PipelineWorker    LiteLLM(embed)  LiteLLM(llm)    Postgres
+ │               │              │              │              │              │                   │               │          │
+ │──message──────►│              │              │              │              │                   │               │          │
+ │               │──POST /captures─►            │              │              │                   │               │          │
+ │               │              │──create()────►│              │              │                   │               │          │
+ │               │              │              │──dedup check──────────────────────────────────────────────────────────────►│
+ │               │              │              │◄────────────no dup────────────────────────────────────────────────────────│
+ │               │              │              │──INSERT capture────────────────────────────────────────────────────────────►│
+ │               │              │              │──enqueue()───►│              │                   │               │          │
+ │               │              │◄─201 {id}────│              │              │                   │               │          │
+ │               │◄─ack─────────│              │              │              │                   │               │          │
+ │               │              │              │              │──process()──►│                   │               │          │
+ │               │              │              │              │              │──embed()──────────►│               │          │
+ │               │              │              │              │              │◄─vector[768]───────│               │          │
+ │               │              │              │              │              │──UPDATE embedding──────────────────────────────►│
+ │               │              │              │              │              │──check_triggers (in-memory)────────────────────►│
+ │               │              │              │              │              │──extract()────────────────────────►│           │
+ │               │              │              │              │              │◄─metadata──────────────────────────│           │
+ │               │              │              │              │              │──UPDATE metadata───────────────────────────────►│
+ │               │              │              │              │              │──UPDATE status=complete────────────────────────►│
+ │◄─thread reply─│◄────────────notify stage────│              │              │                   │               │          │
 ```
 
 **Search Flow (Hybrid + Temporal)**:
 
 ```
-User       SlackBot     CoreAPI    SearchService   EmbeddingService   Ollama    Postgres       BullMQ
- │            │            │            │                │              │          │              │
- │──? query──►│            │            │                │              │          │              │
- │            │──POST /search─►         │                │              │          │              │
- │            │            │──search()─►│                │              │          │              │
- │            │            │            │──embed(query)─►│              │          │              │
- │            │            │            │                │──POST /api/embeddings──►│              │
- │            │            │            │                │◄─vector[768]─│          │              │
- │            │            │            │──match_captures_hybrid(vector, text)────►│              │
- │            │            │            │◄─ranked results (RRF + temporal)────────│              │
- │            │            │            │──enqueue(update_access_stats)────────────────────────►│
- │            │◄─results───│◄───────────│                │              │          │              │
- │◄─formatted─│            │            │                │              │          │              │
+User       SlackBot     CoreAPI    SearchService   EmbeddingService   LiteLLM    Postgres       BullMQ
+ │            │            │            │                │                 │          │              │
+ │──? query──►│            │            │                │                 │          │              │
+ │            │──POST /search─►         │                │                 │          │              │
+ │            │            │──search()─►│                │                 │          │              │
+ │            │            │            │──embed(query)─►│                 │          │              │
+ │            │            │            │                │──POST /embeddings──────────►│              │
+ │            │            │            │                │◄─vector[768]────│           │              │
+ │            │            │            │──match_captures_hybrid(vector, text)─────────►│              │
+ │            │            │            │◄─ranked results (RRF + temporal)─────────────│              │
+ │            │            │            │──enqueue(update_access_stats)───────────────────────────►│
+ │            │◄─results───│◄───────────│                │                 │          │              │
+ │◄─formatted─│            │            │                │                 │          │              │
 ```
 
 ---
@@ -2021,7 +2019,7 @@ function classifyIntent(message: string): 'capture' | 'query' | 'command' {
 
   // LLM-based classification (via LiteLLM → intent model alias)
   // Uses intent_router_v1 prompt template
-  // Falls back to prefix-only if LiteLLM/Ollama is down (default-to-capture)
+  // Falls back to prefix-only if LiteLLM is unreachable (default-to-capture)
 
   return 'capture'; // Default: treat as capture (prevents data loss)
 }
@@ -2040,29 +2038,28 @@ function classifyIntent(message: string): 'capture' | 'query' | 'command' {
 - Socket Mode reconnection: Automatic with exponential backoff
 - Bot ignores its own messages and other bot messages
 
-### 8.2 Ollama Integration
+### 8.2 Embedding Service (via LiteLLM)
 
-**Purpose**: Local embedding generation. LLM chat/completion tasks route through LiteLLM (see §8.7), even when using Ollama-hosted models like llama3.1:8b.
+**Purpose**: Embedding generation for all captures, triggers, and search queries. Routes exclusively through external LiteLLM at llm.k4jda.net using the `jetson-embeddings` alias (Qwen3-Embedding-4B-Q4_K_M on Jetson device). LLM inference also routes through LiteLLM — see §8.7.
 
-**Embedding Model**: Configurable via `ai-routing.yaml`. Supports any Ollama-hosted model that produces 768d vectors (native or Matryoshka-truncated). Qwen3-Embedding models support instruction prefixes (`Instruct: ...`) for asymmetric query/document embedding — the EmbeddingService adds appropriate prefixes when the configured model supports it.
+**Embedding Model**: `jetson-embeddings` alias on LiteLLM → Qwen3-Embedding-4B-Q4_K_M running on Jetson device. Configured to produce 768d vectors. Supports instruction prefixes for asymmetric query/document embedding — EmbeddingService adds appropriate prefix based on type.
 
-**API**: OpenAI-compatible REST API
+**API**: OpenAI embeddings API via LiteLLM (same endpoint as LLM inference)
 
 ```typescript
-// Embedding generation (direct to Ollama — bypasses LiteLLM)
-const model = configService.get('ai-routing').embedding.model; // e.g., 'nomic-embed-text' or 'qwen3-embedding:8b'
-const response = await fetch('http://ollama:11434/api/embeddings', {
-  method: 'POST',
-  body: JSON.stringify({
-    model: model,
-    prompt: captureContent,  // With instruction prefix if model supports it
-  }),
+// Embedding generation via LiteLLM (OpenAI SDK — same client as AIRouterService)
+import OpenAI from 'openai';
+const litellm = new OpenAI({ baseURL: 'https://llm.k4jda.net', apiKey: process.env.LITELLM_API_KEY });
+const model = configService.get('ai-routing').embedding.model; // 'jetson-embeddings'
+const response = await litellm.embeddings.create({
+  model: model,
+  input: captureContent,  // With instruction prefix if model supports it
 });
-// response.embedding → number[768] (truncated if Matryoshka model produces more)
+// response.data[0].embedding → number[768]
 ```
 
 **Error Handling**:
-- Embeddings: NO fallback. If Ollama is down, captures queue in BullMQ and retry when Ollama recovers. This prevents mixing embedding models which would degrade search quality.
+- Embeddings: NO fallback. If LiteLLM/Jetson is unreachable, captures queue in BullMQ and retry. This prevents mixing embedding models which would degrade search quality.
 - LLM tasks: Routed through LiteLLM, which handles fallback to cloud providers.
 
 ### 8.3 Anthropic API Integration (via LiteLLM)
@@ -2172,8 +2169,8 @@ const response = await fetch('http://faster-whisper:8000/transcribe', {
 
 | Alias | Target | Fallback | Timeout |
 |-------|--------|----------|---------|
-| `fast` | ollama/llama3.1:8b (homeserver) | — | 30s |
-| `intent` | ollama/llama3.1:8b (homeserver) | — | 10s |
+| `fast` | TBD (local LLM via LiteLLM) | — | 30s |
+| `intent` | TBD (local LLM via LiteLLM) | — | 10s |
 | `synthesis` | anthropic/claude-sonnet-4-6 | openai/gpt-4o | 60s |
 | `governance` | anthropic/claude-opus-4-6 | claude-sonnet-4-6 | 120s |
 
@@ -2373,7 +2370,7 @@ After 5 failures:
 - Capture's pipeline_status set to `partial` (if other stages succeeded) or `failed`
 - Pushover alert sent (high priority)
 
-**Daily auto-retry sweep**: A scheduled job runs daily, finds all captures with failed stages, and retries each failed stage once. This catches transient issues (Ollama restart, network blip) that resolved after the initial retry window.
+**Daily auto-retry sweep**: A scheduled job runs daily, finds all captures with failed stages, and retries each failed stage once. This catches transient issues (LiteLLM/Jetson unreachable, network blip) that resolved after the initial retry window.
 
 **Manual retry**: `POST /api/v1/captures/:id/retry?stage=extract_metadata`
 
@@ -2403,7 +2400,7 @@ After 5 failures:
 | Level | Usage |
 |-------|-------|
 | ERROR | Service failures, unhandled exceptions, pipeline stage final failures |
-| WARN | Ollama temporary unavailability, budget soft limit, retry attempts |
+| WARN | LiteLLM/Jetson embedding unavailability, budget soft limit, retry attempts |
 | INFO | Capture ingested, pipeline complete, skill executed, search performed |
 | DEBUG | Embedding generation timing, AI router decisions, config reload |
 
@@ -2424,11 +2421,11 @@ No dedicated monitoring stack (no Prometheus, no Grafana). Instead:
 | Container health | Docker healthchecks + Unraid dashboard | Unraid notification |
 | Pipeline failures | `pipeline_status = 'failed'` count | Pushover (high priority) |
 | AI budget | LiteLLM `/spend/logs` endpoint | Pushover at $30 soft, circuit breaker at $50 |
-| Ollama down | Health endpoint check | Pushover (emergency) |
+| LiteLLM/Jetson down | Health endpoint check | Pushover (emergency) |
 | Postgres down | Health endpoint check | Pushover (emergency) |
 | Queue depth | BullMQ dashboard (Bull Board) | Log warning if depth > 50 |
 
-**Health Endpoint**: `GET /health` checks Postgres, Redis, and Ollama connectivity.
+**Health Endpoint**: `GET /health` checks Postgres, Redis, and LiteLLM connectivity.
 
 **Future**: Dockhand under consideration for container lifecycle management.
 
@@ -2460,7 +2457,7 @@ No dedicated monitoring stack (no Prometheus, no Grafana). Instead:
 | `thread:{thread_ts}` | `thread:1709312456.123456` | 1 hour | Auto-expire |
 | `config:{filename}` | `config:pipelines.yaml` | Until reload | `POST /admin/reload-config` or per-job re-read |
 | `budget:{month}` | `budget:2026-03` | 5 minutes | Refreshed on AI call |
-| `health:{service}` | `health:ollama` | 30 seconds | Auto-expire |
+| `health:{service}` | `health:litellm` | 30 seconds | Auto-expire |
 
 ### 11.3 Thread Context Implementation
 
@@ -2811,7 +2808,7 @@ export default defineConfig({
 
 - **Test runner**: Vitest (fast, Vite-native, TypeScript-first)
 - **Database**: Testcontainers (Postgres + pgvector) for integration tests
-- **Mocking**: Vitest built-in mocks for Ollama, Slack, external APIs
+- **Mocking**: Vitest built-in mocks for LiteLLM, Slack, external APIs
 
 ### 15.3 Unit Test Examples
 
@@ -2956,7 +2953,7 @@ describe('Captures API Integration', () => {
 |----------|-------|-----------------|
 | Slack capture → searchable | 1. Send message to #open-brain, 2. Wait for pipeline, 3. Search via API | Capture found with >0.8 similarity |
 | MCP search | 1. Create captures, 2. Call search_brain via MCP, 3. Verify results | Relevant results returned |
-| Pipeline retry | 1. Create capture, 2. Simulate Ollama failure, 3. Restart Ollama, 4. Wait for retry | Capture eventually completes |
+| Pipeline retry | 1. Create capture, 2. Simulate LiteLLM/Jetson unavailability, 3. Restore LiteLLM connectivity, 4. Wait for retry | Capture eventually completes |
 | Deduplication | 1. Send same slack_ts twice | Second attempt returns 409 |
 | Budget circuit breaker | 1. Exhaust budget via LiteLLM, 2. Attempt synthesis | Returns 429 |
 | Hybrid search recall | 1. Create capture with specific keywords, 2. Search with paraphrased query, 3. Search with exact keywords | Both find the capture (RRF fuses both arms) |
@@ -3023,23 +3020,7 @@ services:
       timeout: 5s
       retries: 5
 
-  ollama:
-    image: ollama/ollama:latest
-    restart: unless-stopped
-    volumes:
-      - ./data/ollama:/root/.ollama
-    networks:
-      - open-brain
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    deploy:
-      resources:
-        limits:
-          memory: 16G
-
+  # Ollama: NOT in Open Brain stack. Embeddings (jetson-embeddings) and LLM inference both route through external LiteLLM at https://llm.k4jda.net.
   # LiteLLM is an external shared service at https://llm.k4jda.net — no container here.
 
   faster-whisper:
@@ -3077,7 +3058,6 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/open_brain
       REDIS_URL: redis://redis:6379
-      OLLAMA_URL: http://ollama:11434
       LITELLM_URL: https://llm.k4jda.net
       LITELLM_API_KEY: ${LITELLM_API_KEY}
       MCP_API_KEY: ${MCP_API_KEY}  # MCP embedded at /mcp route
@@ -3127,7 +3107,6 @@ services:
       DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/open_brain
       REDIS_URL: redis://redis:6379
       CORE_API_URL: http://core-api:3000
-      OLLAMA_URL: http://ollama:11434
       LITELLM_URL: https://llm.k4jda.net
       LITELLM_API_KEY: ${LITELLM_API_KEY}
       PUSHOVER_APP_TOKEN: ${PUSHOVER_APP_TOKEN}
@@ -3204,8 +3183,8 @@ services:
 open-brain (single network)
 ┌──────────────────────────────────────────────────────────┐
 │                                                          │
-│  postgres     redis       ollama      faster-whisper     │
-│  litellm      core-api    slack-bot   workers            │
+│  postgres     redis       faster-whisper                 │
+│  core-api     slack-bot   workers                        │
 │  voice-capture web-ui     cloudflared                    │
 │                                                          │
 └──────────────────────────────────────────────────────────┘
@@ -3255,7 +3234,7 @@ LOG_LEVEL=info
 
 ```bash
 # 1. Retrieve secrets from Bitwarden → .env.secrets (gitignored, chmod 600)
-bws secret list --access-token $TROY | jq -r '.[] | select(.key | startswith("dev/open-brain/")) | "\(.key | split("/") | last | ascii_upcase | gsub("-";"_"))=\(.value)"' > .env.secrets
+bws secret list | jq -r '.[] | select(.key | startswith("dev/open-brain/")) | "\(.key | split("/") | last | ascii_upcase | gsub("-";"_"))=\(.value)"' > .env.secrets
 chmod 600 .env.secrets
 
 # 2. Start infrastructure
@@ -3266,12 +3245,7 @@ docker compose exec postgres pg_isready
 
 # 4. Migrations run automatically via core-api entrypoint script (no manual step needed)
 
-# 5. Pull and preload Ollama models
-docker compose up -d ollama
-docker compose exec ollama ollama pull nomic-embed-text  # Or: qwen3-embedding:8b (if selected after benchmarking)
-docker compose exec ollama ollama pull llama3.1:8b
-
-# 5a. Verify external LiteLLM proxy is reachable
+# 5. Verify external LiteLLM proxy is reachable and jetson-embeddings alias works
 curl https://llm.k4jda.net/health  # External shared LiteLLM — not managed by this stack
 
 # 6. Start application stack
@@ -3320,9 +3294,9 @@ No feature flag service — single user, phased deployment. Features enabled by:
 - [ ] Vitest unit + Testcontainers integration tests passing
 
 **Phase 1B: Embedding + Search**
-- [ ] Ollama running with candidate embedding model(s)
-- [ ] Actual CPU embedding throughput measured and documented (update TDD Section 4.5 estimates)
-- [ ] Embedding model benchmarked with 50+ real captures → model selected
+- [ ] LiteLLM jetson-embeddings alias reachable and returning 768d vectors
+- [ ] Actual embedding throughput measured and documented (update TDD Section 4.5 estimates)
+- [ ] Embedding quality validated with 50+ real captures
 - [ ] match_captures (vector + temporal) function deployed
 - [ ] FTS GIN index created on captures.content
 - [ ] match_captures_hybrid (RRF) function deployed
@@ -3331,8 +3305,8 @@ No feature flag service — single user, phased deployment. Features enabled by:
 
 **Phase 1C: Pipeline + LLM Gateway**
 - [ ] Redis running
-- [ ] LiteLLM running with model aliases (fast, synthesis, governance, intent) and budget
-- [ ] AI Router routing embeddings to Ollama, LLM to LiteLLM
+- [ ] External LiteLLM reachable with model aliases (fast, synthesis, governance, intent) and budget configured
+- [ ] AI Router routing all requests (embeddings + LLM) through external LiteLLM
 - [ ] Pipeline stages: embed → extract_metadata → notify (stub)
 - [ ] Pipeline retry logic: patient backoff (30s, 2m, 10m, 30m, 2h)
 - [ ] Bull Board at /admin/queues functional
@@ -3407,7 +3381,7 @@ No feature flag service — single user, phased deployment. Features enabled by:
 | Weekly brief generation | <2 min | Skill execution time |
 | MCP tool response | <5s | Tool execution time |
 | Web dashboard page load | <2s | Time to interactive |
-| Embedding generation | <1s | Ollama API call |
+| Embedding generation | <2s | LiteLLM API call to Jetson |
 | Metadata extraction | <5s | LLM completion time |
 
 ### 18.2 Optimization Strategies
@@ -3451,7 +3425,7 @@ Expected scale for a single-user personal knowledge system.
 | Captures | 50/day, ~18K/year | 100K total | Re-tune HNSW (increase m, ef_construction). Consider IVFFlat if HNSW build time grows. |
 | Postgres disk | ~4KB/capture (1KB content + 3KB embedding) | 1GB (~250K captures) | Non-issue for 32TB array. Add table partitioning by year if queries slow. |
 | Redis memory | ~100 bytes/job, ~1KB/thread context | 1GB | Non-issue. Check for orphaned BullMQ jobs if memory grows unexpectedly. |
-| Ollama memory | 1-16GB depending on model | 16GB limit | Swap to smaller model or increase limit. Only one model loaded at a time for embeddings. |
+| Jetson (external) | N/A — managed on Jetson device | N/A | If Jetson is overloaded, embeddings queue in BullMQ. Monitor via LiteLLM dashboard. |
 | Embedding generation | 1/sec (137M) to 0.1/sec (8B) | >20 captures/minute sustained | Batch embedding endpoint, or queue accepts latency. Unlikely for single user. |
 | LiteLLM | <100 requests/day | 1000/day | Non-issue. LiteLLM handles thousands of RPM. |
 | Postgres connections | ~5 active (API + workers + bot) | 20 (max_connections) | Increase max_connections. Consider PgBouncer if services scale. |
@@ -3528,8 +3502,8 @@ Single-user system — security is network-level, not application-level.
 | Output Skill | Scheduled/triggered AI synthesis process (weekly brief, governance) |
 | Entity | Known person, project, decision, bet, or concept |
 | Intent Router | Slack message classifier (capture vs. query vs. command) |
-| AI Router | Thin application service mapping task types to LiteLLM model aliases (LLM) and Ollama (embeddings) |
-| LiteLLM | Self-hosted proxy providing unified OpenAI-compatible API for all LLM providers |
+| AI Router | Thin application service mapping task types to LiteLLM model aliases — both LLM inference and embeddings route through external LiteLLM |
+| LiteLLM | External shared proxy at llm.k4jda.net providing unified OpenAI-compatible API for embeddings and all LLM providers |
 | Hybrid Search | FTS + vector search fused via Reciprocal Rank Fusion (RRF) |
 | ACT-R Temporal Decay | Cognitive model scoring captures by access recency and frequency |
 | Semantic Trigger | Persistent pattern that fires notifications when new captures match semantically |
@@ -3542,8 +3516,6 @@ Single-user system — security is network-level, not application-level.
 **pipelines.yaml** — Pipeline stage definitions per source/view. See PRD Section 5.2 (F03) for full spec.
 
 **ai-routing.yaml** — Embedding config + task-to-LiteLLM-alias mapping. See PRD Section 5.2 (F08).
-
-**litellm-config.yaml** — LiteLLM proxy config: model list with provider/fallback, budget limits, alerting. See TDD §8.7.
 
 **skills.yaml** — Output skill definitions, schedules, delivery targets.
 
@@ -3597,30 +3569,29 @@ Templates are versioned (`v1`, `v2`, `v3`), stored in `config/prompts/`, hot-rel
 
 Common failure scenarios and resolution steps.
 
-**Ollama down (embeddings queuing)**
-1. Check container: `docker compose logs ollama`
-2. Restart: `docker compose restart ollama`
-3. Verify model loaded: `docker compose exec ollama ollama list`
+**LiteLLM/Jetson embedding unavailable (embeddings queuing)**
+1. Check LiteLLM health: `curl https://llm.k4jda.net/health`
+2. Check jetson-embeddings alias: `curl -H "Authorization: Bearer $LITELLM_API_KEY" https://llm.k4jda.net/v1/models`
+3. If Jetson device is down, wait for it to recover — embeddings queue in BullMQ with patient backoff
 4. Captures will auto-retry via BullMQ backoff. Check Bull Board for queue depth.
-5. If model corrupted: `docker compose exec ollama ollama pull <model-name>`
+5. If LiteLLM configuration issue, check LiteLLM admin panel at llm.k4jda.net
 
-**LiteLLM can't reach providers**
-1. Check container: `docker compose logs litellm`
-2. Verify health: `curl http://localhost:4000/health`
-3. Check API keys: `bws secret list --access-token $TROY | grep open-brain`
-4. LiteLLM auto-falls back (synthesis → gpt-4o, governance → claude-sonnet)
-5. If all providers down: LLM tasks queue in BullMQ. Local Ollama tasks (fast, intent) still work.
+**LiteLLM can't reach LLM providers**
+1. Check LiteLLM health: `curl https://llm.k4jda.net/health`
+2. Check API keys configured on external LiteLLM server
+3. LiteLLM auto-falls back (synthesis → gpt-4o, governance → claude-sonnet)
+4. If all providers down: LLM tasks queue in BullMQ. Captures still ingested; embeddings still work (Jetson path).
 
 **Pipeline queue depth > 100**
 1. Check Bull Board at `/admin/queues`
-2. Most likely cause: Ollama is slow or down
-3. Check Ollama health: `curl http://ollama:11434/`
-4. If Ollama healthy but slow: captures are just queued, they'll process eventually
+2. Most likely cause: LiteLLM/Jetson is slow or unreachable for embeddings
+3. Check LiteLLM health: `curl https://llm.k4jda.net/health`
+4. If LiteLLM healthy but Jetson slow: captures are just queued, they'll process eventually
 5. If persistent: check for a stuck job — remove it via Bull Board
 
-**Embedding model swap**
-1. Update `config/ai-routing.yaml` → `embedding.model`
-2. Pull new model: `docker compose exec ollama ollama pull <new-model>`
+**Embedding model swap (reconfigure on LiteLLM)**
+1. Update `jetson-embeddings` alias on external LiteLLM to point to new model
+2. Update `config/ai-routing.yaml` → `embedding.model` to match new alias
 3. Run re-embedding job: trigger via API or custom script
 4. Monitor progress via Bull Board — estimated times in Section 4.5
 5. Search quality may be degraded during re-embedding (mixed embeddings)
@@ -3641,10 +3612,9 @@ Common failure scenarios and resolution steps.
 
 **Monthly AI budget exceeded**
 1. LiteLLM enforces hard limit — LLM requests return 429
-2. Local tasks (fast, intent via Ollama) still work
-3. Captures still ingested and embedded (Ollama, not LiteLLM)
-4. Synthesis and governance blocked until budget resets
-5. Override: update `max_budget` in `config/litellm-config.yaml`, restart LiteLLM
+2. Captures still ingested; embeddings may also be blocked depending on LiteLLM budget scope
+3. Synthesis and governance blocked until budget resets
+4. Override: update `max_budget` in LiteLLM admin on external server (llm.k4jda.net), no local restart needed
 
 **MCP API key rotation**
 1. Generate new key: `bws secret edit dev/open-brain/mcp-api-key --value "new-key-here"`
@@ -3665,7 +3635,4 @@ Common failure scenarios and resolution steps.
 *This document was completed on 2026-03-04 using `/finish-document`.*
 
 **Questions Resolved:** 32 of 32
-**Reference Files:**
-- Questions: `reference/questions-TDD-20260304-202900.json`
-- Answers: `reference/answers-TDD-20260304-214500.json`
 - Original backup: `TDD.backup-20260304-221000.md`


### PR DESCRIPTION
## Summary

- **Embeddings**: now via `jetson-embeddings` alias on external LiteLLM → Qwen3-Embedding-4B-Q4_K_M running on Jetson device (768d)
- **LLM inference**: `fast`, `intent`, `synthesis`, `governance` aliases all through external LiteLLM
- **No Ollama container** in Open Brain Docker stack — estimated memory footprint drops from ~20-26GB to ~10-12GB

## Files Modified

| File | Changes |
|------|---------|
| `docs/TDD.md` | Remove Ollama container from Docker Compose, tech stack, network topology; rewrite EmbeddingService, §8.2, operational runbook, health checks, sequence diagrams |
| `docs/PRD.md` | Rewrite F07 (EmbeddingService via LiteLLM), F07a (external LiteLLM), F08 ai-routing.yaml; update all acceptance criteria, assumptions, glossary |
| `IMPLEMENTATION_PLAN.md` | Phase 5 EmbeddingService uses OpenAI SDK → LiteLLM; Phase 6.3 AIRouterService; remove OLLAMA_URL; add Phase 6.7 daily sweep worker |
| `IMPLEMENTATION_PLAN-PHASE2.md` | Phase 14.5 AI budget monitoring; Phase 15 web package name fixes |
| `CLAUDE.md` | Update key architecture decisions to reflect external LiteLLM for all AI |

## Architecture Decision

LiteLLM runs as a **shared external service** at `https://llm.k4jda.net`, not as a container inside Open Brain's Docker stack. This enables reuse across multiple workloads and simplifies Open Brain's infrastructure significantly.

Both embeddings and LLM inference use the same LiteLLM client (`LITELLM_URL` + `LITELLM_API_KEY`) — no separate `OLLAMA_URL` needed.