### PR TITLE
fix: normalize skillsApi response and correct trigger endpoint

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -125,8 +125,20 @@ export const entitiesApi = {
 // Skills API
 
 export const skillsApi = {
-  list: () => {
-    return request<{ data: Skill[] }>('/skills')
+  list: async () => {
+    // API returns { skills: [...] } — normalize to { data: Skill[] }
+    type RawSkill = { name: string; schedule: string | null; description: string | null; last_run_at: string | null; last_run_status?: string | null }
+    const raw = await request<{ skills: RawSkill[] }>('/skills')
+    const data: Skill[] = (raw.skills ?? []).map(s => ({
+      id: s.name,
+      name: s.name,
+      description: s.description ?? '',
+      enabled: true,
+      schedule: s.schedule ?? undefined,
+      last_run_at: s.last_run_at ?? undefined,
+      last_run_status: s.last_run_status ?? undefined,
+    }))
+    return { data }
   },
 
   run: (skillName: string, params?: Record<string, unknown>) => {
@@ -137,7 +149,7 @@ export const skillsApi = {
   },
 
   trigger: (skillName: string) => {
-    return request<{ job_id: string }>(`/skills/${skillName}/run`, {
+    return request<{ job_id: string }>(`/skills/${skillName}/trigger`, {
       method: 'POST',
       body: JSON.stringify({}),
     })


### PR DESCRIPTION
## Summary

- `skillsApi.list()`: Core API returns `{ skills: [...] }` not `{ data: Skill[] }`. Without normalization, `res.data` was `undefined`, which got set as the `skills` state, causing `skills.length` to throw and the Settings page to render as a blank white screen.
- `skillsApi.trigger()`: Was POSTing to `/skills/:name/run` (404); corrected to `/skills/:name/trigger`.
- Maps API fields (`name`, `schedule`, `last_run_at`, `description`) to the `Skill` interface shape expected by the Settings page components.

## Key files modified
- `packages/web/src/lib/api.ts` — `skillsApi.list` and `skillsApi.trigger`

## Testing
Settings page at brain.troy-davis.com/settings now renders the System Health, Skills, and Triggers sections correctly instead of a blank white screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)