### PR TITLE
fix: map captures_list API response items field to captures

### DIFF
--- a/packages/slack-bot/src/handlers/commands/capture.ts
+++ b/packages/slack-bot/src/handlers/commands/capture.ts
@@ -16,7 +16,7 @@ export async function handleStats(ts: string, say: SayFn, client: CoreApiClient)
 export async function handleRecent(ts: string, say: SayFn, client: CoreApiClient, limit: number): Promise<void> {
   try {
     const result = await client.captures_list({ limit })
-    await say({ text: formatRecentCaptures(result.captures, limit), thread_ts: ts })
+    await say({ text: formatRecentCaptures(result.captures), thread_ts: ts })
   } catch (err) {
     logger.error({ err }, 'handleCommand: captures_list failed')
     await say({ text: formatError('Could not retrieve recent captures', err), thread_ts: ts })

--- a/packages/slack-bot/src/lib/core-api-client.ts
+++ b/packages/slack-bot/src/lib/core-api-client.ts
@@ -232,7 +232,9 @@ export class CoreApiClient {
     if (params?.source) query.set('source', params.source)
     if (params?.capture_type) query.set('capture_type', params.capture_type)
     const qs = query.toString()
-    return this.request<{ total: number; captures: RecentCapture[] }>(`/api/v1/captures${qs ? `?${qs}` : ''}`)
+    // API returns { items, total, limit, offset } — map items → captures
+    const raw = await this.request<{ total: number; items: RecentCapture[] }>(`/api/v1/captures${qs ? `?${qs}` : ''}`)
+    return { total: raw.total, captures: raw.items ?? [] }
   }
 
   async captures_retry(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

- `GET /api/v1/captures` returns `{ items, total, limit, offset }` but `CoreApiClient.captures_list` was typed as `{ captures, total }`, making `result.captures` always `undefined`
- This caused `!recent N` to crash with `Cannot read properties of undefined (reading 'length')` after PR #11 fixed the routing (the command reached the handler for the first time)
- Also removes a spurious `limit` argument passed to `formatRecentCaptures` (which only accepts one parameter)

## Files Modified

- `packages/slack-bot/src/lib/core-api-client.ts` — deserializes `raw.items` and returns it as `captures`
- `packages/slack-bot/src/handlers/commands/capture.ts` — removes extra `limit` arg from `formatRecentCaptures` call

## Test Plan

- [x] All 327 slack-bot unit tests pass
- [x] `!recent 5` now returns the last 5 captures instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)