### PR TITLE
feat: add data reset endpoint + Danger Zone UI on Settings page

### DIFF
--- a/packages/core-api/src/app.ts
+++ b/packages/core-api/src/app.ts
@@ -69,7 +69,7 @@ export function createApp(deps: AppDependencies = {}): Hono {
   registerEventsRoutes(app)
 
   if (configService) {
-    const adminRouter = createAdminRouter({ configService, redisConnection })
+    const adminRouter = createAdminRouter({ configService, redisConnection, db })
     app.route('/api/v1/admin', adminRouter)
   }
 

--- a/packages/core-api/src/routes/admin.ts
+++ b/packages/core-api/src/routes/admin.ts
@@ -5,7 +5,8 @@ import { BullMQAdapter } from '@bull-board/api/bullMQAdapter'
 import { HonoAdapter } from '@bull-board/hono'
 import { Queue } from 'bullmq'
 import type { ConnectionOptions } from 'bullmq'
-import type { ConfigService } from '@open-brain/shared'
+import { sql } from 'drizzle-orm'
+import type { ConfigService, Database } from '@open-brain/shared'
 import { logger } from '../lib/logger.js'
 
 /**
@@ -24,6 +25,8 @@ export interface AdminRouterOptions {
   configService: ConfigService
   /** Redis connection for Bull Board queue monitoring. Optional — if omitted, /queues returns a placeholder. */
   redisConnection?: ConnectionOptions
+  /** Database instance — required for POST /reset-data */
+  db?: Database
 }
 
 /**
@@ -36,7 +39,7 @@ export interface AdminRouterOptions {
  * Bull Board path: /api/v1/admin/queues
  * (app.ts mounts this router at /api/v1/admin)
  */
-export function createAdminRouter({ configService, redisConnection }: AdminRouterOptions): Hono {
+export function createAdminRouter({ configService, redisConnection, db }: AdminRouterOptions): Hono {
   const router = new Hono()
 
   // POST /config/reload — hot-reload YAML config files
@@ -50,6 +53,63 @@ export function createAdminRouter({ configService, redisConnection }: AdminRoute
       results,
       reloaded_at: new Date().toISOString(),
     }, allSuccess ? 200 : 207)
+  })
+
+  // POST /reset-data — truncate all user data tables, preserve schema + migration history
+  // Requires body: { confirm: "WIPE ALL DATA" }
+  // Preserves: triggers (user config), schema, __drizzle_migrations
+  router.post('/reset-data', async (c) => {
+    if (!db) {
+      return c.json({ error: 'Database not configured for reset endpoint' }, 503)
+    }
+
+    let body: Record<string, unknown> | null = null
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Request body must be JSON with { "confirm": "WIPE ALL DATA" }' }, 400)
+    }
+
+    if (!body || body.confirm !== 'WIPE ALL DATA') {
+      return c.json(
+        { error: 'Confirmation required. Send { "confirm": "WIPE ALL DATA" } in the request body.' },
+        400,
+      )
+    }
+
+    logger.warn('[admin] Data reset initiated — wiping all user data')
+
+    // Tables ordered to avoid FK constraint errors; CASCADE handles any remainder.
+    // Triggers are intentionally preserved (user configuration, not test data).
+    // __drizzle_migrations is a system table and is never touched.
+    await db.execute(sql`
+      TRUNCATE
+        skills_log,
+        ai_audit_log,
+        session_messages,
+        bets,
+        sessions,
+        entity_links,
+        entity_relationships,
+        entities,
+        pipeline_events,
+        captures
+      CASCADE
+    `)
+
+    const clearedTables = [
+      'captures', 'pipeline_events', 'entities', 'entity_links',
+      'entity_relationships', 'sessions', 'session_messages',
+      'bets', 'skills_log', 'ai_audit_log',
+    ]
+
+    logger.warn({ clearedTables }, '[admin] Data reset complete')
+
+    return c.json({
+      cleared: clearedTables,
+      preserved: ['triggers', '__drizzle_migrations', 'schema'],
+      wiped_at: new Date().toISOString(),
+    })
   })
 
   if (redisConnection) {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -195,6 +195,17 @@ export const triggersApi = {
   },
 }
 
