### PR TITLE
feat: add skill-execution BullMQ worker

### DIFF
--- a/packages/workers/src/jobs/skill-execution.ts
+++ b/packages/workers/src/jobs/skill-execution.ts
@@ -1,0 +1,91 @@
+import { Worker, UnrecoverableError } from 'bullmq'
+import type { ConnectionOptions } from 'bullmq'
+import type { Database } from '@open-brain/shared'
+import { logger } from '../lib/logger.js'
+import { executeWeeklyBrief } from '../skills/weekly-brief.js'
+import type { SkillExecutionJobData } from '../queues/skill-execution.js'
+
+/**
+ * BullMQ worker that consumes the `skill-execution` queue and dispatches
+ * to the appropriate skill implementation based on `job.data.skillName`.
+ *
+ * Each skill is responsible for its own error handling, logging to
+ * skills_log, and delivery (email/Pushover). This worker handles
+ * BullMQ lifecycle concerns: concurrency, retries, and fatal errors.
+ *
+ * Adding a new skill:
+ *  1. Implement the skill in src/skills/<skill-name>.ts
+ *  2. Add a case here in the switch statement
+ *  3. Register the skill name in core-api/src/routes/skills.ts KNOWN_SKILLS
+ */
+export function createSkillExecutionWorker(
+  connection: ConnectionOptions,
+  db: Database,
+  opts: {
+    litellmUrl: string
+    litellmApiKey: string
+    promptsDir: string
+    coreApiUrl: string
+  },
+): Worker {
+  const worker = new Worker<SkillExecutionJobData>(
+    'skill-execution',
+    async (job) => {
+      const { skillName, input } = job.data
+
+      logger.info({ skillName, jobId: job.id }, '[skill-execution] job received')
+
+      switch (skillName) {
+        case 'weekly-brief': {
+          const result = await executeWeeklyBrief(db, {
+            windowDays: typeof input?.windowDays === 'number' ? input.windowDays : undefined,
+            tokenBudget: typeof input?.tokenBudget === 'number' ? input.tokenBudget : undefined,
+            modelAlias: typeof input?.modelAlias === 'string' ? input.modelAlias : undefined,
+            emailTo: typeof input?.emailTo === 'string' ? input.emailTo : undefined,
+          })
+
+          logger.info(
+            { skillName, captureCount: result.captureCount, durationMs: result.durationMs },
+            '[skill-execution] weekly-brief complete',
+          )
+          break
+        }
+
+        case 'drift-monitor':
+        case 'daily-connections':
+        case 'pipeline-health': {
+          // These skills are defined in KNOWN_SKILLS for scheduling visibility
+          // but not yet implemented. Log and skip gracefully.
+          logger.warn({ skillName }, '[skill-execution] skill not yet implemented — skipping')
+          break
+        }
+
+        default: {
+          // Unknown skill names are unrecoverable — no point retrying.
+          throw new UnrecoverableError(`[skill-execution] unknown skill: ${skillName}`)
+        }
+      }
+    },
+    {
+      connection,
+      concurrency: 1, // Skills are LLM-heavy; run one at a time
+      limiter: {
+        max: 1,
+        duration: 5_000, // At most 1 skill job per 5 seconds
+      },
+    },
+  )
+
+  worker.on('completed', (job) => {
+    logger.info({ skillName: job.data.skillName, jobId: job.id }, '[skill-execution] job completed')
+  })
+
+  worker.on('failed', (job, err) => {
+    logger.error(
+      { skillName: job?.data.skillName, jobId: job?.id, err },
+      '[skill-execution] job failed',
+    )
+  })
+
+  return worker
+}

--- a/packages/workers/src/main.ts
+++ b/packages/workers/src/main.ts
@@ -16,6 +16,7 @@ import { createPushoverWorker } from './jobs/pushover.js'
 import { createEmailWorker } from './jobs/email.js'
 import { createAccessStatsWorker } from './jobs/update-access-stats.js'
 import { createBudgetCheckWorker } from './jobs/budget-check.js'
+import { createSkillExecutionWorker } from './jobs/skill-execution.js'
 import { registerScheduledJobs } from './scheduler.js'
 import { logger } from './lib/logger.js'
 import type { Worker } from 'bullmq'
@@ -78,6 +79,12 @@ async function main() {
     userKey: pushoverUserKey,
     litellmUrl,
     litellmApiKey,
+  }))
+  workers.push(createSkillExecutionWorker(connection, db, {
+    litellmUrl,
+    litellmApiKey,
+    promptsDir,
+    coreApiUrl: process.env.OPEN_BRAIN_API_URL ?? 'http://core-api:3000',
   }))
 
   logger.info({ count: workers.length }, 'All workers registered')


### PR DESCRIPTION
## Summary

The `skill-execution` BullMQ queue was fully wired on the producer side (Core API enqueues jobs via `POST /skills/:name/trigger`) but had **no consumer** — jobs accumulated in Redis indefinitely and skills never ran.

- **New file**: `packages/workers/src/jobs/skill-execution.ts`
  - `Worker` consuming the `skill-execution` queue
  - Dispatches to skill implementations by `skillName` via switch
  - `weekly-brief` → calls `executeWeeklyBrief()` with input overrides
  - `drift-monitor`, `daily-connections`, `pipeline-health` → warn + skip (stubs)
  - Unknown skill names → `UnrecoverableError` (no infinite retries)
  - Concurrency: 1 (LLM calls are expensive; one at a time)
- **Modified**: `packages/workers/src/main.ts` — registers `createSkillExecutionWorker` with litellmUrl, litellmApiKey, promptsDir, coreApiUrl from env

## Test plan
- [ ] Deploy workers container and verify it starts without error
- [ ] POST to `/api/v1/skills/weekly-brief/trigger` → job appears in `skill-execution` queue
- [ ] Worker picks up job, runs weekly-brief skill end to end
- [ ] `skills_log` row inserted; Briefs page shows run history

🤖 Generated with [Claude Code](https://claude.com/claude-code)