### PR TITLE
feat: implement POST /api/v1/synthesize endpoint

### DIFF
--- a/packages/core-api/src/app.ts
+++ b/packages/core-api/src/app.ts
@@ -16,6 +16,7 @@ import { registerBetRoutes } from './routes/bets.js'
 import { registerSessionRoutes } from './routes/sessions.js'
 import { registerEventsRoutes } from './routes/events.js'
 import { registerDocumentRoutes } from './routes/documents.js'
+import { registerSynthesizeRoutes } from './routes/synthesize.js'
 import { mountMcpServer } from './mcp/server.js'
 import type { CaptureService } from './services/capture.js'
 import type { SearchService } from './services/search.js'
@@ -25,6 +26,7 @@ import type { EntityService } from './services/entity.js'
 import type { BetService } from './services/bet.js'
 import type { SessionService } from './services/session.js'
 import type { GovernanceEngine } from './services/governance-engine.js'
+import type { LLMGatewayService } from './services/llm-gateway.js'
 
 interface AppDependencies {
   configService?: ConfigService
@@ -49,11 +51,13 @@ interface AppDependencies {
   governanceEngine?: GovernanceEngine
   /** Document pipeline queue — required for POST /api/v1/documents upload endpoint */
   documentPipelineQueue?: Queue
+  /** LLM Gateway — required for POST /api/v1/synthesize */
+  llmGateway?: LLMGatewayService
 }
 
 export function createApp(deps: AppDependencies = {}): Hono {
   const app = new Hono()
-  const { configService, captureService, searchService, pipelineService, db, redisConnection, skillQueue, triggerService, entityService, betService, sessionService, documentPipelineQueue } = deps
+  const { configService, captureService, searchService, pipelineService, db, redisConnection, skillQueue, triggerService, entityService, betService, sessionService, documentPipelineQueue, llmGateway } = deps
 
   // Global middleware
   app.use('*', honoLogger())
@@ -77,6 +81,11 @@ export function createApp(deps: AppDependencies = {}): Hono {
 
   if (searchService) {
     registerSearchRoutes(app, searchService)
+  }
+
+  // Synthesize API
+  if (searchService && llmGateway) {
+    registerSynthesizeRoutes(app, searchService, llmGateway)
   }
 
   // Skills API

--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -56,12 +56,13 @@ const entityService = new EntityService(db)
 const betService = new BetService(db)
 
 let governanceEngine: GovernanceEngine | undefined
+let llmGateway: InstanceType<typeof LLMGatewayService> | undefined
 if (litellmApiKey) {
-  const llmGateway = new LLMGatewayService(litellmUrl, litellmApiKey, configService, db, promptsDir)
+  llmGateway = new LLMGatewayService(litellmUrl, litellmApiKey, configService, db, promptsDir)
   governanceEngine = new GovernanceEngine(llmGateway, promptsDir)
   logger.info('GovernanceEngine initialized')
 } else {
-  logger.warn('LITELLM_API_KEY not set — GovernanceEngine disabled (session responds will use fallback)')
+  logger.warn('LITELLM_API_KEY not set — GovernanceEngine and synthesize endpoint disabled')
 }
 
 const sessionService = new SessionService(db, captureService, governanceEngine)
@@ -80,6 +81,7 @@ const app = createApp({
   sessionService,
   governanceEngine,
   documentPipelineQueue,
+  llmGateway,
 })
 const port = Number(process.env.PORT ?? 3000)
 

--- a/packages/core-api/src/routes/synthesize.ts
+++ b/packages/core-api/src/routes/synthesize.ts
@@ -1,0 +1,83 @@
+import type { Hono } from 'hono'
+import { z } from 'zod'
+import { zValidator } from '@hono/zod-validator'
+import type { SearchService } from '../services/search.js'
+import type { LLMGatewayService } from '../services/llm-gateway.js'
+import { logger } from '../lib/logger.js'
+
+const synthesizeBodySchema = z.object({
+  query: z.string().min(1, 'Query is required').max(2000),
+  limit: z.number().int().min(1).max(30).default(10),
+})
+
+/**
+ * Register the synthesize route.
+ *
+ * POST /api/v1/synthesize
+ * Body: { query: string, limit?: number }
+ *
+ * Runs a hybrid search over captures, then asks the LLM to synthesize a
+ * coherent answer grounded in those results. Falls back to FTS-only search
+ * if embedding is unavailable.
+ *
+ * Response: { response: string, capture_count: number }
+ */
+export function registerSynthesizeRoutes(
+  app: Hono,
+  searchService: SearchService,
+  llmGateway: LLMGatewayService,
+): void {
+  app.post('/api/v1/synthesize', zValidator('json', synthesizeBodySchema), async (c) => {
+    const { query, limit } = c.req.valid('json')
+
+    logger.info({ query: query.slice(0, 100), limit }, '[synthesize] request received')
+
+    // Step 1: retrieve relevant captures — try hybrid, fall back to FTS
+    let results
+    try {
+      results = await searchService.search(query, { limit, searchMode: 'hybrid' })
+    } catch {
+      // Embedding unavailable — fall back to FTS so the endpoint still works
+      logger.warn('[synthesize] embedding unavailable, falling back to FTS')
+      results = await searchService.search(query, { limit, searchMode: 'fts' })
+    }
+
+    if (results.length === 0) {
+      return c.json({
+        response: "I couldn't find any captures in your brain that are relevant to this query. Try capturing more notes first.",
+        capture_count: 0,
+      })
+    }
+
+    // Step 2: build context block from captures
+    const contextLines = results.map((r, i) => {
+      const date = new Date(r.capture.created_at).toLocaleDateString('en-US', {
+        month: 'short', day: 'numeric', year: 'numeric',
+      })
+      return `[${i + 1}] (${r.capture.capture_type}, ${r.capture.brain_view}, ${date})\n${r.capture.content}`
+    })
+    const context = contextLines.join('\n\n')
+
+    // Step 3: synthesize with LLM
+    const prompt = `You are a personal AI assistant with access to the user's knowledge base. Answer the user's question based ONLY on the captures below. Be concise and specific. If the captures do not contain enough information to answer confidently, say so.
+
+User question: ${query}
+
+Relevant captures from knowledge base:
+${context}
+
+Answer:`
+
+    const response = await llmGateway.complete(prompt, 'synthesis', {
+      maxTokens: 1024,
+      temperature: 0.2,
+    })
+
+    logger.info({ captureCount: results.length }, '[synthesize] complete')
+
+    return c.json({
+      response: response.trim(),
+      capture_count: results.length,
+    })
+  })
+}


### PR DESCRIPTION
## Summary

Implements the missing \`POST /api/v1/synthesize\` endpoint. The Slack bot's \`synthesize_query()\` has been calling this endpoint since the beginning — every \`!brain ask\` and \`!brain recall\` command was silently returning HTTP 404.

**Flow:**
1. Accepts \`{ query: string, limit?: number }\` (matches \`SynthesizePayload\` in Slack bot client)
2. Runs hybrid semantic + FTS search, falls back to FTS-only if embedding is unavailable
3. Builds a grounded context block from top N captures (with date, type, brain view)
4. Calls LiteLLM \`synthesis\` alias to generate a coherent, grounded answer
5. Returns \`{ response: string, capture_count: number }\`

**Wiring changes:**
- \`LLMGatewayService\` added to \`AppDependencies\` in \`app.ts\` (was not previously injectable)
- \`index.ts\` passes the already-instantiated \`llmGateway\` instance (same one used by GovernanceEngine — no extra instantiation)
- Route is only registered when both \`searchService\` and \`llmGateway\` are present — gracefully absent when \`LITELLM_API_KEY\` is not set

## Files Modified

- `packages/core-api/src/routes/synthesize.ts` *(new)* — route implementation
- `packages/core-api/src/app.ts` — add \`llmGateway\` to \`AppDependencies\`, register route
- `packages/core-api/src/index.ts` — extract \`llmGateway\` to outer scope, pass to \`createApp\`

## Test Plan

- [ ] \`POST /api/v1/synthesize\` with \`{ "query": "recent decisions" }\` returns \`{ response: "...", capture_count: N }\`
- [ ] Slack \`!brain ask <question>\` no longer returns 404
- [ ] With \`LITELLM_API_KEY\` unset, route is absent (no 500 — just 404 with a clear gap)
- [ ] TypeScript compiles clean: \`pnpm --filter @open-brain/core-api exec tsc --noEmit\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)