### PR TITLE
fix: entities_list mapping, entities_search URL, and pipeline/health endpoint (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,51 @@
 # Open Brain — AI Assistant Context
 
+## Operational Rules — Learning Capture
+
+**These rules apply in every session. Do not skip them.**
+
+### When a bug, failure, or deployment issue is diagnosed and fixed
+
+After any non-trivial finding during deployment, testing, or debugging:
+
+1. **Update `CLAUDE.md`** (this file) — add or update a bullet in the relevant section with the operational rule. This is the always-loaded, always-enforced file.
+2. **Update the memory file** — write a detailed entry in `C:\Users\Troy Davis\.claude\projects\C--Users-Troy-Davis-dev-personal-open-brain\memory\` in the appropriate topic file. Include the root cause, the fix, and what to watch for.
+3. **Update `MEMORY.md`** — add a concise bullet + link to the topic file so it survives context compaction.
+
+### What counts as a "non-trivial finding"
+
+- Any container startup failure, crash, or silent failure with a non-obvious root cause
+- Any Docker Compose or networking quirk (port conflicts, healthcheck failures, bridge behavior)
+- Any LiteLLM/embedding/pipeline behavior surprise (retry logic, vector dimensions, queue wiring)
+- Any Slack bot routing behavior (intent classification, @mention vs plain message handling)
+- Any fix that took more than one attempt to get right
+
+### Learning file locations
+
+| File | Purpose | When to write |
+|------|---------|---------------|
+| `CLAUDE.md` (this file) | Operational rules, always enforced | Every session with new learnings |
+| `memory/MEMORY.md` | Concise index, survives compaction | After each new topic file entry |
+| `memory/deployment-learnings.md` | Docker, infra, container startup issues | Any deployment/container finding |
+| `memory/pipeline-learnings.md` | BullMQ pipeline behavior, retry, job wiring | Pipeline/worker findings |
+| `memory/embedding-learnings.md` | Vector dimensions, LiteLLM embedding quirks | Embedding/search findings |
+| `memory/integration-test-findings.md` | Bug patterns from full e2e runs | Test/run bugs |
+
+### Verified operational rules (do not repeat these mistakes)
+
+- **Healthchecks must use `127.0.0.1`, not `localhost`** — Alpine Linux resolves `localhost` to `::1` (IPv6); `wget` cannot connect to IPv6 and healthchecks fail silently. Affects core-api, voice-capture, and web containers.
+- **Docker Compose `ports` lists are appended, not replaced in override files** — `docker-compose.override.yml` with a different port mapping adds a second binding, not a replacement. Set correct ports directly in `docker-compose.yml`.
+- **voice-capture entry point is `dist/server.js`, not `dist/index.js`** — the package builds from `server.ts`. Dockerfile CMD must be `node packages/voice-capture/dist/server.js`.
+- **`postgresql.conf` must set `listen_addresses = '*'`** — without it, Postgres defaults to `localhost` only and blocks all container-to-container connections.
+- **Matryoshka truncation check must use `< 768`, not `!== 768`** — the embedding service slices `raw.slice(0, 768)`. A `!== 768` guard would reject the full 2560-dim vector before slicing.
+- **LiteLLM MCP server names cannot contain `-`** — use `_` instead (e.g., `open_brain` not `open-brain`). Hyphens cause a startup validation exception.
+- **LiteLLM MCP transport must be `http`, not `streamable_http`** — v1.81 accepts only `http`, `sse`, or `stdio`. `streamable_http` causes a Pydantic validation error and crashes startup.
+- **`/health` is Docker-internal only** — nginx does not proxy `/health` externally. Use `/api/v1/captures?limit=1` for external health checks and tunnel verification.
+- **Slack `app_mention` events always route to `handleQuery`** — do not document @mention as a way to trigger captures or commands. Captures and `!commands` require plain channel messages routed through IntentRouter.
+- **`SLACK_SIGNING_SECRET` is not needed for Socket Mode** — signing secrets are for HTTP webhook verification only. Socket Mode only needs `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`.
+
+---
+
 ## What This Is
 
 Self-hosted personal AI knowledge infrastructure. Ingests from voice memos, Slack, documents; stores in Postgres+pgvector; provides semantic search, AI synthesis, weekly briefs, and governance sessions.

--- a/packages/core-api/src/routes/admin.ts
+++ b/packages/core-api/src/routes/admin.ts
@@ -74,12 +74,61 @@ export function createAdminRouter({ configService, redisConnection }: AdminRoute
     router.route('/queues', bullBoardApp)
 
     logger.info('[admin] Bull Board mounted at /api/v1/admin/queues')
+
+    // GET /pipeline/health — returns BullMQ queue counts in PipelineStatus format
+    router.get('/pipeline/health', async (ctx) => {
+      type QueueCounts = { waiting: number; active: number; completed: number; failed: number; delayed: number }
+      const counts: Array<{ name: string } & QueueCounts> = await Promise.all(
+        queues.map(async (q) => {
+          const result = await q.getJobCounts('active', 'waiting', 'completed', 'failed', 'delayed') as QueueCounts
+          return { name: q.name, ...result }
+        }),
+      )
+
+      const queueMap: Record<string, QueueCounts> = {}
+      let totalPending = 0
+      let totalProcessing = 0
+      let totalComplete = 0
+      let totalFailed = 0
+
+      for (const q of counts) {
+        queueMap[q.name] = {
+          waiting: q.waiting ?? 0,
+          active: q.active ?? 0,
+          completed: q.completed ?? 0,
+          failed: q.failed ?? 0,
+          delayed: q.delayed ?? 0,
+        }
+        totalPending += (q.waiting ?? 0) + (q.delayed ?? 0)
+        totalProcessing += q.active ?? 0
+        totalComplete += q.completed ?? 0
+        totalFailed += q.failed ?? 0
+      }
+
+      return ctx.json({
+        queues: queueMap,
+        overall: {
+          pending: totalPending,
+          processing: totalProcessing,
+          complete: totalComplete,
+          failed: totalFailed,
+        },
+      })
+    })
   } else {
     // Placeholder until Redis connection is wired at startup
     router.get('/queues', (c) => {
       return c.json({
         message: 'Bull Board requires a Redis connection — pass redisConnection to createAdminRouter()',
         queues: QUEUE_NAMES,
+      })
+    })
+
+    router.get('/pipeline/health', (c) => {
+      return c.json({
+        message: 'Pipeline health requires a Redis connection',
+        queues: {},
+        overall: { pending: 0, processing: 0, complete: 0, failed: 0 },
       })
     })
   }

--- a/packages/slack-bot/src/lib/core-api-client.ts
+++ b/packages/slack-bot/src/lib/core-api-client.ts
@@ -320,12 +320,23 @@ export class CoreApiClient {
 
   async entities_list(params?: { limit?: number }): Promise<{ total: number; entities: EntityRecord[] }> {
     const query = params?.limit ? `?limit=${params.limit}` : ''
-    return this.request<{ total: number; entities: EntityRecord[] }>(`/api/v1/entities${query}`)
+    // API returns { items, total, limit, offset } — map items → entities
+    const raw = await this.request<{ total: number; items: EntityRecord[] }>(`/api/v1/entities${query}`)
+    return { total: raw.total, entities: raw.items ?? [] }
   }
 
   async entities_search(name: string): Promise<{ total: number; entities: EntityRecord[] }> {
-    const query = encodeURIComponent(name)
-    return this.request<{ total: number; entities: EntityRecord[] }>(`/api/v1/entities/search?q=${query}`)
+    // API uses ?name= param; returns { entity } (single) or 404
+    try {
+      const raw = await this.request<{ entity: EntityRecord }>(`/api/v1/entities?name=${encodeURIComponent(name)}`)
+      return { total: 1, entities: [raw.entity] }
+    } catch (err) {
+      // 404 = entity not found — return empty list so callers can show "no match" message
+      if (err instanceof Error && err.message.startsWith('HTTP 404')) {
+        return { total: 0, entities: [] }
+      }
+      throw err
+    }
   }
 
   async entities_get(id: string): Promise<EntityRecord & { captures: CaptureResult[] }> {


### PR DESCRIPTION
## Summary

Three API integration bugs discovered during live Slack bot testing:

- **`!entities` crash**: `GET /api/v1/entities` returns `{ items, total }` but `entities_list` expected `{ entities, total }`, causing `formatEntityList(undefined)` to throw `Cannot read properties of undefined (reading 'length')`. Fixed by mapping `raw.items → entities`.
- **`!entity <name>` wrong URL**: `entities_search` was calling `/api/v1/entities/search?q=` (non-existent). API uses `GET /api/v1/entities?name=` returning a single `{ entity }` or 404. Fixed URL, mapped response to array, return empty array on 404 for clean "not found" handling.
- **`!pipeline status` HTTP 404**: No `/api/v1/admin/pipeline/health` route existed. Added endpoint that queries BullMQ `getJobCounts()` for all 5 queues and returns `PipelineStatus` format. Includes a placeholder fallback when Redis is unavailable.

## Key Files

- `packages/slack-bot/src/lib/core-api-client.ts` — `entities_list` and `entities_search` fixes
- `packages/core-api/src/routes/admin.ts` — new `GET /pipeline/health` route

## Test Plan

- [x] All 327 slack-bot unit tests pass
- [x] `core-api` TypeScript compiles clean (`tsc --noEmit`)
- [ ] Deploy to homeserver and verify `!entities` lists entities
- [ ] Verify `!entity <name>` returns entity detail
- [ ] Verify `!pipeline status` returns queue counts