### PR TITLE
fix: Board Invalid Date, health version, regression cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,13 @@ After any non-trivial finding during deployment, testing, or debugging:
 - **`/health` is Docker-internal only** — nginx does not proxy `/health` externally. Use `/api/v1/captures?limit=1` for external health checks and tunnel verification.
 - **Slack `app_mention` events always route to `handleQuery`** — do not document @mention as a way to trigger captures or commands. Captures and `!commands` require plain channel messages routed through IntentRouter.
 - **`SLACK_SIGNING_SECRET` is not needed for Socket Mode** — signing secrets are for HTTP webhook verification only. Socket Mode only needs `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`.
+- **`CREATE TRIGGER` is not idempotent** — PostgreSQL has no `CREATE OR REPLACE TRIGGER`. Always add `DROP TRIGGER IF EXISTS <name> ON <table>;` before each `CREATE TRIGGER`. Affects `scripts/init-schema.sql` which is re-applied by integration tests.
+- **Drizzle ORM does not emit `AS` aliases for computed SELECT columns** — `sql<number>\`COUNT(...)\`` in a `.select({mention_count: sql\`...\`})` maps only to JS property names, not SQL aliases. `ORDER BY mention_count` fails with "column does not exist". Use the full expression in ORDER BY: `desc(sql\`COUNT(${entity_links.id})\`)`.
+- **Captures table has no `tsv` column** — FTS uses an expression-based GIN index on `to_tsvector('english', content)`. Inserts are immediately FTS-searchable. Do not try to update a `tsv` column.
+- **`POST /api/v1/captures` returns `{id, pipeline_status, created_at}` only** — not the full capture object. Use `GET /api/v1/captures/:id` for the full record.
+- **Integration tests must use `pnpm exec`, not `npx`** — `npx vitest` on the server pulls a different version that can't resolve TS configs. Use `pnpm --filter @open-brain/core-api exec vitest run --config vitest.config.integration.ts`.
+- **Integration test config filename is `vitest.config.integration.ts`** — not `vitest.integration.config.ts`. The word order matters.
+- **Integration tests need rate limit bypass** — all test helpers send `X-Open-Brain-Caller: integration-test` header. The rate limit middleware skips enforcement for this caller key. Without it, strict tier (20 req/min) exhausts during test runs.
 
 ---
 

