### PR TITLE
feat: add result JSONB column to skills_log for Briefs UI rendering

### DIFF
--- a/packages/core-api/src/routes/skills.ts
+++ b/packages/core-api/src/routes/skills.ts
@@ -182,6 +182,7 @@ export function registerSkillRoutes(
         capture_id::text,
         input_summary,
         output_summary,
+        result,
         duration_ms,
         created_at
       FROM skills_log
@@ -196,6 +197,7 @@ export function registerSkillRoutes(
       capture_id: string | null
       input_summary: string | null
       output_summary: string | null
+      result: Record<string, unknown> | null
       duration_ms: number | null
       created_at: Date | string
     }>).map((row) => ({
@@ -207,6 +209,7 @@ export function registerSkillRoutes(
       completed_at: row.created_at,
       duration_ms: row.duration_ms,
       output: row.output_summary,
+      result: row.result ?? null,
     }))
 
     return c.json({ data })

--- a/packages/shared/drizzle/0007_skills_log_result.sql
+++ b/packages/shared/drizzle/0007_skills_log_result.sql
@@ -1,0 +1,9 @@
+-- Migration: Add result JSONB column to skills_log
+-- Purpose: Store the structured AI output from each skill execution so the
+--          Briefs UI can render individual sections (wins, blockers, risks, etc.)
+--          without parsing the plain-text output_summary field.
+--
+-- The column is nullable — existing rows and skills that don't produce
+-- structured output are unaffected.
+
+ALTER TABLE skills_log ADD COLUMN IF NOT EXISTS result jsonb;

--- a/packages/shared/src/schema/supporting.ts
+++ b/packages/shared/src/schema/supporting.ts
@@ -159,6 +159,7 @@ export const skills_log = pgTable(
     session_id: uuid('session_id').references(() => sessions.id, { onDelete: 'set null' }),
     input_summary: text('input_summary'),
     output_summary: text('output_summary'),
+    result: jsonb('result'),
     duration_ms: integer('duration_ms'),
     created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/workers/src/skills/weekly-brief.ts
+++ b/packages/workers/src/skills/weekly-brief.ts
@@ -203,6 +203,7 @@ export class WeeklyBriefSkill {
       outputSummary: `headline: "${brief.headline}" | wins:${brief.wins.length} blockers:${brief.blockers.length} risks:${brief.risks.length} | email:${emailSent}`,
       durationMs,
       captureId: savedCaptureId ?? undefined,
+      result: brief,
     })
 
     logger.info({ captureCount, durationMs, savedCaptureId }, '[weekly-brief] execution complete')
@@ -648,6 +649,7 @@ export class WeeklyBriefSkill {
     outputSummary: string
     durationMs: number
     captureId?: string
+    result?: WeeklyBriefOutput
   }): Promise<void> {
     try {
       await this.db.insert(skills_log).values({
@@ -655,6 +657,7 @@ export class WeeklyBriefSkill {
         capture_id: params.captureId ?? null,
         input_summary: params.inputSummary,
         output_summary: params.outputSummary,
+        result: params.result ?? null,
         duration_ms: params.durationMs,
       })
     } catch (err) {


### PR DESCRIPTION
## Summary

The weekly brief AI output (headline, wins, blockers, risks, etc.) was being generated, delivered via email/Pushover, but never stored in structured form. The Briefs UI had \`SkillLog.result\` typed and \`parseBriefResult()\` wired — but the API was returning \`null\` for \`result\` so cards always collapsed with no content sections.

This closes the full pipeline: **LLM output → DB → API → UI**.

## What changed

| File | Change |
|------|--------|
| `packages/shared/drizzle/0007_skills_log_result.sql` | New migration: \`ALTER TABLE skills_log ADD COLUMN IF NOT EXISTS result jsonb\` |
| `packages/shared/src/schema/supporting.ts` | Add \`result: jsonb('result')\` to Drizzle \`skills_log\` table |
| `packages/workers/src/skills/weekly-brief.ts` | \`logToSkillsLog()\` now stores the parsed \`WeeklyBriefOutput\` as \`result\` |
| `packages/core-api/src/routes/skills.ts` | \`GET /api/v1/skills/:name/logs\` now selects and returns \`result\` |

## What did NOT need to change

- `packages/web/src/lib/types.ts` — \`SkillLog.result?: Record<string, unknown>\` was already correct
- `packages/web/src/pages/Briefs.tsx` — \`parseBriefResult(log.result)\` was already wired; it just had no data

## Migration

Must be applied on the server **before** deploying the new workers image:

```bash
docker exec open-brain-postgres psql -U openbrain openbrain -c \
  "ALTER TABLE skills_log ADD COLUMN IF NOT EXISTS result jsonb;"
```

The column is nullable — existing rows (and future skills that don't produce structured JSON) are unaffected.

## Test Plan

- [ ] Apply migration on homeserver
- [ ] Deploy updated images (workers + core-api)
- [ ] Trigger a weekly-brief run via "Run Now" on the Briefs page
- [ ] Verify the brief card expands and shows wins/blockers/risks sections
- [ ] Verify \`SELECT result FROM skills_log ORDER BY created_at DESC LIMIT 1\` returns the JSON object

🤖 Generated with [Claude Code](https://claude.com/claude-code)