### PR TITLE
fix: correct weekly-brief skill name and add skills logs route

### DIFF
--- a/packages/core-api/src/routes/skills.ts
+++ b/packages/core-api/src/routes/skills.ts
@@ -163,4 +163,52 @@ export function registerSkillRoutes(
       202,
     )
   })
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/skills/:name/logs
+  // Returns the most recent skills_log entries for a given skill.
+  // Used by the Briefs page to display run history.
+  // -----------------------------------------------------------------------
+  app.get('/api/v1/skills/:name/logs', async (c) => {
+    const name = c.req.param('name')
+    const limitParam = c.req.query('limit')
+    const limit = Math.min(parseInt(limitParam ?? '20', 10) || 20, 100)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await db.execute<any>(sql`
+      SELECT
+        id::text,
+        skill_name,
+        capture_id::text,
+        input_summary,
+        output_summary,
+        duration_ms,
+        created_at
+      FROM skills_log
+      WHERE skill_name = ${name}
+      ORDER BY created_at DESC
+      LIMIT ${limit}
+    `)
+
+    const data = (rows.rows as Array<{
+      id: string
+      skill_name: string
+      capture_id: string | null
+      input_summary: string | null
+      output_summary: string | null
+      duration_ms: number | null
+      created_at: Date | string
+    }>).map((row) => ({
+      id: row.id,
+      skill_name: row.skill_name,
+      capture_id: row.capture_id,
+      status: 'completed',
+      started_at: row.created_at,
+      completed_at: row.created_at,
+      duration_ms: row.duration_ms,
+      output: row.output_summary,
+    }))
+
+    return c.json({ data })
+  })
 }

--- a/packages/web/src/pages/Briefs.tsx
+++ b/packages/web/src/pages/Briefs.tsx
@@ -6,7 +6,7 @@ import { Separator } from '@/components/ui/separator';
 import { skillsApi } from '@/lib/api';
 import type { Skill, SkillLog } from '@/lib/types';
 
-const BRIEF_SKILL = 'weekly_brief';
+const BRIEF_SKILL = 'weekly-brief';
 
 interface BriefContent {
   headline?: string;


### PR DESCRIPTION
## Summary

- **`Briefs.tsx`**: `BRIEF_SKILL` constant was `'weekly_brief'` (underscore) — should be `'weekly-brief'` (hyphen). This caused the trigger button to return 400 (name fails `/^[a-z0-9-]+$/` validation) and the logs fetch to 404 (URL didn't match the route pattern).
- **`routes/skills.ts`**: Added `GET /api/v1/skills/:name/logs` endpoint that queries `skills_log` by `skill_name` and returns entries shaped as `{ data: SkillLog[] }`. This route was completely absent — every page load of the Briefs UI returned 404.

## Key files modified
- `packages/web/src/pages/Briefs.tsx` — one-line skill name fix
- `packages/core-api/src/routes/skills.ts` — new `/logs` route (48 lines)

## Notes
The `skills_log` table currently has no `result` JSONB column, so brief cards will show date/status/duration but not the structured content sections (wins, blockers, etc.). That requires a schema migration + worker update tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)