--- a/packages/core-api/src/routes/bets.ts
+++ b/packages/core-api/src/routes/bets.ts
@@ -6,11 +6,12 @@ import { logger } from '../lib/logger.js'
 /**
  * Register bet tracking API routes.
  *
- * GET   /api/v1/bets          — list bets (optional ?status= filter, ?limit=, ?offset=)
- * POST  /api/v1/bets          — create a new bet
- * GET   /api/v1/bets/expiring — bets due within the next N days (default 7)
- * GET   /api/v1/bets/:id      — get a single bet
- * PATCH /api/v1/bets/:id      — resolve a bet (resolution + evidence)
+ * GET    /api/v1/bets          — list bets (optional ?status= filter, ?limit=, ?offset=)
+ * POST   /api/v1/bets          — create a new bet
+ * GET    /api/v1/bets/expiring — bets due within the next N days (default 7)
+ * GET    /api/v1/bets/:id      — get a single bet
+ * PATCH  /api/v1/bets/:id      — resolve a bet (resolution + evidence)
+ * DELETE /api/v1/bets/:id      — hard-delete a bet
  *
  * Valid resolution values: correct | incorrect | ambiguous
  * Valid status filter values: pending | correct | incorrect | ambiguous
@@ -167,5 +168,15 @@ export function registerBetRoutes(app: Hono, betService: BetService): void {
     logger.info({ betId: id, resolution }, '[bets-api] bet resolved')
 
     return c.json(updated)
+  })
+
+  // -------------------------------------------------------------------------
+  // DELETE /api/v1/bets/:id
+  // Hard-delete a bet (used for regression test cleanup).
+  // -------------------------------------------------------------------------
+  app.delete('/api/v1/bets/:id', async (c) => {
+    const id = c.req.param('id')
+    await betService.delete(id)
+    return c.body(null, 204)
   })
 }

--- a/packages/core-api/src/routes/health.ts
+++ b/packages/core-api/src/routes/health.ts
@@ -1,7 +1,18 @@
 import type { Hono } from 'hono'
 import { Pool } from 'pg'
 import { Redis } from 'ioredis'
+import { readFileSync } from 'node:fs'
 import { logger } from '../lib/logger.js'
+
+// Read version at startup — works in Docker where npm_package_version is unset
+const APP_VERSION = (() => {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'))
+    return pkg.version as string
+  } catch {
+    return process.env.npm_package_version ?? 'unknown'
+  }
+})()
 
 type ServiceStatus = 'healthy' | 'degraded' | 'unhealthy'
 
@@ -86,7 +97,7 @@ async function buildHealthResponse(): Promise<HealthResponse> {
       redis.status === 'unhealthy' || litellm.status === 'degraded' ? 'degraded' : 'healthy'
     ),
     timestamp: new Date().toISOString(),
-    version: process.env.npm_package_version,
+    version: APP_VERSION,
     uptime_s: Math.floor(process.uptime()),
     services: { postgres, redis, litellm },
   }

--- a/packages/core-api/src/services/bet.ts
+++ b/packages/core-api/src/services/bet.ts
@@ -195,6 +195,20 @@ export class BetService {
   }
 
   // --------------------------------------------------------------------------
+  // delete — hard-delete a bet by ID (used for regression test cleanup)
+  // --------------------------------------------------------------------------
+  async delete(id: string): Promise<void> {
+    const [deleted] = await this.db
+      .delete(bets)
+      .where(eq(bets.id, id))
+      .returning({ id: bets.id })
+
+    if (!deleted) {
+      throw new NotFoundError(`Bet not found: ${id}`)
+    }
+  }
+
+  // --------------------------------------------------------------------------
   // _captureResolution — private: insert a capture for the bet resolution.
   // Uses capture_type 'reflection' (outcome of a prediction fits reflection
   // better than decision). capture_type could be 'decision' for bets that

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -238,14 +238,17 @@ interface RawBetRecord {
   confidence: number
   domain: string | null
   resolution_date: string | null
-  resolution: 'correct' | 'incorrect' | 'ambiguous' | null
+  resolution: 'correct' | 'incorrect' | 'ambiguous' | 'pending' | null
   resolution_notes: string | null
   session_id: string | null
   created_at: string
   updated_at: string
 }
 
+const RESOLVED_VALUES = new Set(['correct', 'incorrect', 'ambiguous'])
+
 function mapRawBet(b: RawBetRecord): Bet {
+  const isResolved = b.resolution !== null && RESOLVED_VALUES.has(b.resolution)
   const status: Bet['status'] =
     b.resolution === 'correct' ? 'won' :
     b.resolution === 'incorrect' ? 'lost' :
@@ -261,7 +264,7 @@ function mapRawBet(b: RawBetRecord): Bet {
     status,
     outcome: b.resolution ?? undefined,
     created_at: b.created_at,
-    resolved_at: b.resolution ? b.updated_at : undefined,
+    resolved_at: isResolved ? b.updated_at : undefined,
   }
 }
 

--- a/packages/web/src/pages/Board.tsx
+++ b/packages/web/src/pages/Board.tsx
@@ -245,10 +245,11 @@ function BetRow({ bet, onResolve }: { bet: Bet; onResolve: (id: string, outcome:
 
   const dueDateStr = bet.resolution_date ?? bet.due_date;
   const dueDateObj = dueDateStr ? new Date(dueDateStr) : null;
-  const dueDate = dueDateObj
+  const isValidDate = dueDateObj !== null && !isNaN(dueDateObj.getTime());
+  const dueDate = isValidDate
     ? dueDateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-    : 'No due date';
-  const isPast = dueDateObj !== null && dueDateObj < new Date();
+    : null;
+  const isPast = isValidDate && dueDateObj < new Date();
 
   return (
     <div className="rounded-lg border bg-card px-4 py-3 space-y-2">
@@ -266,7 +267,7 @@ function BetRow({ bet, onResolve }: { bet: Bet; onResolve: (id: string, outcome:
 
       <div className="flex items-center gap-3 text-xs text-muted-foreground">
         <span className={isPast && isOpen ? 'text-destructive font-medium' : ''}>
-          {dueDate !== 'No due date' ? `Due ${dueDate}` : dueDate}{isPast && isOpen ? ' (overdue)' : ''}
+          {dueDate ? `Due ${dueDate}` : 'No due date'}{isPast && isOpen ? ' (overdue)' : ''}
         </span>
         {(bet.tags ?? []).length > 0 && (
           <span className="flex gap-1">

--- a/scripts/regression-test.mjs
+++ b/scripts/regression-test.mjs
@@ -966,18 +966,29 @@ if (RUN_SLACK) {
 section('13. Cleanup');
 
 {
-  let cleaned = 0;
+  let triggers = 0, sessions = 0, captures = 0, bets = 0;
   for (const id of cleanup.triggerIds) {
     const r = await DEL(`/api/v1/triggers/${id}`);
-    if (r.status === 200 || r.status === 204) cleaned++;
+    if (r.status === 200 || r.status === 204) triggers++;
   }
   // Complete any open sessions
   for (const id of cleanup.sessionIds) {
-    await POST(`/api/v1/sessions/${id}/complete`, {});
+    const r = await POST(`/api/v1/sessions/${id}/complete`, {});
+    if (r.status === 200) sessions++;
+  }
+  // Soft-delete test captures
+  for (const id of cleanup.captureIds) {
+    const r = await DEL(`/api/v1/captures/${id}`);
+    if (r.status === 204 || r.status === 200) captures++;
+  }
+  // Delete test bets
+  for (const id of cleanup.betIds) {
+    const r = await DEL(`/api/v1/bets/${id}`);
+    if (r.status === 204 || r.status === 200) bets++;
   }
   pass('TC-CLEANUP-001', `Cleanup complete`,
-    `${cleanup.triggerIds.length} triggers, ${cleanup.sessionIds.length} sessions, ` +
-    `${cleanup.betIds.length} bets (resolved in place), ${cleanup.captureIds.length} captures (kept as test data)`);
+    `${triggers}/${cleanup.triggerIds.length} triggers, ${sessions}/${cleanup.sessionIds.length} sessions, ` +
+    `${captures}/${cleanup.captureIds.length} captures, ${bets}/${cleanup.betIds.length} bets`);
 }
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **Board "Invalid Date" bug (P2)**: Bets with null `resolution_date` showed "Due Invalid Date" — added `isNaN` guard in Board.tsx. Also fixed `resolved_at` incorrectly showing on open bets because API returns `resolution: "pending"` (truthy string).
- **Health version blank (P3)**: Settings page showed empty Version because `npm_package_version` is unset in Docker. Now reads from `package.json` at startup.
- **Regression cleanup (P3)**: Test script now soft-deletes captures and hard-deletes bets instead of leaving them behind. Added `DELETE /api/v1/bets/:id` endpoint.
- **CLAUDE.md**: Synced verified operational rules from hardening session.

## Test plan
- [x] `tsc --noEmit` passes for core-api and web
- [x] 347 core-api unit tests pass
- [x] 32 web unit tests pass
- [ ] Deploy to homeserver and verify Board page shows "No due date" instead of "Invalid Date"
- [ ] Verify Settings page shows version "0.1.0"
- [ ] Run regression test to verify cleanup deletes captures and bets

🤖 Generated with [Claude Code](https://claude.com/claude-code)