### PR TITLE
fix: normalize web API client response field names to match Core API

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -38,9 +38,11 @@ function buildQueryString(params: Record<string, unknown>): string {
 // Captures API
 
 export const capturesApi = {
-  list: (params?: { limit?: number; offset?: number; source?: string; capture_type?: string; brain_view?: string }) => {
+  list: async (params?: { limit?: number; offset?: number; source?: string; capture_type?: string; brain_view?: string }) => {
     const qs = buildQueryString(params ?? {})
-    return request<{ data: Capture[]; total: number; limit: number; offset: number }>(`/captures${qs}`)
+    // API returns { items, total, limit, offset } — normalize to { data, total, limit, offset }
+    const raw = await request<{ items: Capture[]; total: number; limit: number; offset: number }>(`/captures${qs}`)
+    return { data: raw.items ?? [], total: raw.total, limit: raw.limit, offset: raw.offset }
   },
 
   get: (id: string) => {
@@ -77,9 +79,22 @@ export const searchApi = {
 // Entities API
 
 export const entitiesApi = {
-  list: (params?: { type?: string; sort?: string; limit?: number }) => {
+  list: async (params?: { type?: string; sort?: string; limit?: number }) => {
     const qs = buildQueryString(params ?? {})
-    return request<{ data: Entity[]; total: number }>(`/entities${qs}`)
+    // API returns { items, total } — normalize to { data, total }
+    // API uses entity_type (not type) and mention_count (not capture_count)
+    type RawEntity = Omit<Entity, 'type' | 'capture_count' | 'first_seen' | 'last_seen'> & {
+      entity_type: string; mention_count: number; first_seen_at?: string; last_seen_at?: string
+    }
+    const raw = await request<{ items: RawEntity[]; total: number }>(`/entities${qs}`)
+    const data = (raw.items ?? []).map(e => ({
+      ...e,
+      type: e.entity_type as Entity['type'],
+      capture_count: e.mention_count,
+      first_seen: e.first_seen_at ?? '',
+      last_seen: e.last_seen_at ?? '',
+    }))
+    return { data, total: raw.total }
   },
 
   get: (id: string) => {
@@ -144,8 +159,10 @@ export const skillsApi = {
 // Triggers API
 
 export const triggersApi = {
-  list: () => {
-    return request<{ data: Trigger[] }>('/triggers')
+  list: async () => {
+    // API returns { triggers: TriggerRecord[] } — normalize to { data: Trigger[] }
+    const raw = await request<{ triggers: Trigger[] }>('/triggers')
+    return { data: raw.triggers ?? [] }
   },
 
   get: (id: string) => {
@@ -177,7 +194,8 @@ export const triggersApi = {
 
 export const pipelineApi = {
   health: () => {
-    return request<PipelineHealth>('/pipeline/health')
+    // Endpoint is under /admin/pipeline/health
+    return request<PipelineHealth>('/admin/pipeline/health')
   },
 
   retry: (captureId: string) => {
@@ -190,9 +208,11 @@ export const pipelineApi = {
 // Bets API
 
 export const betsApi = {
-  list: (params?: { status?: string }) => {
+  list: async (params?: { status?: string }) => {
     const qs = buildQueryString(params ?? {})
-    return request<{ data: Bet[]; total: number }>(`/bets${qs}`)
+    // API returns { items, total } — normalize to { data, total }
+    const raw = await request<{ items: Bet[]; total: number }>(`/bets${qs}`)
+    return { data: raw.items ?? [], total: raw.total }
   },
 
   get: (id: string) => {


### PR DESCRIPTION
## Summary

- Dashboard was crashing with \`Cannot read properties of undefined (reading 'length')\` on load
- Root cause: Core API returns list payloads as \`{ items, total }\` but \`api.ts\` expected \`{ data, total }\` — \`capturesData.value.data\` was \`undefined\`, which broke \`recentCaptures.length\`
- Same pattern as the Slack bot field mapping fixes (PRs #14, #15)

## Fixes Applied

| API Method | Problem | Fix |
|---|---|---|
| \`capturesApi.list\` | Expected \`{ data }\`, got \`{ items }\` | Map \`items → data\` |
| \`entitiesApi.list\` | Expected \`{ data }\`, got \`{ items }\`; also \`entity_type\`, \`mention_count\`, \`first_seen_at\` field names | Map all fields to UI-expected names |
| \`triggersApi.list\` | Expected \`{ data }\`, got \`{ triggers }\` | Map \`triggers → data\` |
| \`betsApi.list\` | Expected \`{ data }\`, got \`{ items }\` | Map \`items → data\` |
| \`pipelineApi.health\` | Wrong path \`/pipeline/health\` | Fixed to \`/admin/pipeline/health\` |

## Key Files Modified

- \`packages/web/src/lib/api.ts\`

## Test Plan

- [x] Dashboard loads without crash
- [x] Recent captures render correctly
- [x] Pipeline health banner shows correct data
- [x] Entity list page renders
- [x] Bets/Triggers pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)