### PR TITLE
fix: resolve three audit items — MCP column bug, compose env vars, dead code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,15 @@ services:
       REDIS_URL: redis://redis:6379
       LITELLM_URL: https://llm.k4jda.net
       CORE_API_URL: http://core-api:3000
+      OPEN_BRAIN_API_URL: http://core-api:3000
       # LITELLM_API_KEY: set in .env.secrets
+      # PUSHOVER_APP_TOKEN: set in .env.secrets
+      # PUSHOVER_USER_KEY: set in .env.secrets
+      # SMTP_HOST: set in .env.secrets
+      # SMTP_PORT: set in .env.secrets (default 587)
+      # SMTP_USER: set in .env.secrets
+      # SMTP_PASS: set in .env.secrets
+      # SMTP_FROM: set in .env.secrets
     volumes:
       - ./config:/app/config:ro
     depends_on:

--- a/packages/core-api/src/mcp/tools/get-weekly-brief.ts
+++ b/packages/core-api/src/mcp/tools/get-weekly-brief.ts
@@ -22,7 +22,7 @@ export async function getWeeklyBriefTool(input: GetWeeklyBriefInput, db: Databas
     if (input.weeks_ago === 0) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await db.execute<any>(
-        sql`SELECT id::text, skill_name, output, created_at FROM skills_log WHERE skill_name = 'weekly-brief' ORDER BY created_at DESC LIMIT 1`,
+        sql`SELECT id::text, skill_name, output_summary AS output, created_at FROM skills_log WHERE skill_name = 'weekly-brief' ORDER BY created_at DESC LIMIT 1`,
       )
       rows = result.rows
     } else {
@@ -30,7 +30,7 @@ export async function getWeeklyBriefTool(input: GetWeeklyBriefInput, db: Databas
       const targetDate = new Date(Date.now() - input.weeks_ago * 7 * 24 * 60 * 60 * 1000)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await db.execute<any>(
-        sql`SELECT id::text, skill_name, output, created_at FROM skills_log WHERE skill_name = 'weekly-brief' AND created_at <= ${targetDate.toISOString()}::timestamptz ORDER BY created_at DESC LIMIT 1`,
+        sql`SELECT id::text, skill_name, output_summary AS output, created_at FROM skills_log WHERE skill_name = 'weekly-brief' AND created_at <= ${targetDate.toISOString()}::timestamptz ORDER BY created_at DESC LIMIT 1`,
       )
       rows = result.rows
     }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -141,13 +141,6 @@ export const skillsApi = {
     return { data }
   },
 
-  run: (skillName: string, params?: Record<string, unknown>) => {
-    return request<{ job_id: string }>(`/skills/${skillName}/run`, {
-      method: 'POST',
-      body: JSON.stringify(params ?? {}),
-    })
-  },
-
   trigger: (skillName: string) => {
     return request<{ job_id: string }>(`/skills/${skillName}/trigger`, {
       method: 'POST',


### PR DESCRIPTION
## Summary

- **MCP `get-weekly-brief` column bug (CRITICAL)**: Both SQL queries selected a non-existent `output` column from `skills_log`. The table has `output_summary`. Fixed with `output_summary AS output` alias — every MCP call to this tool was throwing a PostgreSQL error.
- **docker-compose.yml missing env vars (WARNING)**: Workers service was missing `OPEN_BRAIN_API_URL` (causing skill-execution worker to fall back to a hardcoded default), and had no comment stubs for `PUSHOVER_APP_TOKEN`, `PUSHOVER_USER_KEY`, and `SMTP_*` vars — operators had no visible hint to set these in `.env.secrets`, causing silent no-ops on all notifications and email delivery.
- **Dead `skillsApi.run()` method (WARNING)**: Was POSTing to `/skills/:name/run` which doesn't exist. The registered route is `/skills/:name/trigger`. Removed the dead method.

## Files Modified

- `packages/core-api/src/mcp/tools/get-weekly-brief.ts` — fix SQL column alias in both query branches
- `docker-compose.yml` — add `OPEN_BRAIN_API_URL`, add comment stubs for notification/email secrets
- `packages/web/src/lib/api.ts` — remove dead `skillsApi.run()` method

## Test Plan

- [ ] MCP `get-weekly-brief` tool no longer throws on DB query (verify via MCP client or direct API call)
- [ ] Workers container picks up `OPEN_BRAIN_API_URL=http://core-api:3000` from compose env
- [ ] No TypeScript compile errors from removing `run()` (no callers existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)