### PR TITLE
fix: repair slack-bot search display — nested response, null content, PG timestamps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,51 @@
 # Open Brain — AI Assistant Context
 
+## Operational Rules — Learning Capture
+
+**These rules apply in every session. Do not skip them.**
+
+### When a bug, failure, or deployment issue is diagnosed and fixed
+
+After any non-trivial finding during deployment, testing, or debugging:
+
+1. **Update `CLAUDE.md`** (this file) — add or update a bullet in the relevant section with the operational rule. This is the always-loaded, always-enforced file.
+2. **Update the memory file** — write a detailed entry in `C:\Users\Troy Davis\.claude\projects\C--Users-Troy-Davis-dev-personal-open-brain\memory\` in the appropriate topic file. Include the root cause, the fix, and what to watch for.
+3. **Update `MEMORY.md`** — add a concise bullet + link to the topic file so it survives context compaction.
+
+### What counts as a "non-trivial finding"
+
+- Any container startup failure, crash, or silent failure with a non-obvious root cause
+- Any Docker Compose or networking quirk (port conflicts, healthcheck failures, bridge behavior)
+- Any LiteLLM/embedding/pipeline behavior surprise (retry logic, vector dimensions, queue wiring)
+- Any Slack bot routing behavior (intent classification, @mention vs plain message handling)
+- Any fix that took more than one attempt to get right
+
+### Learning file locations
+
+| File | Purpose | When to write |
+|------|---------|---------------|
+| `CLAUDE.md` (this file) | Operational rules, always enforced | Every session with new learnings |
+| `memory/MEMORY.md` | Concise index, survives compaction | After each new topic file entry |
+| `memory/deployment-learnings.md` | Docker, infra, container startup issues | Any deployment/container finding |
+| `memory/pipeline-learnings.md` | BullMQ pipeline behavior, retry, job wiring | Pipeline/worker findings |
+| `memory/embedding-learnings.md` | Vector dimensions, LiteLLM embedding quirks | Embedding/search findings |
+| `memory/integration-test-findings.md` | Bug patterns from full e2e runs | Test/run bugs |
+
+### Verified operational rules (do not repeat these mistakes)
+
+- **Healthchecks must use `127.0.0.1`, not `localhost`** — Alpine Linux resolves `localhost` to `::1` (IPv6); `wget` cannot connect to IPv6 and healthchecks fail silently. Affects core-api, voice-capture, and web containers.
+- **Docker Compose `ports` lists are appended, not replaced in override files** — `docker-compose.override.yml` with a different port mapping adds a second binding, not a replacement. Set correct ports directly in `docker-compose.yml`.
+- **voice-capture entry point is `dist/server.js`, not `dist/index.js`** — the package builds from `server.ts`. Dockerfile CMD must be `node packages/voice-capture/dist/server.js`.
+- **`postgresql.conf` must set `listen_addresses = '*'`** — without it, Postgres defaults to `localhost` only and blocks all container-to-container connections.
+- **Matryoshka truncation check must use `< 768`, not `!== 768`** — the embedding service slices `raw.slice(0, 768)`. A `!== 768` guard would reject the full 2560-dim vector before slicing.
+- **LiteLLM MCP server names cannot contain `-`** — use `_` instead (e.g., `open_brain` not `open-brain`). Hyphens cause a startup validation exception.
+- **LiteLLM MCP transport must be `http`, not `streamable_http`** — v1.81 accepts only `http`, `sse`, or `stdio`. `streamable_http` causes a Pydantic validation error and crashes startup.
+- **`/health` is Docker-internal only** — nginx does not proxy `/health` externally. Use `/api/v1/captures?limit=1` for external health checks and tunnel verification.
+- **Slack `app_mention` events always route to `handleQuery`** — do not document @mention as a way to trigger captures or commands. Captures and `!commands` require plain channel messages routed through IntentRouter.
+- **`SLACK_SIGNING_SECRET` is not needed for Socket Mode** — signing secrets are for HTTP webhook verification only. Socket Mode only needs `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`.
+
+---
+
 ## What This Is
 
 Self-hosted personal AI knowledge infrastructure. Ingests from voice memos, Slack, documents; stores in Postgres+pgvector; provides semantic search, AI synthesis, weekly briefs, and governance sessions.

--- a/packages/slack-bot/src/lib/core-api-client.ts
+++ b/packages/slack-bot/src/lib/core-api-client.ts
@@ -242,10 +242,24 @@ export class CoreApiClient {
   // Search
 
   async search_query(payload: SearchPayload): Promise<SearchResponse> {
-    return this.request<SearchResponse>('/api/v1/search', {
+    const raw = await this.request<{ query: string; total: number; results: Array<{ capture: CaptureResult; score: number }> }>('/api/v1/search', {
       method: 'POST',
       body: JSON.stringify(payload),
     })
+    return {
+      query: raw.query,
+      total: raw.total,
+      results: (raw.results ?? []).map(r => ({
+        id: r.capture.id,
+        content: r.capture.content,
+        capture_type: r.capture.capture_type,
+        brain_view: r.capture.brain_view,
+        source: r.capture.source,
+        score: r.score,
+        created_at: r.capture.created_at,
+        pre_extracted: r.capture.pre_extracted,
+      })),
+    }
   }
 
   // Synthesize

--- a/packages/slack-bot/src/lib/formatters.ts
+++ b/packages/slack-bot/src/lib/formatters.ts
@@ -7,7 +7,7 @@ import type { SearchResult, CaptureResult, BrainStats, TriggerRecord, TriggerMat
 
 // Date formatting helper
 function formatDate(isoDate: string): string {
-  const date = new Date(isoDate)
+  const date = new Date(isoDate.replace(' ', 'T').replace(/([+-]\d{2})$/, '$1:00'))
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
@@ -47,7 +47,7 @@ export function formatSearchResults(
     const pct = `${Math.round(r.score * 100)}%`
     const date = formatDate(r.created_at)
     const topics = r.pre_extracted?.topics?.slice(0, 3).join(', ') || ''
-    const content = truncate(r.content)
+    const content = truncate(r.content ?? '')
 
     let line = `${num}. *[${r.capture_type}]* ${date} — ${pct} match\n`
     line += `> ${content}`
@@ -210,7 +210,7 @@ export function formatEntityDetails(entity: EntityRecord & { captures?: CaptureR
 
   const captureList = (entity.captures ?? []).slice(0, 5).map(c => {
     const date = formatDate(c.created_at)
-    return `• [${c.capture_type}] ${truncate(c.content, 80)} — ${date}`
+    return `• [${c.capture_type}] ${truncate(c.content ?? '', 80)} — ${date}`
   }).join('\n')
 
   return `${header}${aliases}\n*Recent Captures:*\n${captureList || '(none)'}`
@@ -299,7 +299,7 @@ export function formatRecentCaptures(captures: RecentCapture[]): string {
   const header = `:inbox_tray: *Recent Captures*\n\n`
   const lines = captures.map((c, i) => {
     const date = formatDate(c.created_at)
-    return `${i + 1}. [${c.capture_type}] ${truncate(c.content, 80)} — ${date}`
+    return `${i + 1}. [${c.capture_type}] ${truncate(c.content ?? '', 80)} — ${date}`
   })
 
   return header + lines.join('\n')


### PR DESCRIPTION
## Summary

- **`core-api-client.ts`**: `search_query()` was returning the raw API response directly as `SearchResponse`, but the search endpoint returns `{ capture: {...}, score, ftsScore, vectorScore }` nested objects. Added mapping to flatten to the flat `SearchResult` interface.
- **`formatters.ts`**: Three `truncate()` call sites passed `content` without null guard, causing `TypeError: Cannot read properties of undefined (reading 'length')` crashes on any search result with undefined content. Added `?? ''` coalescing in `formatSearchResults`, `formatRecentCaptures`, and `formatEntityDetails`.
- **`formatters.ts`**: `formatDate()` used `new Date(isoDate)` which returns `Invalid Date` for PostgreSQL timestamp format (`"2026-03-08 13:25:10.934632+00"` — space separator, `+HH` offset without colon). Added normalization: `replace(' ', 'T').replace(/([+-]\d{2})$/, '$1:00')`.

## Root cause

The search API response shape was never matched to the `SearchResult` interface — the bot was rendering `[undefined] Invalid Date — 1% match` for every result because all fields came back undefined from the nested structure.

## Test plan

- [x] Sent `@Open Brain what decisions have I made about infrastructure?` in #open-brain — results show correct capture types, formatted dates, and content
- [x] Verified 768-dim embeddings continue to store correctly (Matryoshka truncation in `EmbeddingService` confirmed)
- [x] `!stats`, `!recent`, captures all functioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)