+// Admin API
+
+export const adminApi = {
+  resetData: () => {
+    return request<{ cleared: string[]; preserved: string[]; wiped_at: string }>('/admin/reset-data', {
+      method: 'POST',
+      body: JSON.stringify({ confirm: 'WIPE ALL DATA' }),
+    })
+  },
+}
+
 // Pipeline API
 
 export const pipelineApi = {

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import { skillsApi, triggersApi, pipelineApi } from '@/lib/api';
+import { skillsApi, triggersApi, pipelineApi, adminApi } from '@/lib/api';
 import type { Skill, Trigger } from '@/lib/types';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -337,6 +337,143 @@ function TriggersSection({ triggers, loading, error, onAdd, onDelete }: {
   );
 }
 
+// ─── Danger Zone section ──────────────────────────────────────────────────────
+
+const CONFIRM_PHRASE = 'WIPE ALL DATA';
+
+function DangerZoneSection() {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [wiping, setWiping] = useState(false);
+  const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  const confirmed = confirmText === CONFIRM_PHRASE;
+
+  function handleOpen() {
+    setOpen(true);
+    setConfirmText('');
+    setResult(null);
+  }
+
+  function handleClose() {
+    setOpen(false);
+    setConfirmText('');
+  }
+
+  async function handleWipe() {
+    setWiping(true);
+    setResult(null);
+    try {
+      const res = await adminApi.resetData();
+      setResult({
+        success: true,
+        message: `Wiped ${res.cleared.length} tables. The brain is empty — ready for real data.`,
+      });
+      handleClose();
+    } catch (err) {
+      setResult({ success: false, message: err instanceof Error ? err.message : 'Wipe failed' });
+    } finally {
+      setWiping(false);
+    }
+  }
+
+  return (
+    <>
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold text-destructive">Danger Zone</h2>
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-3">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">Wipe All Data</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Permanently deletes all captures, entities, sessions, briefs, bets, and AI audit logs.
+                Schema, migration history, and semantic triggers are preserved. Cannot be undone.
+              </p>
+            </div>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleOpen}
+              className="shrink-0 gap-1.5"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Wipe All Data
+            </Button>
+          </div>
+          {result && (
+            <div className={`flex items-center gap-2 rounded px-3 py-2 text-sm border ${
+              result.success
+                ? 'bg-green-50 text-green-800 border-green-200'
+                : 'bg-destructive/10 text-destructive border-destructive/30'
+            }`}>
+              {result.success
+                ? <CheckCircle className="h-4 w-4 shrink-0" />
+                : <AlertCircle className="h-4 w-4 shrink-0" />}
+              {result.message}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Confirmation modal — rendered at root level to avoid layout clipping */}
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-background/80 backdrop-blur-sm">
+          <div className="bg-card border rounded-lg shadow-lg w-full max-w-md p-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-full bg-destructive/10 p-2 shrink-0">
+                <AlertCircle className="h-5 w-5 text-destructive" />
+              </div>
+              <h3 className="text-base font-semibold">Wipe All Data?</h3>
+            </div>
+
+            <p className="text-sm text-muted-foreground">The following will be <strong>permanently deleted</strong>:</p>
+            <ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
+              <li>All captures and embeddings</li>
+              <li>All entities and relationships</li>
+              <li>All governance sessions and messages</li>
+              <li>All weekly briefs (skills log)</li>
+              <li>All AI audit logs and bets</li>
+            </ul>
+            <p className="text-sm text-muted-foreground">
+              <strong>Preserved:</strong> semantic triggers, schema, migration history.
+            </p>
+
+            <div className="space-y-1.5">
+              <p className="text-xs font-medium">
+                Type{' '}
+                <span className="font-mono bg-muted px-1.5 py-0.5 rounded text-foreground">{CONFIRM_PHRASE}</span>
+                {' '}to confirm:
+              </p>
+              <Input
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={CONFIRM_PHRASE}
+                className="font-mono"
+                autoFocus
+                onKeyDown={(e) => e.key === 'Escape' && handleClose()}
+              />
+            </div>
+
+            <div className="flex gap-2 justify-end pt-1">
+              <Button variant="ghost" size="sm" onClick={handleClose} disabled={wiping}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={!confirmed || wiping}
+                onClick={handleWipe}
+              >
+                {wiping ? 'Wiping...' : 'Confirm Wipe'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
 // ─── Main page ────────────────────────────────────────────────────────────────
 
 export default function Settings() {
@@ -466,6 +603,10 @@ export default function Settings() {
         onAdd={handleAddTrigger}
         onDelete={handleDeleteTrigger}
       />
+
+      <Separator />
+
+      <DangerZoneSection />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a full-stack "Wipe All Data" capability for clearing test data and starting fresh. This is intentionally a high-friction operation — the backend validates a typed confirmation string and the UI requires the user to type `WIPE ALL DATA` before the button enables.

## Backend: `POST /api/v1/admin/reset-data`

- Validates request body must be exactly `{ "confirm": "WIPE ALL DATA" }`
- Runs a single TRUNCATE CASCADE across 10 user-data tables
- **Preserves:** triggers (user configuration), schema, `__drizzle_migrations`
- Returns `{ cleared: string[], preserved: string[], wiped_at: string }`
- \`db\` injected via updated \`AdminRouterOptions\` (no new instantiation)

Tables cleared:
\`captures\`, \`pipeline_events\`, \`entities\`, \`entity_links\`, \`entity_relationships\`, \`sessions\`, \`session_messages\`, \`bets\`, \`skills_log\`, \`ai_audit_log\`

## Frontend: Settings → Danger Zone

1. Red "Wipe All Data" button in a bordered danger section at the bottom of Settings
2. Modal overlay appears explaining exactly what will and won't be deleted
3. User must type `WIPE ALL DATA` (case-sensitive) — confirm button stays disabled until match
4. Escape key and Cancel close without action
5. Success/error feedback shown inline after modal closes

## Files Modified

| File | Change |
|------|--------|
| `packages/core-api/src/routes/admin.ts` | New `POST /reset-data` route; `db` added to `AdminRouterOptions` |
| `packages/core-api/src/app.ts` | Pass `db` to `createAdminRouter()` |
| `packages/web/src/lib/api.ts` | New `adminApi.resetData()` |
| `packages/web/src/pages/Settings.tsx` | New `DangerZoneSection` component + wire into page |

## Test Plan

- [ ] `POST /api/v1/admin/reset-data` with wrong confirm string → 400
- [ ] `POST /api/v1/admin/reset-data` with `{ "confirm": "WIPE ALL DATA" }` → 200 + table list
- [ ] Verify captures/entities/briefs are gone after reset; triggers remain
- [ ] Settings UI: button opens modal, confirm button disabled until text matches exactly
- [ ] Escape key closes modal without wiping
- [ ] Success message appears after wipe completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)