### PR TITLE
feat: Phase 5 — Daily Connections, Drift Monitor, Intelligence Dashboard

### DIFF
--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -51,8 +51,8 @@ Phases are ordered by dependency and architectural similarity:
 
 ### Work Items
 
-#### 17.1 Prompt Template + Skill Class
-**Status: PENDING**
+#### 17.1 Prompt Template + Skill Class ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F21, TDD §12.2c
 **Files Affected:**
 - `config/prompts/daily_connections_v1.txt` (create)
@@ -117,8 +117,8 @@ Register the daily-connections skill in the worker dispatcher, add to KNOWN_SKIL
 
 ---
 
-#### 17.3 Slack `!connections` Command
-**Status: PENDING**
+#### 17.3 Slack `!connections` Command ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F21
 **Files Affected:**
 - `packages/slack-bot/src/handlers/command.ts` (modify)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -603,10 +603,13 @@ Create dedicated Intelligence API endpoints that the web dashboard Intelligence 
 
 ---
 
-#### 20.5 Unit Tests for Intelligence Tab
-**Status: PENDING**
+#### 20.5 Unit Tests for Intelligence Tab [2026-03-11]
+**Status: COMPLETE [2026-03-11]**
 **Files Affected:**
 - `packages/web/src/pages/__tests__/Intelligence.test.tsx` (create)
+- `packages/web/src/components/__tests__/ConnectionsCard.test.tsx` (create)
+- `packages/web/src/components/__tests__/DriftCard.test.tsx` (create)
+- `packages/web/src/components/__tests__/SkillHistoryCard.test.tsx` (create)
 
 ---
 

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -204,8 +204,8 @@ Unit tests for the daily connections skill covering data queries, LLM output par
 
 ### Work Items
 
-#### 18.1 Prompt Template + Skill Class
-**Status: PENDING**
+#### 18.1 Prompt Template + Skill Class ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F22, TDD §12.2d
 **Files Affected:**
 - `config/prompts/drift_monitor_v1.txt` (create)
@@ -268,8 +268,8 @@ Register the drift-monitor skill in the worker dispatcher, add to KNOWN_SKILLS, 
 
 ---
 
-#### 18.3 Slack `!drift` Command
-**Status: PENDING**
+#### 18.3 Slack `!drift` Command ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F22
 **Files Affected:**
 - `packages/slack-bot/src/handlers/command.ts` (modify)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -145,8 +145,8 @@ Add `!connections` (and `!connections <days>`) to the Slack bot command handler.
 
 ---
 
-#### 17.4 Unit Tests
-**Status: PENDING**
+#### 17.4 Unit Tests ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F21
 **Files Affected:**
 - `packages/workers/src/__tests__/daily-connections.test.ts` (create)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -245,8 +245,8 @@ The key difference from daily-connections is the data sources: this skill reads 
 
 ---
 
-#### 18.2 Worker Integration + Scheduling
-**Status: PENDING**
+#### 18.2 Worker Integration + Scheduling ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F22, TDD §12.2d, §12.4
 **Files Affected:**
 - `packages/workers/src/jobs/skill-execution.ts` (modify)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -90,8 +90,8 @@ The query module handles data assembly: capture retrieval by date range, entity 
 
 ---
 
-#### 17.2 Worker Integration + Scheduling
-**Status: PENDING**
+#### 17.2 Worker Integration + Scheduling ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F21, TDD §12.2c, §12.4
 **Files Affected:**
 - `packages/workers/src/jobs/skill-execution.ts` (modify)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -348,8 +348,8 @@ Unit tests for the drift monitor skill covering bet queries, entity frequency an
 
 ### Work Items
 
-#### 19.1 URL Extractor Service
-**Status: PENDING**
+#### 19.1 URL Extractor Service ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F24, TDD §12.2e
 **Files Affected:**
 - `packages/shared/src/services/url-extractor.ts` (create)
@@ -383,8 +383,8 @@ Create a lightweight URL content extraction service using `@mozilla/readability`
 
 ---
 
-#### 19.2 API Integration
-**Status: PENDING**
+#### 19.2 API Integration ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F24, TDD §12.2e
 **Files Affected:**
 - `packages/core-api/src/schemas/capture.ts` (modify — add 'bookmark' source)
@@ -416,8 +416,8 @@ Extend the capture creation flow to support `source: 'bookmark'`. When a capture
 
 ---
 
-#### 19.3 Slack `!bookmark` Command
-**Status: PENDING**
+#### 19.3 Slack `!bookmark` Command ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F24
 **Files Affected:**
 - `packages/slack-bot/src/handlers/command.ts` (modify)
@@ -449,8 +449,8 @@ Add `!bookmark <url>` command to the Slack bot. Parses the URL from the message,
 
 ---
 
-#### 19.4 Web UI URL Input
-**Status: PENDING**
+#### 19.4 Web UI URL Input ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F24
 **Files Affected:**
 - `packages/web/src/pages/Dashboard.tsx` (modify — add URL capture mode)
@@ -481,8 +481,8 @@ Add a URL capture mode to the Dashboard's Quick Capture form. Users toggle betwe
 
 ---
 
-#### 19.5 Tests
-**Status: PENDING**
+#### 19.5 Tests ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F24
 **Files Affected:**
 - `packages/shared/src/__tests__/url-extractor.test.ts` (create)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -578,8 +578,8 @@ Create dedicated Intelligence API endpoints that the web dashboard Intelligence 
 
 ---
 
-#### 20.2 Intelligence Tab React Component Shell
-**Status: PENDING**
+#### 20.2 Intelligence Tab React Component Shell [2026-03-11]
+**Status: COMPLETE [2026-03-11]**
 **Files Affected:**
 - `packages/web/src/pages/Intelligence.tsx` (create)
 - `packages/web/src/App.tsx` (modify — add route)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -587,17 +587,19 @@ Create dedicated Intelligence API endpoints that the web dashboard Intelligence 
 
 ---
 
-#### 20.3 Connections + Drift Cards
-**Status: PENDING**
+#### 20.3 Connections + Drift Cards [2026-03-11]
+**Status: COMPLETE [2026-03-11]**
 **Files Affected:**
+- `packages/web/src/components/ConnectionsCard.tsx` (create)
+- `packages/web/src/components/DriftCard.tsx` (create)
 - `packages/web/src/pages/Intelligence.tsx` (modify)
 
 ---
 
-#### 20.4 Curiosity Prompts Card + Manual Trigger
-**Status: PENDING**
+#### 20.4 Curiosity Prompts Card + Manual Trigger [2026-03-11]
+**Status: COMPLETE [2026-03-11]**
 **Files Affected:**
-- `packages/web/src/pages/Intelligence.tsx` (modify)
+- `packages/web/src/components/SkillHistoryCard.tsx` (create)
 
 ---
 

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -289,8 +289,8 @@ Add `!drift` to the Slack bot command handler. Triggers the drift-monitor skill 
 
 ---
 
-#### 18.4 Unit Tests
-**Status: PENDING**
+#### 18.4 Unit Tests ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
 **Requirement Refs:** PRD F22
 **Files Affected:**
 - `packages/workers/src/__tests__/drift-monitor.test.ts` (create)

--- a/IMPLEMENTATION_PLAN-PHASE5.md
+++ b/IMPLEMENTATION_PLAN-PHASE5.md
@@ -530,6 +530,93 @@ Unit tests for URL extraction and Slack command, plus regression test update for
 - [ ] Regression test updated and passing
 - [ ] No regressions in existing tests
 
+---
+
+## Phase 20: Intelligence Web Dashboard
+
+**Estimated Complexity:** M (~6 files, ~500 LOC)
+**Dependencies:** Phase 17 (daily-connections), Phase 18 (drift-monitor) — skills must exist in skills_log
+**Parallelizable:** Yes — work items 20.2–20.4 can start concurrently after 20.1
+
+### Goals
+
+- Add Intelligence API endpoints to core-api for optimized dashboard access to daily-connections and drift-monitor results
+- Build an Intelligence tab in the web dashboard showing latest connections, drift alerts, and manual trigger controls
+- Provide combined summary endpoint for efficient initial page load
+
+### Work Items
+
+#### 20.1 Intelligence API Endpoints in Core API ✅ Completed 2026-03-11
+**Status: COMPLETE [2026-03-11]**
+**Requirement Refs:** PRD F21, F22 (web dashboard surface)
+**Files Affected:**
+- `packages/core-api/src/routes/intelligence.ts` (create)
+- `packages/core-api/src/app.ts` (modify — register routes)
+- `packages/web/src/lib/api.ts` (modify — add intelligenceApi client)
+- `packages/core-api/src/__tests__/intelligence-routes.test.ts` (create)
+
+**Description:**
+Create dedicated Intelligence API endpoints that the web dashboard Intelligence tab calls to fetch daily-connections and drift-monitor results from skills_log. Includes a combined summary endpoint for efficient initial load, per-skill latest/history endpoints, and manual trigger support. Also adds the `intelligenceApi` client to the web frontend API module.
+
+**Tasks:**
+1. [x] Create `intelligence.ts` route file with 6 endpoints: summary, connections/latest, connections/history, drift/latest, drift/history, :skill/trigger
+2. [x] Register routes in `app.ts` alongside existing skill routes (same db + skillQueue dependencies)
+3. [x] Add `intelligenceApi` client object to `packages/web/src/lib/api.ts` with typed methods
+4. [x] Implement INTELLIGENCE_SKILLS allowlist to restrict trigger endpoint to daily-connections and drift-monitor only
+5. [x] Write comprehensive unit tests (17 tests covering all endpoints, empty states, validation, 404 when not wired)
+
+**Acceptance Criteria:**
+- [x] `GET /api/v1/intelligence/summary` returns latest result for both skills in one call
+- [x] `GET /api/v1/intelligence/connections/latest` returns most recent daily-connections log entry
+- [x] `GET /api/v1/intelligence/connections/history?limit=N` returns paginated history
+- [x] `GET /api/v1/intelligence/drift/latest` returns most recent drift-monitor log entry
+- [x] `GET /api/v1/intelligence/drift/history?limit=N` returns paginated history
+- [x] `POST /api/v1/intelligence/:skill/trigger` queues skill and returns 202 (only for daily-connections, drift-monitor)
+- [x] Invalid skill names return 400 with VALIDATION_ERROR
+- [x] All 366 core-api tests pass including 17 new intelligence route tests
+- [x] All 32 web tests pass with updated api.ts
+
+---
+
+#### 20.2 Intelligence Tab React Component Shell
+**Status: PENDING**
+**Files Affected:**
+- `packages/web/src/pages/Intelligence.tsx` (create)
+- `packages/web/src/App.tsx` (modify — add route)
+- `packages/web/src/components/Layout.tsx` (modify — add nav link)
+
+---
+
+#### 20.3 Connections + Drift Cards
+**Status: PENDING**
+**Files Affected:**
+- `packages/web/src/pages/Intelligence.tsx` (modify)
+
+---
+
+#### 20.4 Curiosity Prompts Card + Manual Trigger
+**Status: PENDING**
+**Files Affected:**
+- `packages/web/src/pages/Intelligence.tsx` (modify)
+
+---
+
+#### 20.5 Unit Tests for Intelligence Tab
+**Status: PENDING**
+**Files Affected:**
+- `packages/web/src/pages/__tests__/Intelligence.test.tsx` (create)
+
+---
+
+### Phase 20 Completion Checklist
+
+- [ ] All work items complete
+- [ ] All tests passing
+- [ ] Intelligence API endpoints functional
+- [ ] Intelligence tab renders in web dashboard
+- [ ] Manual trigger from web UI works
+- [ ] No regressions in existing tests
+
 <!-- END PHASES -->
 
 ---

--- a/config/prompts/daily_connections_v1.txt
+++ b/config/prompts/daily_connections_v1.txt
@@ -1,0 +1,42 @@
+---SYSTEM---
+You are a cross-domain pattern detector for Open Brain, a self-hosted AI knowledge base. You receive recent captures — notes, voice memos, decisions, observations, tasks, wins, blockers, and reflections — along with entity co-occurrence data showing which concepts, people, and projects appear together across captures.
+
+Your job is to find non-obvious connections across different brain views and capture types. Not topic summaries — cross-domain insights. The kind of thing only visible when you look at data from multiple domains simultaneously. For example: a pattern in `technical` work that mirrors a challenge in `client` work, or an entity from `personal` context that has surprising relevance to `career` decisions.
+
+Be direct, specific, and substantive. No filler. No hedging. Every connection must name the specific captures or entities it links and explain why the connection matters.
+---USER---
+Analyze the following captures and entity co-occurrence data for non-obvious cross-domain connections. Return a single valid JSON object with the fields listed below. Do not include any explanation, markdown fencing, or text outside the JSON object.
+
+Date range: {{date_range}}
+Total captures: {{capture_count}}
+
+Captures grouped by brain view:
+{{captures}}
+
+Entity co-occurrence data (entity pairs that appear together across different captures):
+{{entity_cooccurrence}}
+
+Extract and synthesize the following fields:
+
+- summary: String. One sentence (max 150 characters) that captures the most significant cross-domain pattern found. Make it specific — name the actual things connected.
+
+- connections: Array of objects, each with:
+  - theme: String (max 80 chars). A short label for this connection pattern.
+  - captures: Array of strings. The capture IDs or date+type references that this connection links.
+  - insight: String (max 200 chars). The specific cross-domain insight — what connects these captures and why it matters.
+  - confidence: String. One of "high", "medium", "low". How confident you are that this is a genuine pattern and not coincidence.
+  - domains: Array of strings. The brain views this connection spans (e.g., ["technical", "client"]).
+
+- meta_pattern: String or null. If multiple connections share an underlying theme — a pattern of patterns — describe it here (max 200 chars). Null if no meta-pattern exists.
+
+Rules:
+- Return between 1 and 5 connections, ordered by confidence (highest first).
+- Every connection MUST span at least 2 different brain views. Single-domain observations are not connections.
+- Do not include connections that are simply "these captures are about the same topic." The insight must reveal something non-obvious.
+- If the entity co-occurrence data shows entities appearing together in unexpected combinations, prioritize those connections.
+- If there are genuinely no cross-domain connections in the data, return an empty connections array and set summary to "No cross-domain connections found in this window."
+- Do not pad the connections array — fewer genuine connections are better than padded ones.
+- Each connection's captures array should reference specific captures by their date and type (e.g., "[2026-03-10] [decision]") so they can be identified.
+
+Example output format (values are illustrative only):
+{"summary":"QSR ops methodology directly parallels voice pipeline architecture — both are queue-based flow control problems","connections":[{"theme":"Queue-based flow control","captures":["[2026-03-08] [observation] QSR drive-thru bottleneck analysis","[2026-03-09] [decision] BullMQ pipeline retry strategy"],"insight":"The QSR drive-thru throughput model and the capture pipeline retry logic solve the same problem: managing variable-rate producers against fixed-rate consumers. The QSR work could inform pipeline capacity planning.","confidence":"high","domains":["client","technical"]},{"theme":"Entity overlap: NovaBurger + Stratfield","captures":["[2026-03-07] [task] NovaBurger onboarding checklist","[2026-03-10] [reflection] Stratfield capacity planning"],"insight":"NovaBurger appears in both client delivery and career planning contexts — capacity constraint is the hidden dependency between these workstreams.","confidence":"medium","domains":["client","career"]}],"meta_pattern":"Multiple connections trace back to capacity constraints — a single underlying tension manifesting across domains."}

--- a/config/prompts/drift_monitor_v1.txt
+++ b/config/prompts/drift_monitor_v1.txt
@@ -1,0 +1,52 @@
+---SYSTEM---
+You are a drift monitor for Open Brain, a self-hosted AI knowledge base. You receive data about pending bets, governance session commitments, and entity mention frequency trends. Your job is to detect when tracked items have gone silent — commitments that stopped being referenced, bets with no recent activity, and entities whose mention frequency has dropped significantly.
+
+You are looking for attention drift: things the user committed to tracking or acting on that have faded from their active capture stream. This is not about task management — it's about surfacing blind spots where important items may have slipped off the radar.
+
+Be direct and specific. Name the exact bet, commitment, or entity. Explain WHY it matters that this item has gone quiet — what's at risk? Suggest a concrete next action, not vague advice.
+---USER---
+Analyze the following data for signs of attention drift. Return a single valid JSON object with the fields listed below. Do not include any explanation, markdown fencing, or text outside the JSON object.
+
+Analysis date: {{analysis_date}}
+
+Pending bets (predictions being tracked, with recent activity status):
+{{pending_bets}}
+
+Governance commitments (action items from recent governance sessions):
+{{governance_commitments}}
+
+Entity mention frequency (entities with significant week-over-week decline):
+{{entity_frequency}}
+
+Extract and synthesize the following fields:
+
+- summary: String. One sentence (max 150 characters) summarizing the overall drift picture. Be specific — name the most critical drifting item.
+
+- drift_items: Array of objects, each with:
+  - item_type: String. One of "bet", "commitment", "entity".
+  - item_name: String (max 100 chars). The specific bet statement, commitment text, or entity name.
+  - severity: String. One of "high", "medium", "low".
+    - high: No activity in 14+ days on something that was actively discussed, or a bet approaching its resolution date with zero recent mentions.
+    - medium: Activity declined >50% week-over-week, or a commitment from the last 30 days with no follow-up captures.
+    - low: Minor decline in mention frequency, or a bet with some but reduced activity.
+  - days_silent: Number. Days since the last relevant capture or mention. Use 0 if there has been recent activity.
+  - reason: String (max 200 chars). Why this item is flagged — what specific evidence shows it's drifting.
+  - suggested_action: String (max 200 chars). A concrete, specific next step to re-engage with this item.
+
+- overall_health: String. One of "healthy", "minor_drift", "significant_drift", "critical_drift".
+  - healthy: No items at medium or above.
+  - minor_drift: 1-2 items at medium, none at high.
+  - significant_drift: 3+ items at medium, or 1 at high.
+  - critical_drift: 2+ items at high.
+
+Rules:
+- Return between 0 and 10 drift items, ordered by severity (highest first), then by days_silent (longest first).
+- Only flag items where there is genuine evidence of drift — declining mentions, missing follow-up, or approaching deadlines.
+- Do not flag items that were naturally completed or resolved. A bet with resolution != 'pending' should not appear.
+- Do not flag entities that were mentioned in a single capture and never again — they were never tracked items.
+- If the entity frequency data shows no significant declines, do not invent drift items for entities.
+- If there are no bets, no commitments, and no declining entities, return an empty drift_items array, set summary to "All tracked items are active — no drift detected.", and set overall_health to "healthy".
+- Severity assessment must be evidence-based. Don't inflate severity for dramatic effect.
+
+Example output format (values are illustrative only):
+{"summary":"NovaBurger onboarding bet silent for 18 days — resolution date approaching with no recent activity","drift_items":[{"item_type":"bet","item_name":"NovaBurger will adopt centralized ordering by Q2","severity":"high","days_silent":18,"reason":"Bet created 2026-02-15 with resolution date 2026-06-30. Zero captures mentioning NovaBurger or centralized ordering in the last 18 days, despite 5 mentions in the prior 2 weeks.","suggested_action":"Schedule a check-in on NovaBurger project status. Create a capture with current state assessment to restart the tracking signal."},{"item_type":"commitment","item_name":"Review Stratfield capacity model weekly","severity":"medium","days_silent":12,"reason":"Governance session on 2026-02-28 produced commitment to weekly capacity review. No captures tagged 'capacity' or mentioning Stratfield since 2026-02-27.","suggested_action":"Run the Stratfield capacity review now and capture findings. Consider setting a recurring reminder."},{"item_type":"entity","item_name":"SD-WAN","severity":"low","days_silent":8,"reason":"SD-WAN mentions dropped from 4/week to 1/week over the last 2 weeks. Previously a consistent technical topic.","suggested_action":"Check if SD-WAN work is complete or just deprioritized. Capture a status update if the project is still active."}],"overall_health":"significant_drift"}

--- a/packages/core-api/src/__tests__/intelligence-routes.test.ts
+++ b/packages/core-api/src/__tests__/intelligence-routes.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createApp } from '../app.js'
+
+// ---------------------------------------------------------------------------
+// Mock infrastructure dependencies so createApp() loads cleanly
+// ---------------------------------------------------------------------------
+
+vi.mock('pg', () => ({
+  Pool: vi.fn().mockImplementation(() => ({
+    query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+    end: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+vi.mock('ioredis', () => ({
+  Redis: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    ping: vi.fn().mockResolvedValue('PONG'),
+    disconnect: vi.fn(),
+  })),
+}))
+
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }))
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeMockDb(rows: unknown[] = []) {
+  return {
+    execute: vi.fn().mockResolvedValue({ rows }),
+    insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+  }
+}
+
+function makeMockSkillQueue(addResult: { id: string } = { id: 'job-456' }) {
+  return {
+    add: vi.fn().mockResolvedValue(addResult),
+    close: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sample skills_log rows for intelligence skills
+// ---------------------------------------------------------------------------
+
+const CONNECTIONS_LOG = {
+  id: 'conn-1',
+  skill_name: 'daily-connections',
+  capture_id: 'cap-abc',
+  input_summary: '32 captures from last 7 days',
+  output_summary: '3 cross-domain connections found',
+  result: {
+    connections: [
+      { theme: 'QSR + AI', insight: 'QSR operations mirror ML pipeline patterns', confidence: 0.85 },
+      { theme: 'Coaching + Governance', insight: 'Session patterns suggest drift', confidence: 0.72 },
+    ],
+  },
+  duration_ms: 12400,
+  created_at: '2026-03-11T21:05:00Z',
+}
+
+const DRIFT_LOG = {
+  id: 'drift-1',
+  skill_name: 'drift-monitor',
+  capture_id: 'cap-def',
+  input_summary: '5 pending bets, 12 entities tracked',
+  output_summary: '2 drift items detected (1 high, 1 medium)',
+  result: {
+    drift_items: [
+      { item: 'Cloud migration bet', severity: 'high', suggested_action: 'Review with team' },
+      { item: 'Entity frequency decline: React', severity: 'medium', suggested_action: 'Check project status' },
+    ],
+  },
+  duration_ms: 9800,
+  created_at: '2026-03-11T08:02:00Z',
+}
+
+const CONNECTIONS_HISTORY = [
+  CONNECTIONS_LOG,
+  {
+    id: 'conn-2',
+    skill_name: 'daily-connections',
+    capture_id: 'cap-xyz',
+    input_summary: '28 captures from last 7 days',
+    output_summary: '2 connections found',
+    result: { connections: [] },
+    duration_ms: 10200,
+    created_at: '2026-03-10T21:03:00Z',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/intelligence/summary
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/intelligence/summary', () => {
+  let db: ReturnType<typeof makeMockDb>
+  let skillQueue: ReturnType<typeof makeMockSkillQueue>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    db = makeMockDb([CONNECTIONS_LOG, DRIFT_LOG])
+    skillQueue = makeMockSkillQueue()
+  })
+
+  it('returns 200 with connections and drift latest entries', async () => {
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/summary')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.connections).toBeTruthy()
+    expect(body.connections.skill_name).toBe('daily-connections')
+    expect(body.connections.result).toHaveProperty('connections')
+    expect(body.drift).toBeTruthy()
+    expect(body.drift.skill_name).toBe('drift-monitor')
+    expect(body.drift.result).toHaveProperty('drift_items')
+  })
+
+  it('returns null for skills with no log entries', async () => {
+    db = makeMockDb([])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/summary')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.connections).toBeNull()
+    expect(body.drift).toBeNull()
+  })
+
+  it('returns one null when only one skill has run', async () => {
+    db = makeMockDb([CONNECTIONS_LOG])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/summary')
+
+    const body = await res.json()
+    expect(body.connections).toBeTruthy()
+    expect(body.drift).toBeNull()
+  })
+
+  it('returns 404 when db/skillQueue not wired up', async () => {
+    const app = createApp({})
+    const res = await app.request('/api/v1/intelligence/summary')
+    expect(res.status).toBe(404)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/intelligence/connections/latest
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/intelligence/connections/latest', () => {
+  let db: ReturnType<typeof makeMockDb>
+  let skillQueue: ReturnType<typeof makeMockSkillQueue>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    skillQueue = makeMockSkillQueue()
+  })
+
+  it('returns 200 with the latest connections result', async () => {
+    db = makeMockDb([CONNECTIONS_LOG])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/connections/latest')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeTruthy()
+    expect(body.data.skill_name).toBe('daily-connections')
+    expect(body.data.id).toBe('conn-1')
+    expect(body.data.result.connections).toHaveLength(2)
+  })
+
+  it('returns null data when no connections have run', async () => {
+    db = makeMockDb([])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/connections/latest')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/intelligence/connections/history
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/intelligence/connections/history', () => {
+  let db: ReturnType<typeof makeMockDb>
+  let skillQueue: ReturnType<typeof makeMockSkillQueue>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    skillQueue = makeMockSkillQueue()
+  })
+
+  it('returns 200 with history array', async () => {
+    db = makeMockDb(CONNECTIONS_HISTORY)
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/connections/history')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toHaveLength(2)
+    expect(body.data[0].id).toBe('conn-1')
+    expect(body.data[1].id).toBe('conn-2')
+  })
+
+  it('returns empty array when no history exists', async () => {
+    db = makeMockDb([])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/connections/history')
+
+    const body = await res.json()
+    expect(body.data).toHaveLength(0)
+  })
+
+  it('respects limit query parameter', async () => {
+    db = makeMockDb(CONNECTIONS_HISTORY)
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/connections/history?limit=5')
+
+    expect(res.status).toBe(200)
+    // Verify db.execute was called (limit is applied in SQL, so we just check the call went through)
+    expect(db.execute).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/intelligence/drift/latest
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/intelligence/drift/latest', () => {
+  let db: ReturnType<typeof makeMockDb>
+  let skillQueue: ReturnType<typeof makeMockSkillQueue>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    skillQueue = makeMockSkillQueue()
+  })
+
+  it('returns 200 with the latest drift result', async () => {
+    db = makeMockDb([DRIFT_LOG])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/drift/latest')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeTruthy()
+    expect(body.data.skill_name).toBe('drift-monitor')
+    expect(body.data.result.drift_items).toHaveLength(2)
+  })
+
+  it('returns null data when no drift runs exist', async () => {
+    db = makeMockDb([])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/drift/latest')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/intelligence/drift/history
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/intelligence/drift/history', () => {
+  let db: ReturnType<typeof makeMockDb>
+  let skillQueue: ReturnType<typeof makeMockSkillQueue>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    skillQueue = makeMockSkillQueue()
+  })
+
+  it('returns 200 with drift history array', async () => {
+    db = makeMockDb([DRIFT_LOG])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/drift/history')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].skill_name).toBe('drift-monitor')
+  })
+
+  it('caps limit at 50', async () => {
+    db = makeMockDb([])
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    await app.request('/api/v1/intelligence/drift/history?limit=200')
+
+    // The SQL call should have been made — the limit is capped in code
+    expect(db.execute).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/intelligence/:skill/trigger
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/intelligence/:skill/trigger', () => {
+  let db: ReturnType<typeof makeMockDb>
+  let skillQueue: ReturnType<typeof makeMockSkillQueue>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    db = makeMockDb()
+    skillQueue = makeMockSkillQueue()
+  })
+
+  it('returns 202 when triggering daily-connections', async () => {
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/daily-connections/trigger', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(202)
+    const body = await res.json()
+    expect(body.skill).toBe('daily-connections')
+    expect(body.job_id).toBe('job-456')
+    expect(body.status).toBe('queued')
+  })
+
+  it('returns 202 when triggering drift-monitor', async () => {
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/drift-monitor/trigger', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(202)
+    const body = await res.json()
+    expect(body.skill).toBe('drift-monitor')
+  })
+
+  it('passes overrides to the skill queue', async () => {
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    await app.request('/api/v1/intelligence/daily-connections/trigger', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ windowDays: 14 }),
+    })
+
+    expect(skillQueue.add).toHaveBeenCalledWith(
+      'daily-connections',
+      expect.objectContaining({
+        skillName: 'daily-connections',
+        input: expect.objectContaining({ windowDays: 14 }),
+      }),
+      expect.objectContaining({ priority: 2 }),
+    )
+  })
+
+  it('returns 400 for unknown intelligence skill', async () => {
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/weekly-brief/trigger', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('VALIDATION_ERROR')
+    expect(body.error).toContain('weekly-brief')
+    expect(skillQueue.add).not.toHaveBeenCalled()
+  })
+
+  it('accepts trigger with no body', async () => {
+    const app = createApp({ db: db as any, skillQueue: skillQueue as any })
+    const res = await app.request('/api/v1/intelligence/drift-monitor/trigger', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(202)
+  })
+
+  it('returns 404 when db/skillQueue not wired up', async () => {
+    const app = createApp({})
+    const res = await app.request('/api/v1/intelligence/daily-connections/trigger', {
+      method: 'POST',
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/core-api/src/__tests__/skills-routes.test.ts
+++ b/packages/core-api/src/__tests__/skills-routes.test.ts
@@ -111,8 +111,8 @@ describe('GET /api/v1/skills', () => {
     const skillNames = body.skills.map((s: { name: string }) => s.name)
     expect(skillNames).toContain('weekly-brief')
     expect(skillNames).toContain('pipeline-health')
+    expect(skillNames).toContain('daily-connections')
     expect(skillNames).not.toContain('drift-monitor')
-    expect(skillNames).not.toContain('daily-connections')
   })
 
   it('includes schedule and description for known skills', async () => {

--- a/packages/core-api/src/__tests__/skills-routes.test.ts
+++ b/packages/core-api/src/__tests__/skills-routes.test.ts
@@ -112,7 +112,7 @@ describe('GET /api/v1/skills', () => {
     expect(skillNames).toContain('weekly-brief')
     expect(skillNames).toContain('pipeline-health')
     expect(skillNames).toContain('daily-connections')
-    expect(skillNames).not.toContain('drift-monitor')
+    expect(skillNames).toContain('drift-monitor')
   })
 
   it('includes schedule and description for known skills', async () => {

--- a/packages/core-api/src/app.ts
+++ b/packages/core-api/src/app.ts
@@ -18,6 +18,7 @@ import { registerSessionRoutes } from './routes/sessions.js'
 import { registerEventsRoutes } from './routes/events.js'
 import { registerDocumentRoutes } from './routes/documents.js'
 import { registerSynthesizeRoutes } from './routes/synthesize.js'
+import { registerIntelligenceRoutes } from './routes/intelligence.js'
 import { mountMcpServer } from './mcp/server.js'
 import type { CaptureService } from './services/capture.js'
 import type { SearchService } from './services/search.js'
@@ -107,6 +108,7 @@ export function createApp(deps: AppDependencies = {}): Hono {
   // Skills API
   if (db && skillQueue) {
     registerSkillRoutes(app, db, skillQueue)
+    registerIntelligenceRoutes(app, db, skillQueue)
   }
 
   // Triggers API

--- a/packages/core-api/src/routes/intelligence.ts
+++ b/packages/core-api/src/routes/intelligence.ts
@@ -219,11 +219,22 @@ export function registerIntelligenceRoutes(
     }
 
     // Parse optional body for override options (e.g., windowDays)
+    // Allowlist accepted keys per skill to prevent arbitrary data in Redis
+    const ALLOWED_OVERRIDES: Record<string, Set<string>> = {
+      'daily-connections': new Set(['windowDays', 'tokenBudget', 'modelAlias']),
+      'drift-monitor': new Set(['betActivityDays', 'commitmentDays', 'entityWindowDays', 'modelAlias']),
+      'weekly-brief': new Set(['windowDays', 'tokenBudget', 'modelAlias', 'emailTo']),
+    }
     let overrides: Record<string, unknown> = {}
     try {
       const body = await c.req.json().catch(() => null)
       if (body && typeof body === 'object') {
-        overrides = body as Record<string, unknown>
+        const allowed = ALLOWED_OVERRIDES[skill] ?? new Set<string>()
+        for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+          if (allowed.has(key)) {
+            overrides[key] = value
+          }
+        }
       }
     } catch {
       // Body is optional — ignore parse errors

--- a/packages/core-api/src/routes/intelligence.ts
+++ b/packages/core-api/src/routes/intelligence.ts
@@ -1,0 +1,273 @@
+import type { Hono } from 'hono'
+import { sql } from 'drizzle-orm'
+import type { Queue } from 'bullmq'
+import type { Database } from '@open-brain/shared'
+import { logger } from '../lib/logger.js'
+
+/**
+ * Shape of a skills_log row returned by intelligence queries.
+ */
+interface IntelligenceLogRow {
+  id: string
+  skill_name: string
+  capture_id: string | null
+  input_summary: string | null
+  output_summary: string | null
+  result: Record<string, unknown> | null
+  duration_ms: number | null
+  created_at: Date | string
+}
+
+/** Allowed intelligence skill names — prevents arbitrary skill_name injection into SQL */
+const INTELLIGENCE_SKILLS = new Set(['daily-connections', 'drift-monitor'])
+
+/** Job data shape for skill-execution queue */
+interface SkillExecutionJobData {
+  skillName: string
+  captureId?: string
+  sessionId?: string
+  input: Record<string, unknown>
+}
+
+/**
+ * Register intelligence API routes.
+ *
+ * These endpoints provide optimized access to daily-connections and
+ * drift-monitor skill results for the web dashboard's Intelligence tab.
+ *
+ * GET  /api/v1/intelligence/summary                 — combined latest results for both skills
+ * GET  /api/v1/intelligence/connections/latest       — latest daily-connections result
+ * GET  /api/v1/intelligence/connections/history      — recent daily-connections run history
+ * GET  /api/v1/intelligence/drift/latest             — latest drift-monitor result
+ * GET  /api/v1/intelligence/drift/history            — recent drift-monitor run history
+ * POST /api/v1/intelligence/:skill/trigger           — manually trigger an intelligence skill
+ */
+export function registerIntelligenceRoutes(
+  app: Hono,
+  db: Database,
+  skillQueue: Queue<SkillExecutionJobData>,
+): void {
+  // -----------------------------------------------------------------------
+  // GET /api/v1/intelligence/summary
+  // Returns the latest result for both daily-connections and drift-monitor
+  // in a single request — optimized for the Intelligence tab's initial load.
+  // -----------------------------------------------------------------------
+  app.get('/api/v1/intelligence/summary', async (c) => {
+    const rows = await db.execute<IntelligenceLogRow>(sql`
+      SELECT DISTINCT ON (skill_name)
+        id::text,
+        skill_name,
+        capture_id::text,
+        input_summary,
+        output_summary,
+        result,
+        duration_ms,
+        created_at
+      FROM skills_log
+      WHERE skill_name IN ('daily-connections', 'drift-monitor')
+      ORDER BY skill_name, created_at DESC
+    `)
+
+    const bySkill: Record<string, IntelligenceLogRow | null> = {
+      'daily-connections': null,
+      'drift-monitor': null,
+    }
+
+    for (const row of rows.rows) {
+      if (INTELLIGENCE_SKILLS.has(row.skill_name)) {
+        bySkill[row.skill_name] = row
+      }
+    }
+
+    return c.json({
+      connections: bySkill['daily-connections']
+        ? formatLogEntry(bySkill['daily-connections'])
+        : null,
+      drift: bySkill['drift-monitor']
+        ? formatLogEntry(bySkill['drift-monitor'])
+        : null,
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/intelligence/connections/latest
+  // Returns the most recent daily-connections skill result.
+  // -----------------------------------------------------------------------
+  app.get('/api/v1/intelligence/connections/latest', async (c) => {
+    const rows = await db.execute<IntelligenceLogRow>(sql`
+      SELECT
+        id::text,
+        skill_name,
+        capture_id::text,
+        input_summary,
+        output_summary,
+        result,
+        duration_ms,
+        created_at
+      FROM skills_log
+      WHERE skill_name = 'daily-connections'
+      ORDER BY created_at DESC
+      LIMIT 1
+    `)
+
+    if (rows.rows.length === 0) {
+      return c.json({ data: null })
+    }
+
+    return c.json({ data: formatLogEntry(rows.rows[0]) })
+  })
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/intelligence/connections/history?limit=N
+  // Returns recent daily-connections run history.
+  // -----------------------------------------------------------------------
+  app.get('/api/v1/intelligence/connections/history', async (c) => {
+    const limitParam = c.req.query('limit')
+    const limit = Math.min(parseInt(limitParam ?? '10', 10) || 10, 50)
+
+    const rows = await db.execute<IntelligenceLogRow>(sql`
+      SELECT
+        id::text,
+        skill_name,
+        capture_id::text,
+        input_summary,
+        output_summary,
+        result,
+        duration_ms,
+        created_at
+      FROM skills_log
+      WHERE skill_name = 'daily-connections'
+      ORDER BY created_at DESC
+      LIMIT ${limit}
+    `)
+
+    return c.json({ data: rows.rows.map(formatLogEntry) })
+  })
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/intelligence/drift/latest
+  // Returns the most recent drift-monitor skill result.
+  // -----------------------------------------------------------------------
+  app.get('/api/v1/intelligence/drift/latest', async (c) => {
+    const rows = await db.execute<IntelligenceLogRow>(sql`
+      SELECT
+        id::text,
+        skill_name,
+        capture_id::text,
+        input_summary,
+        output_summary,
+        result,
+        duration_ms,
+        created_at
+      FROM skills_log
+      WHERE skill_name = 'drift-monitor'
+      ORDER BY created_at DESC
+      LIMIT 1
+    `)
+
+    if (rows.rows.length === 0) {
+      return c.json({ data: null })
+    }
+
+    return c.json({ data: formatLogEntry(rows.rows[0]) })
+  })
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/intelligence/drift/history?limit=N
+  // Returns recent drift-monitor run history.
+  // -----------------------------------------------------------------------
+  app.get('/api/v1/intelligence/drift/history', async (c) => {
+    const limitParam = c.req.query('limit')
+    const limit = Math.min(parseInt(limitParam ?? '10', 10) || 10, 50)
+
+    const rows = await db.execute<IntelligenceLogRow>(sql`
+      SELECT
+        id::text,
+        skill_name,
+        capture_id::text,
+        input_summary,
+        output_summary,
+        result,
+        duration_ms,
+        created_at
+      FROM skills_log
+      WHERE skill_name = 'drift-monitor'
+      ORDER BY created_at DESC
+      LIMIT ${limit}
+    `)
+
+    return c.json({ data: rows.rows.map(formatLogEntry) })
+  })
+
+  // -----------------------------------------------------------------------
+  // POST /api/v1/intelligence/:skill/trigger
+  // Manually trigger an intelligence skill (daily-connections or drift-monitor).
+  // Returns 202 Accepted — the skill runs asynchronously via BullMQ.
+  // -----------------------------------------------------------------------
+  app.post('/api/v1/intelligence/:skill/trigger', async (c) => {
+    const skill = c.req.param('skill')
+
+    if (!skill || !INTELLIGENCE_SKILLS.has(skill)) {
+      return c.json(
+        {
+          error: `Unknown intelligence skill: '${skill}'. Valid skills: ${Array.from(INTELLIGENCE_SKILLS).join(', ')}`,
+          code: 'VALIDATION_ERROR',
+        },
+        400,
+      )
+    }
+
+    // Parse optional body for override options (e.g., windowDays)
+    let overrides: Record<string, unknown> = {}
+    try {
+      const body = await c.req.json().catch(() => null)
+      if (body && typeof body === 'object') {
+        overrides = body as Record<string, unknown>
+      }
+    } catch {
+      // Body is optional — ignore parse errors
+    }
+
+    logger.info({ skill, overrides }, '[intelligence-api] manual trigger received')
+
+    const job = await skillQueue.add(
+      skill,
+      {
+        skillName: skill,
+        input: overrides,
+      },
+      {
+        priority: 2,
+        jobId: `manual_${skill}_${Date.now()}`,
+      },
+    )
+
+    logger.info({ skill, jobId: job.id }, '[intelligence-api] skill execution enqueued')
+
+    return c.json(
+      {
+        skill,
+        job_id: job.id,
+        status: 'queued',
+        message: `Intelligence skill '${skill}' has been queued for execution`,
+      },
+      202,
+    )
+  })
+}
+
+/**
+ * Formats a raw skills_log row into the shape expected by the web dashboard.
+ */
+function formatLogEntry(row: IntelligenceLogRow) {
+  return {
+    id: row.id,
+    skill_name: row.skill_name,
+    capture_id: row.capture_id,
+    input_summary: row.input_summary,
+    output_summary: row.output_summary,
+    result: row.result ?? null,
+    duration_ms: row.duration_ms,
+    created_at: row.created_at,
+  }
+}

--- a/packages/core-api/src/routes/intelligence.ts
+++ b/packages/core-api/src/routes/intelligence.ts
@@ -8,6 +8,7 @@ import { logger } from '../lib/logger.js'
  * Shape of a skills_log row returned by intelligence queries.
  */
 interface IntelligenceLogRow {
+  [key: string]: unknown
   id: string
   skill_name: string
   capture_id: string | null

--- a/packages/core-api/src/routes/skills.ts
+++ b/packages/core-api/src/routes/skills.ts
@@ -44,7 +44,6 @@ interface SkillExecutionJobData {
  * Mirrors config/skills.yaml. Will be replaced by config-driven lookup
  * once skills.yaml is loaded via ConfigService (Phase 11+).
  */
-// Deferred: drift-monitor — implement when PRD F22 is prioritized
 const KNOWN_SKILLS: Record<string, { schedule: string; description: string }> = {
   'weekly-brief': {
     schedule: '0 20 * * 0', // Sunday 8pm
@@ -53,6 +52,10 @@ const KNOWN_SKILLS: Record<string, { schedule: string; description: string }> = 
   'daily-connections': {
     schedule: '0 21 * * *', // Daily 9pm
     description: 'Surface non-obvious cross-domain connections across recent captures via LLM synthesis and deliver via Pushover',
+  },
+  'drift-monitor': {
+    schedule: '0 8 * * *', // Daily 8am
+    description: 'Detect when tracked commitments, bets, or projects go silent and alert via Pushover if severity >= medium',
   },
   'pipeline-health': {
     schedule: '0 * * * *', // Every hour

--- a/packages/core-api/src/routes/skills.ts
+++ b/packages/core-api/src/routes/skills.ts
@@ -44,11 +44,15 @@ interface SkillExecutionJobData {
  * Mirrors config/skills.yaml. Will be replaced by config-driven lookup
  * once skills.yaml is loaded via ConfigService (Phase 11+).
  */
-// Deferred: drift-monitor, daily-connections — implement when PRD F21/F22 are prioritized
+// Deferred: drift-monitor — implement when PRD F22 is prioritized
 const KNOWN_SKILLS: Record<string, { schedule: string; description: string }> = {
   'weekly-brief': {
     schedule: '0 20 * * 0', // Sunday 8pm
     description: 'Generate a weekly synthesis of all captures and deliver via email + Pushover',
+  },
+  'daily-connections': {
+    schedule: '0 21 * * *', // Daily 9pm
+    description: 'Surface non-obvious cross-domain connections across recent captures via LLM synthesis and deliver via Pushover',
   },
   'pipeline-health': {
     schedule: '0 * * * *', // Every hour

--- a/packages/slack-bot/src/__tests__/connections-command.test.ts
+++ b/packages/slack-bot/src/__tests__/connections-command.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SayFn } from '@slack/bolt'
+import type { GenericMessageEvent } from '@slack/types'
+import { handleCommand } from '../handlers/command.js'
+import type { CoreApiClient } from '../lib/core-api-client.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSay(): SayFn {
+  return vi.fn().mockResolvedValue({})
+}
+
+function makeMessage(text: string, overrides: Partial<Record<string, unknown>> = {}): GenericMessageEvent {
+  return {
+    type: 'message',
+    subtype: undefined,
+    channel: 'C1234567890',
+    ts: '1234567890.000100',
+    text,
+    user: 'U111222333',
+    ...overrides,
+  } as unknown as GenericMessageEvent
+}
+
+function makeClient(overrides: Partial<CoreApiClient> = {}): CoreApiClient {
+  return {
+    stats_get: vi.fn(),
+    skills_trigger: vi.fn().mockResolvedValue({ queued: true, job_id: 'job-connections-001' }),
+    skills_last_run: vi.fn(),
+    captures_list: vi.fn(),
+    captures_get: vi.fn(),
+    captures_create: vi.fn(),
+    captures_retry: vi.fn(),
+    search_query: vi.fn(),
+    synthesize_query: vi.fn(),
+    entities_list: vi.fn(),
+    entities_search: vi.fn(),
+    entities_merge: vi.fn(),
+    entities_split: vi.fn(),
+    pipeline_health: vi.fn(),
+    triggers_create: vi.fn(),
+    triggers_list: vi.fn(),
+    triggers_delete: vi.fn(),
+    triggers_test: vi.fn(),
+    sessions_create: vi.fn(),
+    sessions_list: vi.fn(),
+    sessions_respond: vi.fn(),
+    sessions_pause: vi.fn(),
+    sessions_resume: vi.fn(),
+    sessions_complete: vi.fn(),
+    sessions_abandon: vi.fn(),
+    bets_list: vi.fn(),
+    bets_create: vi.fn(),
+    bets_expiring: vi.fn(),
+    bets_resolve: vi.fn(),
+    ...overrides,
+  } as unknown as CoreApiClient
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('!connections command', () => {
+  let say: SayFn
+  let client: CoreApiClient
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    say = makeSay()
+    client = makeClient()
+  })
+
+  // -----------------------------------------------------------------------
+  // Default (no args)
+  // -----------------------------------------------------------------------
+
+  describe('!connections (default)', () => {
+    it('sends acknowledgment message with default 7-day window', async () => {
+      await handleCommand(makeMessage('!connections'), say, client)
+      const firstCall = (say as ReturnType<typeof vi.fn>).mock.calls[0][0] as { text: string; thread_ts: string }
+      expect(firstCall.text).toContain('7 days')
+      expect(firstCall.thread_ts).toBe('1234567890.000100')
+    })
+
+    it('calls skills_trigger with daily-connections and default windowDays', async () => {
+      await handleCommand(makeMessage('!connections'), say, client)
+      expect(client.skills_trigger).toHaveBeenCalledWith('daily-connections', { windowDays: 7 })
+    })
+
+    it('sends queued confirmation after trigger', async () => {
+      await handleCommand(makeMessage('!connections'), say, client)
+      // Second call is the queued confirmation
+      const calls = (say as ReturnType<typeof vi.fn>).mock.calls
+      expect(calls.length).toBeGreaterThanOrEqual(2)
+      const secondCall = calls[1][0] as { text: string }
+      expect(secondCall.text).toContain('queued')
+      expect(secondCall.text).toContain('job-connections-001')
+    })
+
+    it('replies in thread', async () => {
+      const msg = makeMessage('!connections', { ts: '9999.0001' })
+      await handleCommand(msg, say, client)
+      expect(say).toHaveBeenCalledWith(expect.objectContaining({ thread_ts: '9999.0001' }))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Custom days
+  // -----------------------------------------------------------------------
+
+  describe('!connections <days>', () => {
+    it('passes custom day count to skills_trigger', async () => {
+      await handleCommand(makeMessage('!connections 14'), say, client)
+      expect(client.skills_trigger).toHaveBeenCalledWith('daily-connections', { windowDays: 14 })
+    })
+
+    it('sends acknowledgment with custom day count', async () => {
+      await handleCommand(makeMessage('!connections 30'), say, client)
+      const firstCall = (say as ReturnType<typeof vi.fn>).mock.calls[0][0] as { text: string }
+      expect(firstCall.text).toContain('30 days')
+    })
+
+    it('caps day count at 90', async () => {
+      await handleCommand(makeMessage('!connections 365'), say, client)
+      expect(client.skills_trigger).toHaveBeenCalledWith('daily-connections', { windowDays: 90 })
+    })
+
+    it('acknowledges with capped day count in message', async () => {
+      await handleCommand(makeMessage('!connections 365'), say, client)
+      const firstCall = (say as ReturnType<typeof vi.fn>).mock.calls[0][0] as { text: string }
+      expect(firstCall.text).toContain('90 days')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Invalid arguments
+  // -----------------------------------------------------------------------
+
+  describe('!connections <invalid>', () => {
+    it('returns error for non-numeric argument', async () => {
+      await handleCommand(makeMessage('!connections abc'), say, client)
+      const call = (say as ReturnType<typeof vi.fn>).mock.calls[0][0] as { text: string }
+      expect(call.text).toContain(':warning:')
+      expect(call.text).toContain('Invalid argument')
+      expect(client.skills_trigger).not.toHaveBeenCalled()
+    })
+
+    it('returns error for zero', async () => {
+      await handleCommand(makeMessage('!connections 0'), say, client)
+      const call = (say as ReturnType<typeof vi.fn>).mock.calls[0][0] as { text: string }
+      expect(call.text).toContain(':warning:')
+      expect(client.skills_trigger).not.toHaveBeenCalled()
+    })
+
+    it('returns error for negative number', async () => {
+      await handleCommand(makeMessage('!connections -5'), say, client)
+      const call = (say as ReturnType<typeof vi.fn>).mock.calls[0][0] as { text: string }
+      expect(call.text).toContain(':warning:')
+      expect(client.skills_trigger).not.toHaveBeenCalled()
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe('!connections error handling', () => {
+    it('handles skills_trigger failure gracefully', async () => {
+      ;(client.skills_trigger as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('503 Service Unavailable'))
+      await handleCommand(makeMessage('!connections'), say, client)
+      const lastCall = (say as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0] as { text: string }
+      expect(lastCall.text).toContain('failed')
+    })
+
+    it('handles non-queued trigger response', async () => {
+      ;(client.skills_trigger as ReturnType<typeof vi.fn>).mockResolvedValue({ queued: false })
+      await handleCommand(makeMessage('!connections'), say, client)
+      const lastCall = (say as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0] as { text: string }
+      expect(lastCall.text).toContain('triggered')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Worker dispatcher — daily-connections case routing
+// ---------------------------------------------------------------------------
+
+describe('skill-execution worker — daily-connections dispatch', () => {
+  it('daily-connections case calls executeDailyConnections with typed input', async () => {
+    // Verify the dispatcher module imports and routes correctly
+    // We import the module to confirm it can be loaded without error
+    const mod = await import('../../src/handlers/commands/connections.js')
+    expect(typeof mod.handleConnectionsCommand).toBe('function')
+  })
+})

--- a/packages/slack-bot/src/__tests__/drift-command.test.ts
+++ b/packages/slack-bot/src/__tests__/drift-command.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SayFn } from '@slack/bolt'
+import type { GenericMessageEvent } from '@slack/types'
+import { handleCommand } from '../handlers/command.js'
+import type { CoreApiClient } from '../lib/core-api-client.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSay(): SayFn {
+  return vi.fn().mockResolvedValue({})
+}
+
+function makeMessage(text: string, overrides: Partial<Record<string, unknown>> = {}): GenericMessageEvent {
+  return {
+    type: 'message',
+    subtype: undefined,
+    channel: 'C1234567890',
+    ts: '1234567890.000100',
+    text,
+    user: 'U111222333',
+    ...overrides,
+  } as unknown as GenericMessageEvent
+}
+
+function makeClient(overrides: Partial<CoreApiClient> = {}): CoreApiClient {
+  return {
+    stats_get: vi.fn(),
+    skills_trigger: vi.fn().mockResolvedValue({ queued: true, job_id: 'job-drift-001' }),
+    skills_last_run: vi.fn(),
+    captures_list: vi.fn(),
+    captures_get: vi.fn(),
+    captures_create: vi.fn(),
+    captures_retry: vi.fn(),
+    search_query: vi.fn(),
+    synthesize_query: vi.fn(),
+    entities_list: vi.fn(),
+    entities_search: vi.fn(),
+    entities_merge: vi.fn(),
+    entities_split: vi.fn(),
+    pipeline_health: vi.fn(),
+    triggers_create: vi.fn(),
+    triggers_list: vi.fn(),
+    triggers_delete: vi.fn(),
+    triggers_test: vi.fn(),
+    sessions_create: vi.fn(),
+    sessions_list: vi.fn(),
+    sessions_respond: vi.fn(),
+    sessions_pause: vi.fn(),
+    sessions_resume: vi.fn(),
+    sessions_complete: vi.fn(),
+    sessions_abandon: vi.fn(),
+    bets_list: vi.fn(),
+    bets_create: vi.fn(),
+    bets_expiring: vi.fn(),
+    bets_resolve: vi.fn(),
+    ...overrides,
+  } as unknown as CoreApiClient
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('!drift command', () => {
+  let say: SayFn
+  let client: CoreApiClient
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    say = makeSay()
+    client = makeClient()
+  })
+
+  // -----------------------------------------------------------------------
+  // Default (no args)
+  // -----------------------------------------------------------------------
+
+  describe('!drift (trigger)', () => {
+    it('sends acknowledgment message', async () => {
+      await handleCommand(makeMessage('!drift'), say, client)
+      const firstCall = (say as ReturnType<typeof vi.fn>).mock.calls[0][0] as { text: string; thread_ts: string }
+      expect(firstCall.text).toContain('drift analysis')
+      expect(firstCall.thread_ts).toBe('1234567890.000100')
+    })
+
+    it('calls skills_trigger with drift-monitor', async () => {
+      await handleCommand(makeMessage('!drift'), say, client)
+      expect(client.skills_trigger).toHaveBeenCalledWith('drift-monitor', {})
+    })
+
+    it('sends queued confirmation after trigger', async () => {
+      await handleCommand(makeMessage('!drift'), say, client)
+      // Second call is the queued confirmation
+      const calls = (say as ReturnType<typeof vi.fn>).mock.calls
+      expect(calls.length).toBeGreaterThanOrEqual(2)
+      const secondCall = calls[1][0] as { text: string }
+      expect(secondCall.text).toContain('queued')
+      expect(secondCall.text).toContain('job-drift-001')
+    })
+
+    it('replies in thread', async () => {
+      const msg = makeMessage('!drift', { ts: '9999.0001' })
+      await handleCommand(msg, say, client)
+      expect(say).toHaveBeenCalledWith(expect.objectContaining({ thread_ts: '9999.0001' }))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  describe('!drift error handling', () => {
+    it('handles skills_trigger failure gracefully', async () => {
+      ;(client.skills_trigger as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('503 Service Unavailable'))
+      await handleCommand(makeMessage('!drift'), say, client)
+      const lastCall = (say as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0] as { text: string }
+      expect(lastCall.text).toContain('failed')
+    })
+
+    it('handles non-queued trigger response', async () => {
+      ;(client.skills_trigger as ReturnType<typeof vi.fn>).mockResolvedValue({ queued: false })
+      await handleCommand(makeMessage('!drift'), say, client)
+      const lastCall = (say as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0] as { text: string }
+      expect(lastCall.text).toContain('triggered')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Extra args ignored
+  // -----------------------------------------------------------------------
+
+  describe('!drift with extra args', () => {
+    it('ignores extra arguments and triggers normally', async () => {
+      await handleCommand(makeMessage('!drift extra stuff'), say, client)
+      expect(client.skills_trigger).toHaveBeenCalledWith('drift-monitor', {})
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Module export verification
+// ---------------------------------------------------------------------------
+
+describe('drift command — module export', () => {
+  it('handleDriftCommand is exported as a function', async () => {
+    const mod = await import('../../src/handlers/commands/drift.js')
+    expect(typeof mod.handleDriftCommand).toBe('function')
+  })
+})

--- a/packages/slack-bot/src/handlers/command.ts
+++ b/packages/slack-bot/src/handlers/command.ts
@@ -18,6 +18,7 @@ import {
   handleBoardCommand,
   handleBetCommand,
   handleTriggerCommand,
+  handleConnectionsCommand,
   handlePipelineStatus,
   handleHelp,
   HELP_TEXT,
@@ -119,6 +120,10 @@ export async function handleCommand(
 
     case 'trigger':
       await handleTriggerCommand(ts, say, coreApiClient, subCmd, args)
+      break
+
+    case 'connections':
+      await handleConnectionsCommand(ts, say, coreApiClient, subCmd)
       break
 
     case 'help':

--- a/packages/slack-bot/src/handlers/command.ts
+++ b/packages/slack-bot/src/handlers/command.ts
@@ -19,6 +19,7 @@ import {
   handleBetCommand,
   handleTriggerCommand,
   handleConnectionsCommand,
+  handleDriftCommand,
   handlePipelineStatus,
   handleHelp,
   HELP_TEXT,
@@ -124,6 +125,10 @@ export async function handleCommand(
 
     case 'connections':
       await handleConnectionsCommand(ts, say, coreApiClient, subCmd)
+      break
+
+    case 'drift':
+      await handleDriftCommand(ts, say, coreApiClient)
       break
 
     case 'help':

--- a/packages/slack-bot/src/handlers/commands/connections.ts
+++ b/packages/slack-bot/src/handlers/commands/connections.ts
@@ -1,0 +1,50 @@
+import type { SayFn } from '@slack/bolt'
+import type { CoreApiClient } from '../../lib/core-api-client.js'
+import { formatError } from '../../lib/formatters.js'
+import { logger } from '../../lib/logger.js'
+
+/**
+ * Handle `!connections [days]` — trigger the daily-connections skill.
+ *
+ * - `!connections`     → 7-day window (default)
+ * - `!connections 14`  → 14-day window
+ * - `!connections abc` → error: invalid argument
+ */
+export async function handleConnectionsCommand(
+  ts: string,
+  say: SayFn,
+  client: CoreApiClient,
+  subCmd: string,
+): Promise<void> {
+  // Parse optional day count from first argument
+  let windowDays = 7
+
+  if (subCmd) {
+    const parsed = parseInt(subCmd, 10)
+    if (isNaN(parsed) || parsed < 1) {
+      await say({
+        text: ':warning: Invalid argument. Usage: `!connections [days]` — days must be a positive number (default: 7)',
+        thread_ts: ts,
+      })
+      return
+    }
+    windowDays = Math.min(parsed, 90) // Cap at 90 days to prevent excessive queries
+  }
+
+  // Acknowledge immediately — skill runs asynchronously
+  await say({
+    text: `_Running daily connections analysis (last ${windowDays} days)…_`,
+    thread_ts: ts,
+  })
+
+  try {
+    const result = await client.skills_trigger('daily-connections', { windowDays })
+    const status = result.queued
+      ? `Connections analysis queued (job \`${result.job_id}\`). Results will arrive via Pushover.`
+      : 'Connections analysis triggered.'
+    await say({ text: status, thread_ts: ts })
+  } catch (err) {
+    logger.error({ err, windowDays }, 'handleCommand: skills_trigger(daily-connections) failed')
+    await say({ text: formatError('Connections analysis failed', err), thread_ts: ts })
+  }
+}

--- a/packages/slack-bot/src/handlers/commands/drift.ts
+++ b/packages/slack-bot/src/handlers/commands/drift.ts
@@ -1,0 +1,32 @@
+import type { SayFn } from '@slack/bolt'
+import type { CoreApiClient } from '../../lib/core-api-client.js'
+import { formatError } from '../../lib/formatters.js'
+import { logger } from '../../lib/logger.js'
+
+/**
+ * Handle `!drift` — trigger the drift-monitor skill.
+ *
+ * No arguments — the skill uses its own defaults for analysis windows.
+ */
+export async function handleDriftCommand(
+  ts: string,
+  say: SayFn,
+  client: CoreApiClient,
+): Promise<void> {
+  // Acknowledge immediately — skill runs asynchronously
+  await say({
+    text: '_Running drift analysis…_',
+    thread_ts: ts,
+  })
+
+  try {
+    const result = await client.skills_trigger('drift-monitor', {})
+    const status = result.queued
+      ? `Drift analysis queued (job \`${result.job_id}\`). Results will arrive via Pushover.`
+      : 'Drift analysis triggered.'
+    await say({ text: status, thread_ts: ts })
+  } catch (err) {
+    logger.error({ err }, 'handleCommand: skills_trigger(drift-monitor) failed')
+    await say({ text: formatError('Drift analysis failed', err), thread_ts: ts })
+  }
+}

--- a/packages/slack-bot/src/handlers/commands/help.ts
+++ b/packages/slack-bot/src/handlers/commands/help.ts
@@ -25,6 +25,7 @@ export const HELP_TEXT = `*Open Brain — Available Commands*
 
 *Intelligence*
   \`!connections [days]\`  — run daily connections analysis (default: 7 days)
+  \`!drift\`               — run drift analysis (silent bets, declining topics)
 
 *Pipeline*
   \`!pipeline status\`    — pipeline queue health

--- a/packages/slack-bot/src/handlers/commands/help.ts
+++ b/packages/slack-bot/src/handlers/commands/help.ts
@@ -23,6 +23,9 @@ export const HELP_TEXT = `*Open Brain — Available Commands*
   \`!trigger delete <n>\` — deactivate a trigger by name/id
   \`!trigger test "text"\`— test query against existing captures
 
+*Intelligence*
+  \`!connections [days]\`  — run daily connections analysis (default: 7 days)
+
 *Pipeline*
   \`!pipeline status\`    — pipeline queue health
 

--- a/packages/slack-bot/src/handlers/commands/index.ts
+++ b/packages/slack-bot/src/handlers/commands/index.ts
@@ -13,6 +13,7 @@ export { handleBoardCommand } from './board.js'
 export { handleBetCommand } from './bet.js'
 export { handleTriggerCommand } from './trigger.js'
 export { handleConnectionsCommand } from './connections.js'
+export { handleDriftCommand } from './drift.js'
 export { handlePipelineStatus } from './pipeline.js'
 export { handleHelp, HELP_TEXT } from './help.js'
 

--- a/packages/slack-bot/src/handlers/commands/index.ts
+++ b/packages/slack-bot/src/handlers/commands/index.ts
@@ -12,6 +12,7 @@ export { handleEntities, handleEntityDetail, handleEntityMerge, handleEntitySpli
 export { handleBoardCommand } from './board.js'
 export { handleBetCommand } from './bet.js'
 export { handleTriggerCommand } from './trigger.js'
+export { handleConnectionsCommand } from './connections.js'
 export { handlePipelineStatus } from './pipeline.js'
 export { handleHelp, HELP_TEXT } from './help.js'
 

--- a/packages/slack-bot/src/intent/router.ts
+++ b/packages/slack-bot/src/intent/router.ts
@@ -54,6 +54,7 @@ const COMMAND_NAMES = new Set([
   'stats', 'status', 'help', 'brief', 'budget', 'views', 'types', 'ping',
   'recent', 'retry', 'entities', 'entity', 'trigger', 'pipeline', 'board', 'bet',
   'connections',
+  'drift',
 ])
 
 /**

--- a/packages/slack-bot/src/intent/router.ts
+++ b/packages/slack-bot/src/intent/router.ts
@@ -53,6 +53,7 @@ const QUESTION_PATTERNS = [
 const COMMAND_NAMES = new Set([
   'stats', 'status', 'help', 'brief', 'budget', 'views', 'types', 'ping',
   'recent', 'retry', 'entities', 'entity', 'trigger', 'pipeline', 'board', 'bet',
+  'connections',
 ])
 
 /**

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,6 +10,7 @@ const EntityDetail = lazy(() => import('@/pages/EntityDetail'));
 const Briefs = lazy(() => import('@/pages/Briefs'));
 const Board = lazy(() => import('@/pages/Board'));
 const Voice = lazy(() => import('@/pages/Voice'));
+const Intelligence = lazy(() => import('@/pages/Intelligence'));
 const Settings = lazy(() => import('@/pages/Settings'));
 
 function PageLoader() {
@@ -34,6 +35,7 @@ export default function App() {
           <Route path="briefs" element={<Briefs />} />
           <Route path="board" element={<Board />} />
           <Route path="voice" element={<Voice />} />
+          <Route path="intelligence" element={<Intelligence />} />
           <Route path="settings" element={<Settings />} />
         </Route>
       </Routes>

--- a/packages/web/src/components/ConnectionsCard.tsx
+++ b/packages/web/src/components/ConnectionsCard.tsx
@@ -1,0 +1,143 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { IntelligenceEntry } from '@/lib/api';
+
+// Mirrors DailyConnectionsOutput / ConnectionItem from workers skill
+interface ConnectionItem {
+  theme: string;
+  captures: string[];
+  insight: string;
+  confidence: 'high' | 'medium' | 'low';
+  domains: string[];
+}
+
+interface DailyConnectionsOutput {
+  summary: string;
+  connections: ConnectionItem[];
+  meta_pattern: string | null;
+}
+
+interface ConnectionsCardProps {
+  entry: IntelligenceEntry;
+}
+
+const CONFIDENCE_STYLES: Record<string, string> = {
+  high: 'bg-green-100 text-green-800 border-green-200',
+  medium: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  low: 'bg-gray-100 text-gray-600 border-gray-200',
+};
+
+function parseResult(entry: IntelligenceEntry): DailyConnectionsOutput | null {
+  const raw = entry.result;
+  if (!raw || typeof raw !== 'object') return null;
+
+  const r = raw as Record<string, unknown>;
+  const summary = typeof r.summary === 'string' ? r.summary : '';
+  const meta_pattern = typeof r.meta_pattern === 'string' ? r.meta_pattern : null;
+
+  const connections: ConnectionItem[] = [];
+  if (Array.isArray(r.connections)) {
+    for (const item of r.connections) {
+      if (typeof item === 'object' && item !== null) {
+        const c = item as Record<string, unknown>;
+        connections.push({
+          theme: typeof c.theme === 'string' ? c.theme : '(unnamed)',
+          captures: Array.isArray(c.captures) ? c.captures.filter((v): v is string => typeof v === 'string') : [],
+          insight: typeof c.insight === 'string' ? c.insight : '',
+          confidence: isConfidence(c.confidence) ? c.confidence : 'low',
+          domains: Array.isArray(c.domains) ? c.domains.filter((v): v is string => typeof v === 'string') : [],
+        });
+      }
+    }
+  }
+
+  return { summary, connections, meta_pattern };
+}
+
+function isConfidence(val: unknown): val is 'high' | 'medium' | 'low' {
+  return val === 'high' || val === 'medium' || val === 'low';
+}
+
+export default function ConnectionsCard({ entry }: ConnectionsCardProps) {
+  const output = parseResult(entry);
+
+  // Fallback: no structured result, show output_summary
+  if (!output || output.connections.length === 0) {
+    return (
+      <div className="space-y-2">
+        {entry.output_summary && (
+          <p className="text-sm text-muted-foreground">{entry.output_summary}</p>
+        )}
+        {!entry.output_summary && (
+          <p className="text-sm text-muted-foreground italic">No structured connections data available.</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Summary */}
+      {output.summary && (
+        <p className="text-sm">{output.summary}</p>
+      )}
+
+      {/* Connection items */}
+      <div className="space-y-3">
+        {output.connections.map((conn, i) => (
+          <div
+            key={i}
+            className="rounded-lg border bg-card p-3 space-y-2"
+          >
+            {/* Theme + confidence */}
+            <div className="flex items-start justify-between gap-2">
+              <span className="text-sm font-medium leading-snug">{conn.theme}</span>
+              <Badge
+                variant="outline"
+                className={cn('text-xs shrink-0 border', CONFIDENCE_STYLES[conn.confidence])}
+              >
+                {conn.confidence}
+              </Badge>
+            </div>
+
+            {/* Insight */}
+            {conn.insight && (
+              <p className="text-sm text-muted-foreground leading-relaxed">{conn.insight}</p>
+            )}
+
+            {/* Domains (cross-domain indicators) */}
+            {conn.domains.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {conn.domains.map((domain) => (
+                  <Badge key={domain} variant="secondary" className="text-xs">
+                    {domain}
+                  </Badge>
+                ))}
+                {conn.domains.length > 1 && (
+                  <Badge variant="outline" className="text-xs border-amber-300 text-amber-700 bg-amber-50">
+                    cross-domain
+                  </Badge>
+                )}
+              </div>
+            )}
+
+            {/* Related captures */}
+            {conn.captures.length > 0 && (
+              <div className="text-xs text-muted-foreground">
+                {conn.captures.length} related capture{conn.captures.length !== 1 ? 's' : ''}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Meta-pattern */}
+      {output.meta_pattern && (
+        <div className="rounded-lg border border-dashed border-amber-300 bg-amber-50/50 p-3">
+          <p className="text-xs font-medium text-amber-800 mb-1">Meta-pattern</p>
+          <p className="text-sm text-amber-900">{output.meta_pattern}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/DriftCard.tsx
+++ b/packages/web/src/components/DriftCard.tsx
@@ -1,0 +1,183 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { IntelligenceEntry } from '@/lib/api';
+
+// Mirrors DriftMonitorOutput / DriftItem from workers skill
+interface DriftItem {
+  item_type: 'bet' | 'commitment' | 'entity';
+  item_name: string;
+  severity: 'high' | 'medium' | 'low';
+  days_silent: number;
+  reason: string;
+  suggested_action: string;
+}
+
+interface DriftMonitorOutput {
+  summary: string;
+  drift_items: DriftItem[];
+  overall_health: 'healthy' | 'minor_drift' | 'significant_drift' | 'critical_drift';
+}
+
+interface DriftCardProps {
+  entry: IntelligenceEntry;
+}
+
+const SEVERITY_STYLES: Record<string, string> = {
+  high: 'bg-red-100 text-red-800 border-red-200',
+  medium: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  low: 'bg-green-100 text-green-800 border-green-200',
+};
+
+const SEVERITY_DOT: Record<string, string> = {
+  high: 'bg-red-500',
+  medium: 'bg-yellow-500',
+  low: 'bg-green-500',
+};
+
+const HEALTH_STYLES: Record<string, { label: string; color: string }> = {
+  healthy: { label: 'Healthy', color: 'text-green-700 bg-green-100' },
+  minor_drift: { label: 'Minor Drift', color: 'text-yellow-700 bg-yellow-100' },
+  significant_drift: { label: 'Significant Drift', color: 'text-orange-700 bg-orange-100' },
+  critical_drift: { label: 'Critical Drift', color: 'text-red-700 bg-red-100' },
+};
+
+const ITEM_TYPE_LABELS: Record<string, string> = {
+  bet: 'Bet',
+  commitment: 'Commitment',
+  entity: 'Entity',
+};
+
+function parseResult(entry: IntelligenceEntry): DriftMonitorOutput | null {
+  const raw = entry.result;
+  if (!raw || typeof raw !== 'object') return null;
+
+  const r = raw as Record<string, unknown>;
+  const summary = typeof r.summary === 'string' ? r.summary : '';
+  const overall_health = isHealth(r.overall_health) ? r.overall_health : 'healthy';
+
+  const drift_items: DriftItem[] = [];
+  if (Array.isArray(r.drift_items)) {
+    for (const item of r.drift_items) {
+      if (typeof item === 'object' && item !== null) {
+        const d = item as Record<string, unknown>;
+        drift_items.push({
+          item_type: isItemType(d.item_type) ? d.item_type : 'entity',
+          item_name: typeof d.item_name === 'string' ? d.item_name : '(unnamed)',
+          severity: isSeverity(d.severity) ? d.severity : 'low',
+          days_silent: typeof d.days_silent === 'number' ? d.days_silent : 0,
+          reason: typeof d.reason === 'string' ? d.reason : '',
+          suggested_action: typeof d.suggested_action === 'string' ? d.suggested_action : '',
+        });
+      }
+    }
+  }
+
+  return { summary, drift_items, overall_health };
+}
+
+function isHealth(val: unknown): val is DriftMonitorOutput['overall_health'] {
+  return val === 'healthy' || val === 'minor_drift' || val === 'significant_drift' || val === 'critical_drift';
+}
+
+function isSeverity(val: unknown): val is 'high' | 'medium' | 'low' {
+  return val === 'high' || val === 'medium' || val === 'low';
+}
+
+function isItemType(val: unknown): val is 'bet' | 'commitment' | 'entity' {
+  return val === 'bet' || val === 'commitment' || val === 'entity';
+}
+
+export default function DriftCard({ entry }: DriftCardProps) {
+  const output = parseResult(entry);
+
+  // Fallback: no structured result, show output_summary
+  if (!output) {
+    return (
+      <div className="space-y-2">
+        {entry.output_summary && (
+          <p className="text-sm text-muted-foreground">{entry.output_summary}</p>
+        )}
+        {!entry.output_summary && (
+          <p className="text-sm text-muted-foreground italic">No structured drift data available.</p>
+        )}
+      </div>
+    );
+  }
+
+  const healthInfo = HEALTH_STYLES[output.overall_health] ?? HEALTH_STYLES.healthy;
+
+  return (
+    <div className="space-y-3">
+      {/* Overall health score */}
+      <div className="flex items-center gap-2">
+        <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold', healthInfo.color)}>
+          {healthInfo.label}
+        </span>
+        {output.drift_items.length > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {output.drift_items.length} item{output.drift_items.length !== 1 ? 's' : ''} detected
+          </span>
+        )}
+      </div>
+
+      {/* Summary */}
+      {output.summary && (
+        <p className="text-sm">{output.summary}</p>
+      )}
+
+      {/* Drift items */}
+      {output.drift_items.length > 0 ? (
+        <div className="space-y-2">
+          {output.drift_items.map((item, i) => (
+            <div
+              key={i}
+              className="rounded-lg border bg-card p-3 space-y-1.5"
+            >
+              {/* Header: severity dot + name + badges */}
+              <div className="flex items-start gap-2">
+                <span className={cn('mt-1.5 inline-block h-2 w-2 rounded-full shrink-0', SEVERITY_DOT[item.severity])} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-sm font-medium">{item.item_name}</span>
+                    <Badge
+                      variant="outline"
+                      className={cn('text-xs border', SEVERITY_STYLES[item.severity])}
+                    >
+                      {item.severity}
+                    </Badge>
+                    <Badge variant="secondary" className="text-xs">
+                      {ITEM_TYPE_LABELS[item.item_type] ?? item.item_type}
+                    </Badge>
+                    {item.days_silent > 0 && (
+                      <span className="text-xs text-muted-foreground">
+                        {item.days_silent}d silent
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Reason */}
+              {item.reason && (
+                <p className="text-sm text-muted-foreground ml-4">{item.reason}</p>
+              )}
+
+              {/* Suggested action */}
+              {item.suggested_action && (
+                <div className="ml-4 rounded bg-accent/50 px-2 py-1">
+                  <p className="text-xs text-muted-foreground">
+                    <span className="font-medium">Action:</span> {item.suggested_action}
+                  </p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground italic">
+          No drift items detected — all tracked items are active.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   Users,
   FileText,
   Gavel,
+  Lightbulb,
   Mic,
   Settings,
   Brain,
@@ -26,6 +27,7 @@ const navItems: NavItem[] = [
   { to: '/entities', label: 'Entities', icon: Users },
   { to: '/briefs', label: 'Briefs', icon: FileText },
   { to: '/board', label: 'Board', icon: Gavel },
+  { to: '/intelligence', label: 'Intelligence', icon: Lightbulb },
   { to: '/voice', label: 'Voice', icon: Mic },
 ];
 

--- a/packages/web/src/components/SkillHistoryCard.tsx
+++ b/packages/web/src/components/SkillHistoryCard.tsx
@@ -1,0 +1,313 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronDown, ChevronRight, Play, History, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn, formatRelativeTime } from '@/lib/utils';
+import type { IntelligenceEntry } from '@/lib/api';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SkillHistoryCardProps {
+  /** Display title, e.g. "Connections" or "Drift Monitor" */
+  title: string;
+  /** Short description shown below the title */
+  description: string;
+  /** Icon rendered next to the title */
+  icon: React.ReactNode;
+  /** Skill identifier used for the trigger call */
+  skillName: 'daily-connections' | 'drift-monitor';
+  /** Most recent entry (from summary or latest endpoint). May be null before first run. */
+  latestEntry: IntelligenceEntry | null;
+  /** Function that fetches history entries on demand */
+  fetchHistory: (limit?: number) => Promise<{ data: IntelligenceEntry[] }>;
+  /** Function that triggers a new skill run */
+  onTrigger: (skill: 'daily-connections' | 'drift-monitor') => Promise<void>;
+  /** Whether a trigger is currently in-flight (managed by parent) */
+  triggering?: boolean;
+  /** Optional className on the root Card */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Status helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_STYLES: Record<string, { badge: string; icon: React.ReactNode }> = {
+  completed: {
+    badge: 'bg-green-100 text-green-700 border-green-200',
+    icon: <CheckCircle2 className="h-3 w-3 text-green-600" />,
+  },
+  failed: {
+    badge: 'bg-red-100 text-red-700 border-red-200',
+    icon: <XCircle className="h-3 w-3 text-red-600" />,
+  },
+  running: {
+    badge: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    icon: <Loader2 className="h-3 w-3 text-yellow-600 animate-spin" />,
+  },
+};
+
+function statusStyle(entry: IntelligenceEntry) {
+  // Infer status: if duration_ms exists the run completed; if output_summary is null it may have failed
+  if (entry.duration_ms != null && entry.output_summary) return STATUS_STYLES.completed;
+  if (entry.duration_ms != null && !entry.output_summary) return STATUS_STYLES.failed;
+  return STATUS_STYLES.running;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms == null) return '--';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Expandable history row
+// ---------------------------------------------------------------------------
+
+function HistoryRow({ entry }: { entry: IntelligenceEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const style = statusStyle(entry);
+
+  // Build a human-readable result preview from the JSONB result
+  const resultPreview = entry.result ? buildResultPreview(entry.result) : null;
+
+  return (
+    <div className="border-b last:border-b-0">
+      <button
+        className="flex w-full items-center gap-2 px-1 py-2 text-left hover:bg-accent/50 transition-colors rounded-sm"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span className="shrink-0 text-muted-foreground">
+          {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        </span>
+        <span className="shrink-0">{style.icon}</span>
+        <span className="flex-1 min-w-0 text-xs truncate text-muted-foreground">
+          {formatRelativeTime(entry.created_at)}
+        </span>
+        <Badge variant="outline" className={cn('text-[10px] border', style.badge)}>
+          {formatDuration(entry.duration_ms)}
+        </Badge>
+      </button>
+
+      {expanded && (
+        <div className="pl-8 pr-2 pb-3 space-y-2">
+          {/* Output summary */}
+          {entry.output_summary && (
+            <p className="text-sm leading-relaxed">{entry.output_summary}</p>
+          )}
+
+          {/* Structured result details */}
+          {resultPreview && resultPreview.length > 0 && (
+            <div className="space-y-1.5">
+              {resultPreview.map((item, i) => (
+                <div key={i} className="rounded-md bg-accent/40 px-2.5 py-1.5">
+                  {item.label && (
+                    <p className="text-xs font-medium mb-0.5">{item.label}</p>
+                  )}
+                  <p className="text-xs text-muted-foreground">{item.text}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Fallback: raw JSON for anything not covered by preview */}
+          {!entry.output_summary && !resultPreview && entry.result && (
+            <pre className="rounded-md bg-accent/40 p-2 text-[11px] overflow-x-auto max-h-48 text-muted-foreground">
+              {JSON.stringify(entry.result, null, 2)}
+            </pre>
+          )}
+
+          {/* Meta line */}
+          <div className="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+            <span>{new Date(entry.created_at).toLocaleString()}</span>
+            {entry.capture_id && <span>capture: {entry.capture_id.slice(0, 8)}</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result preview builder — extracts structured items from JSONB result
+// ---------------------------------------------------------------------------
+
+interface PreviewItem {
+  label?: string;
+  text: string;
+}
+
+function buildResultPreview(result: Record<string, unknown>): PreviewItem[] | null {
+  const items: PreviewItem[] = [];
+
+  // daily-connections: result.connections is an array of { theme, insight, confidence }
+  if (Array.isArray(result.connections)) {
+    for (const conn of result.connections as Array<{ theme?: string; insight?: string; confidence?: number }>) {
+      const label = conn.theme
+        ? `${conn.theme}${conn.confidence != null ? ` (${Math.round(conn.confidence * 100)}%)` : ''}`
+        : undefined;
+      if (conn.insight) {
+        items.push({ label, text: conn.insight });
+      }
+    }
+  }
+
+  // drift-monitor: result.drift_items is an array of { item, severity, suggested_action }
+  if (Array.isArray(result.drift_items)) {
+    for (const d of result.drift_items as Array<{ item?: string; severity?: string; suggested_action?: string }>) {
+      const severityTag = d.severity ? `[${d.severity}]` : '';
+      const label = d.item ? `${severityTag} ${d.item}`.trim() : severityTag || undefined;
+      if (d.suggested_action) {
+        items.push({ label, text: d.suggested_action });
+      }
+    }
+  }
+
+  // Generic: if result has a "summary" string
+  if (typeof result.summary === 'string' && items.length === 0) {
+    items.push({ text: result.summary });
+  }
+
+  return items.length > 0 ? items : null;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function SkillHistoryCard({
+  title,
+  description,
+  icon,
+  skillName,
+  latestEntry,
+  fetchHistory,
+  onTrigger,
+  triggering = false,
+  className,
+}: SkillHistoryCardProps) {
+  const [showHistory, setShowHistory] = useState(false);
+  const [history, setHistory] = useState<IntelligenceEntry[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+
+  const loadHistory = useCallback(async () => {
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      const res = await fetchHistory(20);
+      setHistory(res.data);
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : 'Failed to load history');
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, [fetchHistory]);
+
+  // Fetch history when the panel is opened
+  useEffect(() => {
+    if (showHistory && history.length === 0 && !historyLoading) {
+      loadHistory();
+    }
+  }, [showHistory, history.length, historyLoading, loadHistory]);
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {icon}
+            <CardTitle className="text-lg">{title}</CardTitle>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onTrigger(skillName)}
+            disabled={triggering}
+            className="gap-1.5 text-xs"
+          >
+            {triggering ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Play className="h-3 w-3" />
+            )}
+            {triggering ? 'Queuing...' : 'Run'}
+          </Button>
+        </div>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        {/* Latest entry */}
+        {latestEntry ? (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Badge variant="default" className="text-xs">
+                {latestEntry.duration_ms
+                  ? `${(latestEntry.duration_ms / 1000).toFixed(1)}s`
+                  : 'completed'}
+              </Badge>
+              <span>{formatRelativeTime(latestEntry.created_at)}</span>
+            </div>
+            {latestEntry.output_summary && (
+              <p className="text-sm line-clamp-4">{latestEntry.output_summary}</p>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+            <p className="text-sm">No analysis yet.</p>
+            <p className="text-xs mt-1">Click "Run" to generate your first analysis.</p>
+          </div>
+        )}
+
+        {/* History toggle */}
+        <div className="mt-3 pt-2 border-t">
+          <button
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors w-full"
+            onClick={() => setShowHistory((v) => !v)}
+          >
+            <History className="h-3.5 w-3.5" />
+            <span>{showHistory ? 'Hide history' : 'Show run history'}</span>
+            <span className="ml-auto">
+              {showHistory ? (
+                <ChevronDown className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5" />
+              )}
+            </span>
+          </button>
+
+          {showHistory && (
+            <div className="mt-2">
+              {historyLoading && (
+                <div className="flex items-center gap-2 justify-center py-4 text-xs text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Loading history...
+                </div>
+              )}
+
+              {historyError && (
+                <div className="text-xs text-destructive py-2">{historyError}</div>
+              )}
+
+              {!historyLoading && !historyError && history.length === 0 && (
+                <p className="text-xs text-muted-foreground py-2 text-center">No runs recorded yet.</p>
+              )}
+
+              {!historyLoading && history.length > 0 && (
+                <div className="max-h-80 overflow-y-auto">
+                  {history.map((entry) => (
+                    <HistoryRow key={entry.id} entry={entry} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/components/__tests__/ConnectionsCard.test.tsx
+++ b/packages/web/src/components/__tests__/ConnectionsCard.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ConnectionsCard from '../ConnectionsCard'
+import type { IntelligenceEntry } from '@/lib/api'
+
+function makeEntry(overrides: Partial<IntelligenceEntry> = {}): IntelligenceEntry {
+  return {
+    id: 'entry-1',
+    skill_name: 'daily-connections',
+    capture_id: null,
+    input_summary: null,
+    output_summary: 'Found 3 connections across captures',
+    result: null,
+    duration_ms: 5200,
+    created_at: '2026-03-10T21:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ConnectionsCard', () => {
+  // ---------- structured connections rendering ----------
+
+  it('renders structured connections with theme, insight, and confidence', () => {
+    const entry = makeEntry({
+      result: {
+        summary: 'Cross-domain patterns detected',
+        connections: [
+          {
+            theme: 'AI + Operations',
+            captures: ['cap-1', 'cap-2'],
+            insight: 'LLM orchestration mirrors supply chain routing',
+            confidence: 'high',
+            domains: ['technical', 'client'],
+          },
+          {
+            theme: 'Career Leverage',
+            captures: ['cap-3'],
+            insight: 'Consulting frameworks apply to AI product pitches',
+            confidence: 'medium',
+            domains: ['career'],
+          },
+        ],
+        meta_pattern: 'Systems-thinking thread across all domains',
+      },
+    })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    // Summary text
+    expect(screen.getByText('Cross-domain patterns detected')).toBeInTheDocument()
+
+    // Connection themes
+    expect(screen.getByText('AI + Operations')).toBeInTheDocument()
+    expect(screen.getByText('Career Leverage')).toBeInTheDocument()
+
+    // Insights
+    expect(screen.getByText('LLM orchestration mirrors supply chain routing')).toBeInTheDocument()
+    expect(screen.getByText('Consulting frameworks apply to AI product pitches')).toBeInTheDocument()
+
+    // Confidence badges
+    expect(screen.getByText('high')).toBeInTheDocument()
+    expect(screen.getByText('medium')).toBeInTheDocument()
+
+    // Domain badges
+    expect(screen.getByText('technical')).toBeInTheDocument()
+    expect(screen.getByText('client')).toBeInTheDocument()
+    expect(screen.getByText('career')).toBeInTheDocument()
+
+    // Cross-domain indicator (for connection with 2+ domains)
+    expect(screen.getByText('cross-domain')).toBeInTheDocument()
+
+    // Related captures count
+    expect(screen.getByText('2 related captures')).toBeInTheDocument()
+    expect(screen.getByText('1 related capture')).toBeInTheDocument()
+
+    // Meta-pattern
+    expect(screen.getByText('Meta-pattern')).toBeInTheDocument()
+    expect(screen.getByText('Systems-thinking thread across all domains')).toBeInTheDocument()
+  })
+
+  // ---------- empty state ----------
+
+  it('shows empty state when result is null', () => {
+    const entry = makeEntry({ result: null, output_summary: null })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    expect(screen.getByText('No structured connections data available.')).toBeInTheDocument()
+  })
+
+  it('shows output_summary fallback when result is null but output_summary exists', () => {
+    const entry = makeEntry({ result: null, output_summary: 'Some text summary' })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    expect(screen.getByText('Some text summary')).toBeInTheDocument()
+    // Should NOT show the generic empty message
+    expect(screen.queryByText('No structured connections data available.')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when connections array is empty', () => {
+    const entry = makeEntry({
+      result: { summary: '', connections: [], meta_pattern: null },
+      output_summary: null,
+    })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    expect(screen.getByText('No structured connections data available.')).toBeInTheDocument()
+  })
+
+  // ---------- missing / malformed result data ----------
+
+  it('handles result with no connections key', () => {
+    const entry = makeEntry({
+      result: { summary: 'Something', meta_pattern: null },
+      output_summary: null,
+    })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    // No connections → falls through to empty state
+    expect(screen.getByText('No structured connections data available.')).toBeInTheDocument()
+  })
+
+  it('handles connection items with missing fields gracefully', () => {
+    const entry = makeEntry({
+      result: {
+        summary: 'Partial data',
+        connections: [
+          {
+            // theme, captures, insight, confidence, domains all missing
+          },
+        ],
+        meta_pattern: null,
+      },
+    })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    // Defaults applied: theme → '(unnamed)', confidence → 'low'
+    expect(screen.getByText('(unnamed)')).toBeInTheDocument()
+    expect(screen.getByText('low')).toBeInTheDocument()
+  })
+
+  it('handles non-object result gracefully', () => {
+    const entry = makeEntry({
+      result: 'just a string' as unknown as Record<string, unknown>,
+      output_summary: null,
+    })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    expect(screen.getByText('No structured connections data available.')).toBeInTheDocument()
+  })
+
+  // ---------- no meta_pattern ----------
+
+  it('does not render meta-pattern section when null', () => {
+    const entry = makeEntry({
+      result: {
+        summary: 'Summary here',
+        connections: [
+          {
+            theme: 'Theme A',
+            captures: [],
+            insight: 'Insight A',
+            confidence: 'low',
+            domains: [],
+          },
+        ],
+        meta_pattern: null,
+      },
+    })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    expect(screen.queryByText('Meta-pattern')).not.toBeInTheDocument()
+  })
+
+  // ---------- single domain (no cross-domain badge) ----------
+
+  it('does not render cross-domain badge for single-domain connection', () => {
+    const entry = makeEntry({
+      result: {
+        summary: '',
+        connections: [
+          {
+            theme: 'Focused',
+            captures: [],
+            insight: 'Single domain insight',
+            confidence: 'high',
+            domains: ['technical'],
+          },
+        ],
+        meta_pattern: null,
+      },
+    })
+
+    render(<ConnectionsCard entry={entry} />)
+
+    expect(screen.getByText('technical')).toBeInTheDocument()
+    expect(screen.queryByText('cross-domain')).not.toBeInTheDocument()
+  })
+})

--- a/packages/web/src/components/__tests__/DriftCard.test.tsx
+++ b/packages/web/src/components/__tests__/DriftCard.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import DriftCard from '../DriftCard'
+import type { IntelligenceEntry } from '@/lib/api'
+
+function makeEntry(overrides: Partial<IntelligenceEntry> = {}): IntelligenceEntry {
+  return {
+    id: 'drift-1',
+    skill_name: 'drift-monitor',
+    capture_id: null,
+    input_summary: null,
+    output_summary: 'Drift analysis complete',
+    result: null,
+    duration_ms: 3400,
+    created_at: '2026-03-10T08:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('DriftCard', () => {
+  // ---------- severity badges ----------
+
+  it('renders severity badges correctly for each drift item', () => {
+    const entry = makeEntry({
+      result: {
+        summary: 'Found 3 items drifting',
+        drift_items: [
+          {
+            item_type: 'bet',
+            item_name: 'AI adoption bet',
+            severity: 'high',
+            days_silent: 14,
+            reason: 'No captures mentioning this bet in 2 weeks',
+            suggested_action: 'Review bet status',
+          },
+          {
+            item_type: 'commitment',
+            item_name: 'Weekly governance session',
+            severity: 'medium',
+            days_silent: 7,
+            reason: 'Missed last session',
+            suggested_action: 'Schedule catch-up',
+          },
+          {
+            item_type: 'entity',
+            item_name: 'Kubernetes',
+            severity: 'low',
+            days_silent: 3,
+            reason: 'Slight decline in mentions',
+            suggested_action: 'Monitor',
+          },
+        ],
+        overall_health: 'significant_drift',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    // Severity badges
+    expect(screen.getByText('high')).toBeInTheDocument()
+    expect(screen.getByText('medium')).toBeInTheDocument()
+    expect(screen.getByText('low')).toBeInTheDocument()
+
+    // Item names
+    expect(screen.getByText('AI adoption bet')).toBeInTheDocument()
+    expect(screen.getByText('Weekly governance session')).toBeInTheDocument()
+    expect(screen.getByText('Kubernetes')).toBeInTheDocument()
+
+    // Item type badges
+    expect(screen.getByText('Bet')).toBeInTheDocument()
+    expect(screen.getByText('Commitment')).toBeInTheDocument()
+    expect(screen.getByText('Entity')).toBeInTheDocument()
+
+    // Days silent
+    expect(screen.getByText('14d silent')).toBeInTheDocument()
+    expect(screen.getByText('7d silent')).toBeInTheDocument()
+    expect(screen.getByText('3d silent')).toBeInTheDocument()
+
+    // Reasons
+    expect(screen.getByText('No captures mentioning this bet in 2 weeks')).toBeInTheDocument()
+
+    // Suggested actions
+    expect(screen.getByText(/Review bet status/)).toBeInTheDocument()
+    expect(screen.getByText(/Schedule catch-up/)).toBeInTheDocument()
+  })
+
+  // ---------- health score rendering ----------
+
+  it('renders overall health score badge', () => {
+    const entry = makeEntry({
+      result: {
+        summary: 'All clear',
+        drift_items: [],
+        overall_health: 'healthy',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText('Healthy')).toBeInTheDocument()
+  })
+
+  it.each([
+    ['minor_drift', 'Minor Drift'],
+    ['significant_drift', 'Significant Drift'],
+    ['critical_drift', 'Critical Drift'],
+    ['healthy', 'Healthy'],
+  ] as const)('renders health label "%s" as "%s"', (health, label) => {
+    const entry = makeEntry({
+      result: {
+        summary: '',
+        drift_items: [],
+        overall_health: health,
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  // ---------- empty state (no drift items) ----------
+
+  it('shows no-drift message when drift_items is empty', () => {
+    const entry = makeEntry({
+      result: {
+        summary: 'Everything looks good',
+        drift_items: [],
+        overall_health: 'healthy',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(
+      screen.getByText('No drift items detected — all tracked items are active.'),
+    ).toBeInTheDocument()
+  })
+
+  // ---------- null / missing result ----------
+
+  it('shows empty state when result is null', () => {
+    const entry = makeEntry({ result: null, output_summary: null })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText('No structured drift data available.')).toBeInTheDocument()
+  })
+
+  it('shows output_summary fallback when result is null but output_summary exists', () => {
+    const entry = makeEntry({ result: null, output_summary: 'Drift summary text' })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText('Drift summary text')).toBeInTheDocument()
+    expect(screen.queryByText('No structured drift data available.')).not.toBeInTheDocument()
+  })
+
+  // ---------- malformed result data ----------
+
+  it('handles drift items with missing fields gracefully', () => {
+    const entry = makeEntry({
+      result: {
+        summary: 'Partial',
+        drift_items: [
+          {
+            // All fields missing — parser applies defaults
+          },
+        ],
+        overall_health: 'minor_drift',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    // Defaults: item_name → '(unnamed)', severity → 'low', item_type → 'entity'
+    expect(screen.getByText('(unnamed)')).toBeInTheDocument()
+    expect(screen.getByText('low')).toBeInTheDocument()
+    expect(screen.getByText('Entity')).toBeInTheDocument()
+  })
+
+  it('handles unknown overall_health value by defaulting to healthy', () => {
+    const entry = makeEntry({
+      result: {
+        summary: '',
+        drift_items: [],
+        overall_health: 'unknown_value',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText('Healthy')).toBeInTheDocument()
+  })
+
+  it('handles non-object result gracefully', () => {
+    const entry = makeEntry({
+      result: 42 as unknown as Record<string, unknown>,
+      output_summary: null,
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText('No structured drift data available.')).toBeInTheDocument()
+  })
+
+  // ---------- items detected count ----------
+
+  it('renders item count text for multiple drift items', () => {
+    const entry = makeEntry({
+      result: {
+        summary: '',
+        drift_items: [
+          { item_type: 'bet', item_name: 'A', severity: 'high', days_silent: 10, reason: '', suggested_action: '' },
+          { item_type: 'bet', item_name: 'B', severity: 'medium', days_silent: 5, reason: '', suggested_action: '' },
+        ],
+        overall_health: 'significant_drift',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText('2 items detected')).toBeInTheDocument()
+  })
+
+  it('renders singular item count for single drift item', () => {
+    const entry = makeEntry({
+      result: {
+        summary: '',
+        drift_items: [
+          { item_type: 'entity', item_name: 'React', severity: 'low', days_silent: 2, reason: '', suggested_action: '' },
+        ],
+        overall_health: 'minor_drift',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.getByText('1 item detected')).toBeInTheDocument()
+  })
+
+  // ---------- days_silent = 0 is not shown ----------
+
+  it('does not render days silent when value is 0', () => {
+    const entry = makeEntry({
+      result: {
+        summary: '',
+        drift_items: [
+          { item_type: 'bet', item_name: 'Fresh bet', severity: 'low', days_silent: 0, reason: '', suggested_action: '' },
+        ],
+        overall_health: 'healthy',
+      },
+    })
+
+    render(<DriftCard entry={entry} />)
+
+    expect(screen.queryByText(/0d silent/)).not.toBeInTheDocument()
+  })
+})

--- a/packages/web/src/components/__tests__/SkillHistoryCard.test.tsx
+++ b/packages/web/src/components/__tests__/SkillHistoryCard.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SkillHistoryCard from '../SkillHistoryCard'
+import type { SkillHistoryCardProps } from '../SkillHistoryCard'
+import type { IntelligenceEntry } from '@/lib/api'
+
+// Stub EventSource so sse.ts module init doesn't throw
+class NoopEventSource {
+  addEventListener() {}
+  removeEventListener() {}
+  close() {}
+  onerror = null
+}
+vi.stubGlobal('EventSource', NoopEventSource)
+
+function makeEntry(overrides: Partial<IntelligenceEntry> = {}): IntelligenceEntry {
+  return {
+    id: 'log-1',
+    skill_name: 'daily-connections',
+    capture_id: 'cap-abc',
+    input_summary: null,
+    output_summary: 'Found 3 cross-domain patterns',
+    result: {
+      summary: 'Patterns detected',
+      connections: [{ theme: 'AI + Ops', insight: 'Great insight', confidence: 'high' }],
+    },
+    duration_ms: 5200,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function defaultProps(overrides: Partial<SkillHistoryCardProps> = {}): SkillHistoryCardProps {
+  return {
+    title: 'Connections',
+    description: 'Cross-domain patterns',
+    icon: <span data-testid="icon">icon</span>,
+    skillName: 'daily-connections',
+    latestEntry: makeEntry(),
+    fetchHistory: vi.fn().mockResolvedValue({ data: [] }),
+    onTrigger: vi.fn().mockResolvedValue(undefined),
+    triggering: false,
+    ...overrides,
+  }
+}
+
+describe('SkillHistoryCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ---------- renders latest entry ----------
+
+  it('renders title, description, and latest entry summary', () => {
+    render(<SkillHistoryCard {...defaultProps()} />)
+
+    expect(screen.getByText('Connections')).toBeInTheDocument()
+    expect(screen.getByText('Cross-domain patterns')).toBeInTheDocument()
+    expect(screen.getByText('Found 3 cross-domain patterns')).toBeInTheDocument()
+  })
+
+  it('renders duration badge for latest entry', () => {
+    render(<SkillHistoryCard {...defaultProps()} />)
+
+    // duration_ms 5200 → "5.2s"
+    expect(screen.getByText('5.2s')).toBeInTheDocument()
+  })
+
+  it('renders "completed" when duration_ms is null', () => {
+    const entry = makeEntry({ duration_ms: null })
+    render(<SkillHistoryCard {...defaultProps({ latestEntry: entry })} />)
+
+    expect(screen.getByText('completed')).toBeInTheDocument()
+  })
+
+  // ---------- empty state (no latestEntry) ----------
+
+  it('shows empty state when latestEntry is null', () => {
+    render(<SkillHistoryCard {...defaultProps({ latestEntry: null })} />)
+
+    expect(screen.getByText('No analysis yet.')).toBeInTheDocument()
+    expect(screen.getByText('Click "Run" to generate your first analysis.')).toBeInTheDocument()
+  })
+
+  // ---------- trigger button ----------
+
+  it('renders Run button that calls onTrigger with skillName', async () => {
+    const user = userEvent.setup()
+    const onTrigger = vi.fn().mockResolvedValue(undefined)
+
+    render(<SkillHistoryCard {...defaultProps({ onTrigger })} />)
+
+    // The Run button text is exactly "Run" — use getAllByRole and pick the first
+    // (the second button with "run" in name is "Show run history")
+    const runButtons = screen.getAllByRole('button', { name: /run/i })
+    const button = runButtons[0]
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveTextContent('Run')
+
+    await user.click(button)
+
+    expect(onTrigger).toHaveBeenCalledOnce()
+    expect(onTrigger).toHaveBeenCalledWith('daily-connections')
+  })
+
+  it('disables trigger button and shows "Queuing..." when triggering', () => {
+    render(<SkillHistoryCard {...defaultProps({ triggering: true })} />)
+
+    const button = screen.getByRole('button', { name: /queuing/i })
+    expect(button).toBeDisabled()
+  })
+
+  // ---------- history panel ----------
+
+  it('shows "Show run history" button', () => {
+    render(<SkillHistoryCard {...defaultProps()} />)
+
+    expect(screen.getByText('Show run history')).toBeInTheDocument()
+  })
+
+  it('expands history panel and fetches history on click', async () => {
+    const user = userEvent.setup()
+    const historyEntries = [
+      makeEntry({ id: 'h1', output_summary: 'Run 1', duration_ms: 3000 }),
+      makeEntry({ id: 'h2', output_summary: 'Run 2', duration_ms: 4500 }),
+    ]
+    const fetchHistory = vi.fn().mockResolvedValue({ data: historyEntries })
+
+    render(<SkillHistoryCard {...defaultProps({ fetchHistory })} />)
+
+    const toggle = screen.getByText('Show run history')
+    await user.click(toggle)
+
+    // fetchHistory should be called
+    expect(fetchHistory).toHaveBeenCalledWith(20)
+
+    // After loading, history entries should be visible
+    await waitFor(() => {
+      expect(screen.getByText('Hide history')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty history message when no runs recorded', async () => {
+    const user = userEvent.setup()
+    const fetchHistory = vi.fn().mockResolvedValue({ data: [] })
+
+    render(<SkillHistoryCard {...defaultProps({ fetchHistory })} />)
+
+    await user.click(screen.getByText('Show run history'))
+
+    await waitFor(() => {
+      expect(screen.getByText('No runs recorded yet.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message when history fetch fails', async () => {
+    const user = userEvent.setup()
+    const fetchHistory = vi.fn().mockRejectedValue(new Error('Network error'))
+
+    render(<SkillHistoryCard {...defaultProps({ fetchHistory })} />)
+
+    await user.click(screen.getByText('Show run history'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+
+  // ---------- icon rendering ----------
+
+  it('renders the icon prop', () => {
+    render(<SkillHistoryCard {...defaultProps()} />)
+
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+  })
+})

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -230,6 +230,64 @@ export const pipelineApi = {
   },
 }
 
+// Intelligence API — daily-connections and drift-monitor skill results
+
+export interface IntelligenceEntry {
+  id: string
+  skill_name: string
+  capture_id: string | null
+  input_summary: string | null
+  output_summary: string | null
+  result: Record<string, unknown> | null
+  duration_ms: number | null
+  created_at: string
+}
+
+export interface IntelligenceSummary {
+  connections: IntelligenceEntry | null
+  drift: IntelligenceEntry | null
+}
+
+export const intelligenceApi = {
+  /** Fetch latest results for both daily-connections and drift-monitor in one call */
+  summary: () => {
+    return request<IntelligenceSummary>('/intelligence/summary')
+  },
+
+  /** Fetch latest daily-connections result */
+  connectionsLatest: () => {
+    return request<{ data: IntelligenceEntry | null }>('/intelligence/connections/latest')
+  },
+
+  /** Fetch daily-connections run history */
+  connectionsHistory: (limit?: number) => {
+    const qs = buildQueryString({ limit })
+    return request<{ data: IntelligenceEntry[] }>(`/intelligence/connections/history${qs}`)
+  },
+
+  /** Fetch latest drift-monitor result */
+  driftLatest: () => {
+    return request<{ data: IntelligenceEntry | null }>('/intelligence/drift/latest')
+  },
+
+  /** Fetch drift-monitor run history */
+  driftHistory: (limit?: number) => {
+    const qs = buildQueryString({ limit })
+    return request<{ data: IntelligenceEntry[] }>(`/intelligence/drift/history${qs}`)
+  },
+
+  /** Manually trigger an intelligence skill */
+  trigger: (skill: 'daily-connections' | 'drift-monitor', overrides?: Record<string, unknown>) => {
+    return request<{ skill: string; job_id: string; status: string; message: string }>(
+      `/intelligence/${skill}/trigger`,
+      {
+        method: 'POST',
+        body: JSON.stringify(overrides ?? {}),
+      },
+    )
+  },
+}
+
 // Bets API — API uses statement/confidence/resolution; web uses description/status/due_date
 
 interface RawBetRecord {

--- a/packages/web/src/pages/Intelligence.tsx
+++ b/packages/web/src/pages/Intelligence.tsx
@@ -1,0 +1,223 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, AlertCircle, Lightbulb, TrendingDown, Play } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { intelligenceApi } from '@/lib/api';
+import type { IntelligenceSummary } from '@/lib/api';
+
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export default function Intelligence() {
+  const [summary, setSummary] = useState<IntelligenceSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [triggeringSkill, setTriggeringSkill] = useState<string | null>(null);
+  const [triggerMsg, setTriggerMsg] = useState<string | null>(null);
+
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    setError(null);
+    try {
+      const data = await intelligenceApi.summary();
+      setSummary(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load intelligence data');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    load(true);
+  }
+
+  async function handleTrigger(skill: 'daily-connections' | 'drift-monitor') {
+    setTriggeringSkill(skill);
+    setTriggerMsg(null);
+    try {
+      await intelligenceApi.trigger(skill);
+      const label = skill === 'daily-connections' ? 'Connections analysis' : 'Drift monitor';
+      setTriggerMsg(`${label} queued -- check back in a few minutes.`);
+      setTimeout(() => setTriggerMsg(null), 8000);
+    } catch (err) {
+      setTriggerMsg(err instanceof Error ? err.message : 'Trigger failed');
+    } finally {
+      setTriggeringSkill(null);
+    }
+  }
+
+  // Loading skeleton
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">Intelligence</h1>
+        <div className="animate-pulse space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            {[...Array(2)].map((_, i) => (
+              <div key={i} className="h-48 rounded-lg bg-secondary" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const connectionsEntry = summary?.connections ?? null;
+  const driftEntry = summary?.drift ?? null;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Intelligence</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Daily connections and drift monitoring insights
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing} className="gap-2">
+          <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Trigger feedback */}
+      {triggerMsg && (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
+          {triggerMsg}
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <Separator />
+
+      {/* Intelligence cards grid */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {/* Connections card */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Lightbulb className="h-5 w-5 text-amber-500" />
+                <CardTitle className="text-lg">Connections</CardTitle>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleTrigger('daily-connections')}
+                disabled={triggeringSkill === 'daily-connections'}
+                className="gap-1.5 text-xs"
+              >
+                <Play className="h-3 w-3" />
+                {triggeringSkill === 'daily-connections' ? 'Queuing...' : 'Run'}
+              </Button>
+            </div>
+            <CardDescription>
+              Cross-domain patterns across recent captures
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {connectionsEntry ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Badge variant="default" className="text-xs">
+                    {connectionsEntry.duration_ms
+                      ? `${(connectionsEntry.duration_ms / 1000).toFixed(1)}s`
+                      : 'completed'}
+                  </Badge>
+                  <span>{formatRelativeTime(connectionsEntry.created_at)}</span>
+                </div>
+                {connectionsEntry.output_summary && (
+                  <p className="text-sm line-clamp-4">{connectionsEntry.output_summary}</p>
+                )}
+                {/* Placeholder: 19.3 will render structured result cards here */}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+                <p className="text-sm">No connections analysis yet.</p>
+                <p className="text-xs mt-1">Click "Run" to generate your first analysis.</p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Drift card */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <TrendingDown className="h-5 w-5 text-red-500" />
+                <CardTitle className="text-lg">Drift Monitor</CardTitle>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleTrigger('drift-monitor')}
+                disabled={triggeringSkill === 'drift-monitor'}
+                className="gap-1.5 text-xs"
+              >
+                <Play className="h-3 w-3" />
+                {triggeringSkill === 'drift-monitor' ? 'Queuing...' : 'Run'}
+              </Button>
+            </div>
+            <CardDescription>
+              Silent bets, declining entities, stale commitments
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {driftEntry ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Badge variant="default" className="text-xs">
+                    {driftEntry.duration_ms
+                      ? `${(driftEntry.duration_ms / 1000).toFixed(1)}s`
+                      : 'completed'}
+                  </Badge>
+                  <span>{formatRelativeTime(driftEntry.created_at)}</span>
+                </div>
+                {driftEntry.output_summary && (
+                  <p className="text-sm line-clamp-4">{driftEntry.output_summary}</p>
+                )}
+                {/* Placeholder: 19.3 will render structured drift items here */}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
+                <p className="text-sm">No drift analysis yet.</p>
+                <p className="text-xs mt-1">Click "Run" to check for drifting items.</p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/Intelligence.tsx
+++ b/packages/web/src/pages/Intelligence.tsx
@@ -6,6 +6,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Separator } from '@/components/ui/separator';
 import { intelligenceApi } from '@/lib/api';
 import type { IntelligenceSummary } from '@/lib/api';
+import ConnectionsCard from '@/components/ConnectionsCard';
+import DriftCard from '@/components/DriftCard';
 
 function formatRelativeTime(iso: string): string {
   const date = new Date(iso);
@@ -156,10 +158,7 @@ export default function Intelligence() {
                   </Badge>
                   <span>{formatRelativeTime(connectionsEntry.created_at)}</span>
                 </div>
-                {connectionsEntry.output_summary && (
-                  <p className="text-sm line-clamp-4">{connectionsEntry.output_summary}</p>
-                )}
-                {/* Placeholder: 19.3 will render structured result cards here */}
+                <ConnectionsCard entry={connectionsEntry} />
               </div>
             ) : (
               <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">
@@ -204,10 +203,7 @@ export default function Intelligence() {
                   </Badge>
                   <span>{formatRelativeTime(driftEntry.created_at)}</span>
                 </div>
-                {driftEntry.output_summary && (
-                  <p className="text-sm line-clamp-4">{driftEntry.output_summary}</p>
-                )}
-                {/* Placeholder: 19.3 will render structured drift items here */}
+                <DriftCard entry={driftEntry} />
               </div>
             ) : (
               <div className="rounded-lg border border-dashed p-6 text-center text-muted-foreground">

--- a/packages/web/src/pages/__tests__/Intelligence.test.tsx
+++ b/packages/web/src/pages/__tests__/Intelligence.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+// Mock the API module before importing Intelligence
+vi.mock('../../lib/api', () => ({
+  intelligenceApi: {
+    summary: vi.fn(),
+    connectionsHistory: vi.fn(),
+    driftHistory: vi.fn(),
+    trigger: vi.fn(),
+  },
+}))
+
+// Stub global EventSource so sse.ts module initialisation doesn't throw
+class NoopEventSource {
+  addEventListener() {}
+  removeEventListener() {}
+  close() {}
+  onerror = null
+}
+vi.stubGlobal('EventSource', NoopEventSource)
+
+import Intelligence from '../Intelligence'
+import { intelligenceApi } from '../../lib/api'
+
+function renderIntelligence() {
+  return render(
+    <MemoryRouter>
+      <Intelligence />
+    </MemoryRouter>,
+  )
+}
+
+const mockConnectionsEntry = {
+  id: 'conn-1',
+  skill_name: 'daily-connections',
+  capture_id: 'cap-1',
+  input_summary: null,
+  output_summary: 'Found 3 cross-domain patterns',
+  result: {
+    summary: 'Cross-domain patterns detected',
+    connections: [
+      {
+        theme: 'AI + Operations',
+        captures: ['c1', 'c2'],
+        insight: 'Supply chain parallels',
+        confidence: 'high',
+        domains: ['technical', 'client'],
+      },
+    ],
+    meta_pattern: null,
+  },
+  duration_ms: 5200,
+  created_at: '2026-03-10T21:00:00Z',
+}
+
+const mockDriftEntry = {
+  id: 'drift-1',
+  skill_name: 'drift-monitor',
+  capture_id: 'cap-2',
+  input_summary: null,
+  output_summary: 'No significant drift detected',
+  result: {
+    summary: 'All clear',
+    drift_items: [],
+    overall_health: 'healthy',
+  },
+  duration_ms: 3400,
+  created_at: '2026-03-10T08:00:00Z',
+}
+
+describe('Intelligence page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ---------- renders both cards ----------
+
+  it('renders both Connections and Drift Monitor sections with data', async () => {
+    vi.mocked(intelligenceApi.summary).mockResolvedValue({
+      connections: mockConnectionsEntry,
+      drift: mockDriftEntry,
+    })
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByText('Connections')).toBeInTheDocument()
+      expect(screen.getByText('Drift Monitor')).toBeInTheDocument()
+    })
+
+    // Connections card content renders
+    expect(screen.getByText('Cross-domain patterns detected')).toBeInTheDocument()
+
+    // Drift card content renders
+    expect(screen.getByText('Healthy')).toBeInTheDocument()
+  })
+
+  // ---------- loading state ----------
+
+  it('renders loading skeleton initially', () => {
+    // Never resolve the promise to keep in loading state
+    vi.mocked(intelligenceApi.summary).mockReturnValue(new Promise(() => {}))
+
+    renderIntelligence()
+
+    // Title should be visible even during loading
+    expect(screen.getByText('Intelligence')).toBeInTheDocument()
+  })
+
+  // ---------- error state ----------
+
+  it('renders error message when API fails', async () => {
+    vi.mocked(intelligenceApi.summary).mockRejectedValue(new Error('API 500: Internal Server Error'))
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByText('API 500: Internal Server Error')).toBeInTheDocument()
+    })
+  })
+
+  it('renders generic error for non-Error throws', async () => {
+    vi.mocked(intelligenceApi.summary).mockRejectedValue('kaboom')
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load intelligence data')).toBeInTheDocument()
+    })
+  })
+
+  // ---------- empty states (no data yet) ----------
+
+  it('renders empty states when both connections and drift are null', async () => {
+    vi.mocked(intelligenceApi.summary).mockResolvedValue({
+      connections: null,
+      drift: null,
+    })
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByText('No connections analysis yet.')).toBeInTheDocument()
+      expect(screen.getByText('No drift analysis yet.')).toBeInTheDocument()
+    })
+  })
+
+  // ---------- page heading and description ----------
+
+  it('renders page heading and description after load', async () => {
+    vi.mocked(intelligenceApi.summary).mockResolvedValue({
+      connections: null,
+      drift: null,
+    })
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByText('Intelligence')).toBeInTheDocument()
+      expect(screen.getByText('Daily connections and drift monitoring insights')).toBeInTheDocument()
+    })
+  })
+
+  // ---------- Refresh button ----------
+
+  it('renders Refresh button', async () => {
+    vi.mocked(intelligenceApi.summary).mockResolvedValue({
+      connections: null,
+      drift: null,
+    })
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument()
+    })
+  })
+
+  // ---------- Run buttons ----------
+
+  it('renders Run buttons for both skills', async () => {
+    vi.mocked(intelligenceApi.summary).mockResolvedValue({
+      connections: mockConnectionsEntry,
+      drift: mockDriftEntry,
+    })
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      const runButtons = screen.getAllByRole('button', { name: /run/i })
+      // Two Run buttons (connections + drift)
+      expect(runButtons.length).toBe(2)
+    })
+  })
+
+  // ---------- partial data ----------
+
+  it('renders when only connections data available', async () => {
+    vi.mocked(intelligenceApi.summary).mockResolvedValue({
+      connections: mockConnectionsEntry,
+      drift: null,
+    })
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByText('Cross-domain patterns detected')).toBeInTheDocument()
+      expect(screen.getByText('No drift analysis yet.')).toBeInTheDocument()
+    })
+  })
+
+  it('renders when only drift data available', async () => {
+    vi.mocked(intelligenceApi.summary).mockResolvedValue({
+      connections: null,
+      drift: mockDriftEntry,
+    })
+
+    renderIntelligence()
+
+    await waitFor(() => {
+      expect(screen.getByText('No connections analysis yet.')).toBeInTheDocument()
+      expect(screen.getByText('Healthy')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/workers/src/__tests__/daily-connections.test.ts
+++ b/packages/workers/src/__tests__/daily-connections.test.ts
@@ -534,7 +534,7 @@ describe('DailyConnectionsSkill', () => {
         }),
       )
       // Verify message contains summary and connection themes
-      const sendCall = (pushover.send as MockInstance).mock.calls[0][0]
+      const sendCall = (pushover.send as unknown as MockInstance).mock.calls[0][0]
       expect(sendCall.message).toContain(SAMPLE_CONNECTIONS_OUTPUT.summary)
       expect(sendCall.message).toContain('Client-Infrastructure Convergence')
     })

--- a/packages/workers/src/__tests__/daily-connections.test.ts
+++ b/packages/workers/src/__tests__/daily-connections.test.ts
@@ -1,0 +1,727 @@
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest'
+import { join } from 'node:path'
+import { DailyConnectionsSkill, parseOutput } from '../skills/daily-connections.js'
+import type { DailyConnectionsOutput } from '../skills/daily-connections.js'
+import {
+  queryRecentCaptures,
+  buildEntityCoOccurrence,
+  assembleContext,
+  formatCoOccurrence,
+  fmtDate,
+  formatCapture,
+  CHARS_PER_TOKEN,
+  DEFAULT_TOKEN_BUDGET,
+  VIEW_ORDER,
+} from '../skills/daily-connections-query.js'
+import type { EntityCoOccurrence } from '../skills/daily-connections-query.js'
+import type { CaptureRecord } from '@open-brain/shared'
+import { PushoverService } from '../services/pushover.js'
+
+// Prompt templates live at <repo-root>/config/prompts/
+const REPO_PROMPTS_DIR = join(import.meta.dirname, '..', '..', '..', '..', 'config', 'prompts')
+
+// ============================================================
+// Fixtures
+// ============================================================
+
+function makeCapture(overrides: Partial<CaptureRecord> = {}): CaptureRecord {
+  return {
+    id: 'cap-1',
+    content: 'Test capture content.',
+    capture_type: 'observation',
+    brain_view: 'technical',
+    source: 'api',
+    tags: [],
+    captured_at: new Date('2026-03-01T10:00:00Z'),
+    created_at: new Date('2026-03-01T10:00:00Z'),
+    updated_at: new Date('2026-03-01T10:00:00Z'),
+    content_hash: 'hash1',
+    pipeline_status: 'complete',
+    pipeline_attempts: 1,
+    ...overrides,
+  } as CaptureRecord
+}
+
+const SAMPLE_CAPTURES: CaptureRecord[] = [
+  makeCapture({
+    id: 'cap-1',
+    content: 'Closed the NovaBurger retainer — $8K/month starting April.',
+    capture_type: 'win',
+    brain_view: 'client',
+    tags: ['stratfield', 'revenue'],
+    captured_at: new Date('2026-03-01T10:00:00Z'),
+    content_hash: 'hash1',
+  }),
+  makeCapture({
+    id: 'cap-2',
+    content: 'QSR ops dashboard blocked — IT access request still pending.',
+    capture_type: 'blocker',
+    brain_view: 'work-internal',
+    tags: ['qsr', 'infrastructure'],
+    captured_at: new Date('2026-03-02T14:30:00Z'),
+    content_hash: 'hash2',
+  }),
+  makeCapture({
+    id: 'cap-3',
+    content: 'Voice pipeline end-to-end working — Apple Watch to Postgres.',
+    capture_type: 'win',
+    brain_view: 'technical',
+    tags: ['open-brain', 'voice'],
+    captured_at: new Date('2026-03-03T09:00:00Z'),
+    content_hash: 'hash3',
+  }),
+]
+
+const SAMPLE_CO_OCCURRENCE: EntityCoOccurrence[] = [
+  { entity_a_name: 'QSR Corp', entity_a_type: 'organization', entity_b_name: 'NovaBurger', entity_b_type: 'organization', co_occurrence_count: 5 },
+  { entity_a_name: 'Troy', entity_a_type: 'person', entity_b_name: 'Open Brain', entity_b_type: 'project', co_occurrence_count: 3 },
+]
+
+const SAMPLE_CONNECTIONS_OUTPUT: DailyConnectionsOutput = {
+  summary: 'Cross-domain pattern between QSR client work and technical infrastructure.',
+  connections: [
+    {
+      theme: 'Client-Infrastructure Convergence',
+      captures: ['cap-1', 'cap-2'],
+      insight: 'The QSR ops dashboard blocker mirrors a pattern in voice pipeline work — both require upstream API access.',
+      confidence: 'high',
+      domains: ['client', 'technical'],
+    },
+    {
+      theme: 'Revenue-Tech Alignment',
+      captures: ['cap-1', 'cap-3'],
+      insight: 'NovaBurger retainer success correlates with voice pipeline completion — both validate the AI-first approach.',
+      confidence: 'medium',
+      domains: ['client', 'technical'],
+    },
+  ],
+  meta_pattern: 'Infrastructure readiness is the gating factor across all domains.',
+}
+
+// ============================================================
+// Mock helpers
+// ============================================================
+
+function makeMockDb(captures = SAMPLE_CAPTURES, coOccurrence = SAMPLE_CO_OCCURRENCE) {
+  let callCount = 0
+  return {
+    execute: vi.fn().mockImplementation(() => {
+      callCount++
+      // First call: queryRecentCaptures, second call: buildEntityCoOccurrence
+      if (callCount === 1) return Promise.resolve({ rows: captures })
+      return Promise.resolve({ rows: coOccurrence })
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+  }
+}
+
+function makeMockOpenAI(jsonOutput: DailyConnectionsOutput = SAMPLE_CONNECTIONS_OUTPUT) {
+  return {
+    chat: {
+      completions: {
+        create: vi.fn().mockResolvedValue({
+          choices: [{ message: { content: JSON.stringify(jsonOutput) } }],
+          usage: { prompt_tokens: 600, completion_tokens: 300, total_tokens: 900 },
+        }),
+      },
+    },
+  }
+}
+
+function makePushoverService(configured = true) {
+  const svc = new PushoverService('fake-token', 'fake-user')
+  if (!configured) {
+    Object.defineProperty(svc, 'isConfigured', { get: () => false })
+  }
+  vi.spyOn(svc, 'send').mockResolvedValue(undefined)
+  return svc
+}
+
+function makeSkill(opts: {
+  captures?: CaptureRecord[]
+  coOccurrence?: EntityCoOccurrence[]
+  connectionsOutput?: DailyConnectionsOutput
+  pushoverConfigured?: boolean
+  promptsDir?: string
+  coreApiResponse?: { ok: boolean; json?: object; status?: number }
+} = {}) {
+  const db = makeMockDb(opts.captures ?? SAMPLE_CAPTURES, opts.coOccurrence ?? SAMPLE_CO_OCCURRENCE)
+  const mockLitellm = makeMockOpenAI(opts.connectionsOutput ?? SAMPLE_CONNECTIONS_OUTPUT)
+  const pushover = makePushoverService(opts.pushoverConfigured ?? true)
+
+  const fetchResponse = opts.coreApiResponse ?? { ok: true, json: { id: 'saved-cap-id' } }
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: fetchResponse.ok,
+    status: fetchResponse.status ?? (fetchResponse.ok ? 200 : 500),
+    json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
+    text: vi.fn().mockResolvedValue(''),
+  })
+
+  const skill = new DailyConnectionsSkill({
+    db: db as unknown as import('@open-brain/shared').Database,
+    promptsDir: opts.promptsDir ?? REPO_PROMPTS_DIR,
+    coreApiUrl: 'http://localhost:3000',
+    pushover,
+  })
+
+  // Replace internal litellmClient
+  // @ts-ignore — accessing private field for testing
+  skill.litellmClient = mockLitellm
+
+  // Replace global fetch
+  vi.stubGlobal('fetch', mockFetch)
+
+  return { skill, db, mockLitellm, pushover, mockFetch }
+}
+
+// ============================================================
+// Tests: parseOutput
+// ============================================================
+
+describe('parseOutput', () => {
+  it('parses valid JSON into DailyConnectionsOutput', () => {
+    const raw = JSON.stringify(SAMPLE_CONNECTIONS_OUTPUT)
+    const result = parseOutput(raw)
+    expect(result.summary).toBe(SAMPLE_CONNECTIONS_OUTPUT.summary)
+    expect(result.connections).toHaveLength(2)
+    expect(result.connections[0].theme).toBe('Client-Infrastructure Convergence')
+    expect(result.connections[0].confidence).toBe('high')
+    expect(result.meta_pattern).toBe(SAMPLE_CONNECTIONS_OUTPUT.meta_pattern)
+  })
+
+  it('strips markdown code fences before parsing', () => {
+    const raw = '```json\n' + JSON.stringify(SAMPLE_CONNECTIONS_OUTPUT) + '\n```'
+    const result = parseOutput(raw)
+    expect(result.summary).toBe(SAMPLE_CONNECTIONS_OUTPUT.summary)
+    expect(result.connections).toHaveLength(2)
+  })
+
+  it('strips code fences without language specifier', () => {
+    const raw = '```\n' + JSON.stringify(SAMPLE_CONNECTIONS_OUTPUT) + '\n```'
+    const result = parseOutput(raw)
+    expect(result.summary).toBe(SAMPLE_CONNECTIONS_OUTPUT.summary)
+  })
+
+  it('returns fallback for completely invalid JSON', () => {
+    const raw = 'This is not JSON at all, sorry.'
+    const result = parseOutput(raw)
+    expect(result.summary).toBe('This is not JSON at all, sorry.')
+    expect(result.connections).toEqual([])
+    expect(result.meta_pattern).toBeNull()
+  })
+
+  it('truncates raw text to 150 chars for fallback summary', () => {
+    const raw = 'A'.repeat(300)
+    const result = parseOutput(raw)
+    expect(result.summary).toHaveLength(150)
+  })
+
+  it('handles missing summary field gracefully', () => {
+    const raw = JSON.stringify({ connections: [], meta_pattern: null })
+    const result = parseOutput(raw)
+    expect(result.summary).toBe('(no summary)')
+  })
+
+  it('handles missing connections array gracefully', () => {
+    const raw = JSON.stringify({ summary: 'Test', meta_pattern: null })
+    const result = parseOutput(raw)
+    expect(result.connections).toEqual([])
+  })
+
+  it('handles missing meta_pattern gracefully', () => {
+    const raw = JSON.stringify({ summary: 'Test', connections: [] })
+    const result = parseOutput(raw)
+    expect(result.meta_pattern).toBeNull()
+  })
+
+  it('provides defaults for malformed connection items', () => {
+    const raw = JSON.stringify({
+      summary: 'Test',
+      connections: [
+        { theme: 42, captures: 'not-array', insight: null, confidence: 'bogus', domains: 'nope' },
+      ],
+      meta_pattern: null,
+    })
+    const result = parseOutput(raw)
+    expect(result.connections).toHaveLength(1)
+    expect(result.connections[0].theme).toBe('(unnamed)')
+    expect(result.connections[0].captures).toEqual([])
+    expect(result.connections[0].insight).toBe('')
+    expect(result.connections[0].confidence).toBe('low')
+    expect(result.connections[0].domains).toEqual([])
+  })
+
+  it('filters non-string items from captures and domains arrays', () => {
+    const raw = JSON.stringify({
+      summary: 'Test',
+      connections: [
+        { theme: 'T', captures: ['cap-1', 42, null, 'cap-2'], insight: 'I', confidence: 'high', domains: ['a', 123, 'b'] },
+      ],
+      meta_pattern: null,
+    })
+    const result = parseOutput(raw)
+    expect(result.connections[0].captures).toEqual(['cap-1', 'cap-2'])
+    expect(result.connections[0].domains).toEqual(['a', 'b'])
+  })
+
+  it('handles empty string input', () => {
+    const result = parseOutput('')
+    expect(result.connections).toEqual([])
+  })
+})
+
+// ============================================================
+// Tests: query module — fmtDate
+// ============================================================
+
+describe('fmtDate', () => {
+  it('formats a Date as YYYY-MM-DD', () => {
+    expect(fmtDate(new Date('2026-03-10T14:30:00Z'))).toBe('2026-03-10')
+  })
+
+  it('handles year boundaries', () => {
+    expect(fmtDate(new Date('2025-12-31T23:59:59Z'))).toBe('2025-12-31')
+  })
+})
+
+// ============================================================
+// Tests: query module — formatCapture
+// ============================================================
+
+describe('formatCapture', () => {
+  it('formats a capture with date, type, and content', () => {
+    const c = makeCapture({ capture_type: 'win', content: 'Shipped feature X' })
+    const result = formatCapture(c)
+    expect(result).toContain('[2026-03-01]')
+    expect(result).toContain('[win]')
+    expect(result).toContain('Shipped feature X')
+  })
+
+  it('includes tags when present', () => {
+    const c = makeCapture({ tags: ['alpha', 'beta'] })
+    const result = formatCapture(c)
+    expect(result).toContain('[alpha, beta]')
+  })
+
+  it('omits tag brackets when tags are empty', () => {
+    const c = makeCapture({ tags: [] })
+    const result = formatCapture(c)
+    expect(result).not.toContain('[]')
+  })
+
+  it('ends with a newline', () => {
+    const result = formatCapture(makeCapture())
+    expect(result.endsWith('\n')).toBe(true)
+  })
+})
+
+// ============================================================
+// Tests: query module — formatCoOccurrence
+// ============================================================
+
+describe('formatCoOccurrence', () => {
+  it('formats entity pairs as plain text', () => {
+    const result = formatCoOccurrence(SAMPLE_CO_OCCURRENCE)
+    expect(result).toContain('QSR Corp (organization) + NovaBurger (organization): 5 co-occurrences')
+    expect(result).toContain('Troy (person) + Open Brain (project): 3 co-occurrences')
+  })
+
+  it('returns placeholder text for empty pairs', () => {
+    const result = formatCoOccurrence([])
+    expect(result).toBe('(no entity co-occurrence data available)')
+  })
+})
+
+// ============================================================
+// Tests: query module — assembleContext
+// ============================================================
+
+describe('assembleContext', () => {
+  const MULTI_VIEW_CAPTURES: CaptureRecord[] = [
+    makeCapture({ id: 'c1', brain_view: 'career', content: 'Career capture', captured_at: new Date('2026-03-05'), content_hash: 'h1' }),
+    makeCapture({ id: 'c2', brain_view: 'career', content: 'Another career capture', captured_at: new Date('2026-03-04'), content_hash: 'h2' }),
+    makeCapture({ id: 'c3', brain_view: 'client', content: 'Client work capture', captured_at: new Date('2026-03-05'), content_hash: 'h3' }),
+    makeCapture({ id: 'c4', brain_view: 'technical', content: 'Technical capture', captured_at: new Date('2026-03-03'), content_hash: 'h4' }),
+    makeCapture({ id: 'c5', brain_view: 'personal', content: 'Personal note', captured_at: new Date('2026-03-02'), content_hash: 'h5' }),
+    makeCapture({ id: 'c6', brain_view: 'custom-view' as any, content: 'Custom view capture', captured_at: new Date('2026-03-01'), content_hash: 'h6' }),
+  ]
+
+  it('groups captures by brain_view with section headers', () => {
+    const { contextText } = assembleContext(MULTI_VIEW_CAPTURES, 100_000)
+    expect(contextText).toContain('=== CAREER')
+    expect(contextText).toContain('=== CLIENT')
+    expect(contextText).toContain('=== TECHNICAL')
+    expect(contextText).toContain('=== PERSONAL')
+  })
+
+  it('follows VIEW_ORDER for configured views', () => {
+    const { contextText } = assembleContext(MULTI_VIEW_CAPTURES, 100_000)
+    const careerIdx = contextText.indexOf('=== CAREER')
+    const clientIdx = contextText.indexOf('=== CLIENT')
+    const technicalIdx = contextText.indexOf('=== TECHNICAL')
+    const personalIdx = contextText.indexOf('=== PERSONAL')
+
+    expect(careerIdx).toBeLessThan(clientIdx)
+    expect(clientIdx).toBeLessThan(technicalIdx)
+    expect(technicalIdx).toBeLessThan(personalIdx)
+  })
+
+  it('places unknown views after configured views', () => {
+    const { contextText } = assembleContext(MULTI_VIEW_CAPTURES, 100_000)
+    const personalIdx = contextText.indexOf('=== PERSONAL')
+    const customIdx = contextText.indexOf('=== CUSTOM-VIEW')
+    expect(personalIdx).toBeLessThan(customIdx)
+  })
+
+  it('returns capturesByView with correct counts', () => {
+    const { capturesByView } = assembleContext(MULTI_VIEW_CAPTURES, 100_000)
+    expect(capturesByView['career']).toBe(2)
+    expect(capturesByView['client']).toBe(1)
+    expect(capturesByView['technical']).toBe(1)
+    expect(capturesByView['personal']).toBe(1)
+    expect(capturesByView['custom-view']).toBe(1)
+  })
+
+  it('includes capture count in section header', () => {
+    const { contextText } = assembleContext(MULTI_VIEW_CAPTURES, 100_000)
+    expect(contextText).toContain('=== CAREER (2 captures) ===')
+    expect(contextText).toContain('=== CLIENT (1 captures) ===')
+  })
+
+  it('truncates when maxChars is exceeded', () => {
+    const largeCaps = Array.from({ length: 50 }, (_, i) =>
+      makeCapture({ id: `c-${i}`, brain_view: 'technical', content: 'x'.repeat(200), content_hash: `h-${i}` }),
+    )
+    const { contextText } = assembleContext(largeCaps, 500)
+    const matches = contextText.match(/\[observation\]/g)
+    expect(matches).toBeTruthy()
+    expect(matches!.length).toBeLessThan(50)
+  })
+
+  it('returns empty contextText for empty captures', () => {
+    const { contextText, capturesByView } = assembleContext([], 100_000)
+    expect(contextText).toBe('')
+    expect(Object.keys(capturesByView)).toHaveLength(0)
+  })
+
+  it('handles captures with null brain_view as "unknown"', () => {
+    const cap = makeCapture({ brain_view: undefined as any })
+    const { contextText } = assembleContext([cap], 100_000)
+    expect(contextText).toContain('=== UNKNOWN')
+  })
+})
+
+// ============================================================
+// Tests: query module — queryRecentCaptures
+// ============================================================
+
+describe('queryRecentCaptures', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls db.execute and returns rows', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: SAMPLE_CAPTURES }) }
+    const result = await queryRecentCaptures(mockDb as any, 7)
+    expect(mockDb.execute).toHaveBeenCalledOnce()
+    expect(result).toEqual(SAMPLE_CAPTURES)
+  })
+
+  it('returns empty array when no captures found', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [] }) }
+    const result = await queryRecentCaptures(mockDb as any, 7)
+    expect(result).toEqual([])
+  })
+})
+
+// ============================================================
+// Tests: query module — buildEntityCoOccurrence
+// ============================================================
+
+describe('buildEntityCoOccurrence', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls db.execute and returns entity co-occurrence rows', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: SAMPLE_CO_OCCURRENCE }) }
+    const result = await buildEntityCoOccurrence(mockDb as any, ['cap-1', 'cap-2'])
+    expect(mockDb.execute).toHaveBeenCalledOnce()
+    expect(result).toEqual(SAMPLE_CO_OCCURRENCE)
+  })
+
+  it('returns empty array when captureIds is empty', async () => {
+    const mockDb = { execute: vi.fn() }
+    const result = await buildEntityCoOccurrence(mockDb as any, [])
+    expect(result).toEqual([])
+    expect(mockDb.execute).not.toHaveBeenCalled()
+  })
+
+  it('returns empty array on db error', async () => {
+    const mockDb = { execute: vi.fn().mockRejectedValue(new Error('relation does not exist')) }
+    const result = await buildEntityCoOccurrence(mockDb as any, ['cap-1'])
+    expect(result).toEqual([])
+  })
+
+  it('respects topN parameter', async () => {
+    const manyPairs = Array.from({ length: 20 }, (_, i) => ({
+      entity_a_name: `EntityA-${i}`,
+      entity_a_type: 'organization',
+      entity_b_name: `EntityB-${i}`,
+      entity_b_type: 'person',
+      co_occurrence_count: 20 - i,
+    }))
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: manyPairs.slice(0, 5) }) }
+    const result = await buildEntityCoOccurrence(mockDb as any, ['cap-1'], 5)
+    expect(result).toHaveLength(5)
+  })
+})
+
+// ============================================================
+// Tests: query module — constants
+// ============================================================
+
+describe('constants', () => {
+  it('VIEW_ORDER contains all 5 brain views', () => {
+    expect(VIEW_ORDER).toEqual(['career', 'work-internal', 'client', 'technical', 'personal'])
+  })
+
+  it('CHARS_PER_TOKEN is 4', () => {
+    expect(CHARS_PER_TOKEN).toBe(4)
+  })
+
+  it('DEFAULT_TOKEN_BUDGET is 30_000', () => {
+    expect(DEFAULT_TOKEN_BUDGET).toBe(30_000)
+  })
+})
+
+// ============================================================
+// Tests: DailyConnectionsSkill — execute happy path
+// ============================================================
+
+describe('DailyConnectionsSkill', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('execute — happy path', () => {
+    it('returns a DailyConnectionsResult with correct captureCount', async () => {
+      const { skill } = makeSkill()
+      const result = await skill.execute()
+
+      expect(result.captureCount).toBe(SAMPLE_CAPTURES.length)
+      expect(result.output.summary).toBe(SAMPLE_CONNECTIONS_OUTPUT.summary)
+      expect(result.output.connections).toHaveLength(2)
+      expect(result.durationMs).toBeGreaterThan(0)
+    })
+
+    it('returns savedCaptureId from Core API response', async () => {
+      const { skill } = makeSkill()
+      const result = await skill.execute()
+      expect(result.savedCaptureId).toBe('saved-cap-id')
+    })
+
+    it('sends Pushover notification with top 3 connections', async () => {
+      const { skill, pushover } = makeSkill()
+      await skill.execute()
+
+      expect(pushover.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Daily Connections',
+          priority: 0,
+        }),
+      )
+      // Verify message contains summary and connection themes
+      const sendCall = (pushover.send as MockInstance).mock.calls[0][0]
+      expect(sendCall.message).toContain(SAMPLE_CONNECTIONS_OUTPUT.summary)
+      expect(sendCall.message).toContain('Client-Infrastructure Convergence')
+    })
+
+    it('saves connections back to brain via Core API POST', async () => {
+      const { skill, mockFetch } = makeSkill()
+      await skill.execute()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/captures',
+        expect.objectContaining({ method: 'POST' }),
+      )
+
+      // Verify capture body
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(fetchBody.capture_type).toBe('reflection')
+      expect(fetchBody.brain_view).toBe('personal')
+      expect(fetchBody.tags).toEqual(['connections', 'skill-output'])
+      expect(fetchBody.metadata.source_metadata.generator).toBe('daily-connections-skill')
+    })
+
+    it('writes a skills_log entry', async () => {
+      const { skill, db } = makeSkill()
+      await skill.execute()
+
+      const insertSpy = db.insert as MockInstance
+      expect(insertSpy).toHaveBeenCalled()
+      const valuesSpy = insertSpy.mock.results[0].value.values as MockInstance
+      const logEntry = valuesSpy.mock.calls[0][0]
+      expect(logEntry.skill_name).toBe('daily-connections')
+      expect(logEntry.input_summary).toContain('3 captures')
+      expect(logEntry.output_summary).toContain('summary:')
+      expect(logEntry.result).toBeDefined()
+    })
+
+    it('calls LLM with daily_connections_v1 template variables substituted', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      await skill.execute()
+
+      const createSpy = mockLitellm.chat.completions.create as MockInstance
+      const callArgs = createSpy.mock.calls[0][0]
+      const prompt: string = callArgs.messages[0].content
+
+      // Template vars should be substituted
+      expect(prompt).not.toContain('{{date_range}}')
+      expect(prompt).not.toContain('{{capture_count}}')
+      expect(prompt).not.toContain('{{captures}}')
+      expect(prompt).not.toContain('{{entity_cooccurrence}}')
+
+      // Should contain actual content
+      expect(prompt).toContain('3')
+      expect(prompt).toContain('NovaBurger')
+    })
+
+    it('respects custom windowDays and tokenBudget options', async () => {
+      const { skill, db } = makeSkill()
+      await skill.execute({ windowDays: 14, tokenBudget: 10_000 })
+
+      // db.execute called at least once for captures query
+      expect(db.execute).toHaveBeenCalled()
+    })
+
+    it('uses the provided modelAlias in LLM call', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      await skill.execute({ modelAlias: 'custom-model' })
+
+      const createSpy = mockLitellm.chat.completions.create as MockInstance
+      const callArgs = createSpy.mock.calls[0][0]
+      expect(callArgs.model).toBe('custom-model')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Empty captures
+  // ----------------------------------------------------------
+
+  describe('execute — no captures in window', () => {
+    it('returns empty output and skips LLM call', async () => {
+      const { skill, mockLitellm } = makeSkill({ captures: [] })
+      const result = await skill.execute()
+
+      expect(result.captureCount).toBe(0)
+      expect(result.output.summary).toBe('')
+      expect(result.output.connections).toEqual([])
+      expect(result.output.meta_pattern).toBeNull()
+      expect(result.savedCaptureId).toBeNull()
+      expect(mockLitellm.chat.completions.create).not.toHaveBeenCalled()
+    })
+
+    it('still writes a skills_log entry when no captures found', async () => {
+      const { skill, db } = makeSkill({ captures: [] })
+      await skill.execute()
+
+      expect(db.insert).toHaveBeenCalled()
+      const valuesSpy = (db.insert as MockInstance).mock.results[0].value.values as MockInstance
+      const logEntry = valuesSpy.mock.calls[0][0]
+      expect(logEntry.output_summary).toContain('Skipped')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Single capture
+  // ----------------------------------------------------------
+
+  describe('execute — single capture', () => {
+    it('processes a single capture without error', async () => {
+      const singleCapture = [makeCapture({ id: 'cap-solo', content: 'Only one capture here' })]
+      const { skill } = makeSkill({ captures: singleCapture })
+      const result = await skill.execute()
+
+      expect(result.captureCount).toBe(1)
+      expect(result.output).toBeDefined()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Delivery failures (non-fatal)
+  // ----------------------------------------------------------
+
+  describe('delivery — non-fatal failures', () => {
+    it('continues if Pushover delivery fails', async () => {
+      const { skill, pushover } = makeSkill()
+      vi.spyOn(pushover, 'send').mockRejectedValue(new Error('Pushover API down'))
+
+      const result = await skill.execute()
+      expect(result.output.summary).toBe(SAMPLE_CONNECTIONS_OUTPUT.summary)
+    })
+
+    it('continues if Core API save-back fails', async () => {
+      const { skill } = makeSkill({ coreApiResponse: { ok: false, status: 500 } })
+
+      const result = await skill.execute()
+      expect(result.output.summary).toBe(SAMPLE_CONNECTIONS_OUTPUT.summary)
+      expect(result.savedCaptureId).toBeNull()
+    })
+
+    it('continues if skills_log insert fails', async () => {
+      const { skill, db } = makeSkill()
+      ;(db.insert as MockInstance).mockReturnValue({
+        values: vi.fn().mockRejectedValue(new Error('DB write failed')),
+      })
+
+      const result = await skill.execute()
+      expect(result.captureCount).toBe(SAMPLE_CAPTURES.length)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Notification configuration
+  // ----------------------------------------------------------
+
+  describe('notification configuration', () => {
+    it('skips Pushover if not configured', async () => {
+      const { skill, pushover } = makeSkill({ pushoverConfigured: false })
+      await skill.execute()
+      expect(pushover.send).not.toHaveBeenCalled()
+    })
+
+    it('skips Pushover if no connections found', async () => {
+      const emptyOutput: DailyConnectionsOutput = { summary: 'Nothing found', connections: [], meta_pattern: null }
+      const { skill, pushover } = makeSkill({ connectionsOutput: emptyOutput })
+      await skill.execute()
+      expect(pushover.send).not.toHaveBeenCalled()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // LLM timeout
+  // ----------------------------------------------------------
+
+  describe('execute — LLM timeout', () => {
+    it('propagates LLM timeout error', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      ;(mockLitellm.chat.completions.create as MockInstance).mockRejectedValue(new Error('Request timed out'))
+
+      await expect(skill.execute()).rejects.toThrow('Request timed out')
+    })
+  })
+})
+
+// ============================================================
+// Tests: executeDailyConnections top-level function
+// ============================================================
+
+describe('executeDailyConnections', () => {
+  it('is exported and callable (delegates to DailyConnectionsSkill)', async () => {
+    const { executeDailyConnections } = await import('../skills/daily-connections.js')
+    expect(typeof executeDailyConnections).toBe('function')
+  })
+})

--- a/packages/workers/src/__tests__/drift-monitor.test.ts
+++ b/packages/workers/src/__tests__/drift-monitor.test.ts
@@ -1,0 +1,1007 @@
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest'
+import { join } from 'node:path'
+import { DriftMonitorSkill, parseOutput } from '../skills/drift-monitor.js'
+import type { DriftMonitorOutput, DriftMonitorResult, DriftMonitorOptions } from '../skills/drift-monitor.js'
+import {
+  queryPendingBets,
+  queryBetActivity,
+  queryEntityFrequency,
+  queryGovernanceCommitments,
+  formatPendingBets,
+  formatGovernanceCommitments,
+  formatEntityFrequency,
+  fmtDate,
+  DEFAULT_BET_ACTIVITY_DAYS,
+  DEFAULT_COMMITMENT_DAYS,
+  DEFAULT_ENTITY_WINDOW_DAYS,
+} from '../skills/drift-monitor-query.js'
+import type {
+  PendingBet,
+  BetWithActivity,
+  EntityFrequency,
+  GovernanceCommitment,
+} from '../skills/drift-monitor-query.js'
+import { PushoverService } from '../services/pushover.js'
+
+// Prompt templates live at <repo-root>/config/prompts/
+const REPO_PROMPTS_DIR = join(import.meta.dirname, '..', '..', '..', '..', 'config', 'prompts')
+
+// ============================================================
+// Fixtures
+// ============================================================
+
+const SAMPLE_PENDING_BETS: PendingBet[] = [
+  {
+    id: 'bet-1',
+    statement: 'NovaBurger will adopt centralized ordering by Q2',
+    confidence: 75,
+    domain: 'client',
+    resolution_date: '2026-06-30',
+    created_at: '2026-02-15T10:00:00Z',
+  },
+  {
+    id: 'bet-2',
+    statement: 'Open Brain will replace all manual note-taking within 3 months',
+    confidence: 60,
+    domain: 'technical',
+    resolution_date: null,
+    created_at: '2026-01-10T08:00:00Z',
+  },
+]
+
+const SAMPLE_BETS_WITH_ACTIVITY: BetWithActivity[] = [
+  {
+    ...SAMPLE_PENDING_BETS[0],
+    recent_capture_count: 0,
+    days_since_last_mention: null,
+  },
+  {
+    ...SAMPLE_PENDING_BETS[1],
+    recent_capture_count: 3,
+    days_since_last_mention: 2,
+  },
+]
+
+const SAMPLE_ENTITY_FREQUENCY: EntityFrequency[] = [
+  {
+    entity_id: 'ent-1',
+    entity_name: 'SD-WAN',
+    entity_type: 'technology',
+    current_count: 1,
+    previous_count: 5,
+    change_pct: -80,
+  },
+  {
+    entity_id: 'ent-2',
+    entity_name: 'Stratfield',
+    entity_type: 'organization',
+    current_count: 0,
+    previous_count: 3,
+    change_pct: -100,
+  },
+]
+
+const SAMPLE_GOVERNANCE_COMMITMENTS: GovernanceCommitment[] = [
+  {
+    session_id: 'sess-001-abcdef',
+    session_date: '2026-02-28T15:30:00Z',
+    summary: 'Reviewed capacity planning and agreed to weekly check-ins.',
+    closing_message: 'Action items: 1. Review Stratfield capacity model weekly. 2. Update client pipeline tracker.',
+  },
+]
+
+const SAMPLE_DRIFT_OUTPUT: DriftMonitorOutput = {
+  summary: 'NovaBurger bet silent 18 days — resolution date approaching with no activity.',
+  drift_items: [
+    {
+      item_type: 'bet',
+      item_name: 'NovaBurger will adopt centralized ordering by Q2',
+      severity: 'high',
+      days_silent: 18,
+      reason: 'Zero captures mentioning NovaBurger in the last 18 days.',
+      suggested_action: 'Schedule a check-in on NovaBurger project status.',
+    },
+    {
+      item_type: 'commitment',
+      item_name: 'Review Stratfield capacity model weekly',
+      severity: 'medium',
+      days_silent: 12,
+      reason: 'No captures tagged capacity or mentioning Stratfield since 2026-02-27.',
+      suggested_action: 'Run the Stratfield capacity review now and capture findings.',
+    },
+    {
+      item_type: 'entity',
+      item_name: 'SD-WAN',
+      severity: 'low',
+      days_silent: 8,
+      reason: 'SD-WAN mentions dropped from 5/week to 1/week.',
+      suggested_action: 'Check if SD-WAN work is complete or just deprioritized.',
+    },
+  ],
+  overall_health: 'significant_drift',
+}
+
+// ============================================================
+// Mock helpers
+// ============================================================
+
+/**
+ * Build a mock database that returns specified data for sequential execute() calls.
+ * Call order: queryPendingBets, then N queryBetActivity calls, then queryGovernanceCommitments,
+ * then queryEntityFrequency.
+ */
+function makeMockDb(opts: {
+  pendingBets?: PendingBet[]
+  betActivityRows?: Array<{ recent_count: string; days_since: string | null }>
+  commitments?: GovernanceCommitment[]
+  entityFrequency?: Array<{
+    entity_id: string
+    entity_name: string
+    entity_type: string
+    current_count: string
+    previous_count: string
+  }>
+} = {}) {
+  const pendingBets = opts.pendingBets ?? SAMPLE_PENDING_BETS
+  const betActivityRow = opts.betActivityRows ?? [
+    { recent_count: '0', days_since: null },
+    { recent_count: '3', days_since: '2' },
+  ]
+  const commitments = opts.commitments ?? SAMPLE_GOVERNANCE_COMMITMENTS
+  const entityFreq = opts.entityFrequency ?? [
+    { entity_id: 'ent-1', entity_name: 'SD-WAN', entity_type: 'technology', current_count: '1', previous_count: '5' },
+    { entity_id: 'ent-2', entity_name: 'Stratfield', entity_type: 'organization', current_count: '0', previous_count: '3' },
+  ]
+
+  let callCount = 0
+  const betCount = pendingBets.length
+
+  return {
+    execute: vi.fn().mockImplementation(() => {
+      callCount++
+      // Call 1: queryPendingBets
+      if (callCount === 1) return Promise.resolve({ rows: pendingBets })
+      // Calls 2..(1+betCount): queryBetActivity for each bet
+      if (callCount <= 1 + betCount) {
+        const betIdx = callCount - 2
+        return Promise.resolve({ rows: [betActivityRow[betIdx] ?? { recent_count: '0', days_since: null }] })
+      }
+      // Next call: queryGovernanceCommitments
+      if (callCount === 2 + betCount) return Promise.resolve({ rows: commitments })
+      // Next call: queryEntityFrequency
+      return Promise.resolve({ rows: entityFreq })
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+  }
+}
+
+function makeMockOpenAI(jsonOutput: DriftMonitorOutput = SAMPLE_DRIFT_OUTPUT) {
+  return {
+    chat: {
+      completions: {
+        create: vi.fn().mockResolvedValue({
+          choices: [{ message: { content: JSON.stringify(jsonOutput) } }],
+          usage: { prompt_tokens: 400, completion_tokens: 200, total_tokens: 600 },
+        }),
+      },
+    },
+  }
+}
+
+function makePushoverService(configured = true) {
+  const svc = new PushoverService('fake-token', 'fake-user')
+  if (!configured) {
+    Object.defineProperty(svc, 'isConfigured', { get: () => false })
+  }
+  vi.spyOn(svc, 'send').mockResolvedValue(undefined)
+  return svc
+}
+
+function makeSkill(opts: {
+  pendingBets?: PendingBet[]
+  betActivityRows?: Array<{ recent_count: string; days_since: string | null }>
+  commitments?: GovernanceCommitment[]
+  entityFrequency?: Array<{
+    entity_id: string
+    entity_name: string
+    entity_type: string
+    current_count: string
+    previous_count: string
+  }>
+  driftOutput?: DriftMonitorOutput
+  pushoverConfigured?: boolean
+  promptsDir?: string
+  coreApiResponse?: { ok: boolean; json?: object; status?: number }
+} = {}) {
+  const db = makeMockDb({
+    pendingBets: opts.pendingBets,
+    betActivityRows: opts.betActivityRows,
+    commitments: opts.commitments,
+    entityFrequency: opts.entityFrequency,
+  })
+  const mockLitellm = makeMockOpenAI(opts.driftOutput ?? SAMPLE_DRIFT_OUTPUT)
+  const pushover = makePushoverService(opts.pushoverConfigured ?? true)
+
+  const fetchResponse = opts.coreApiResponse ?? { ok: true, json: { id: 'saved-drift-id' } }
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: fetchResponse.ok,
+    status: fetchResponse.status ?? (fetchResponse.ok ? 200 : 500),
+    json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
+    text: vi.fn().mockResolvedValue(''),
+  })
+
+  const skill = new DriftMonitorSkill({
+    db: db as unknown as import('@open-brain/shared').Database,
+    promptsDir: opts.promptsDir ?? REPO_PROMPTS_DIR,
+    coreApiUrl: 'http://localhost:3000',
+    pushover,
+  })
+
+  // Replace internal litellmClient
+  // @ts-ignore — accessing private field for testing
+  skill.litellmClient = mockLitellm
+
+  // Replace global fetch
+  vi.stubGlobal('fetch', mockFetch)
+
+  return { skill, db, mockLitellm, pushover, mockFetch }
+}
+
+// ============================================================
+// Tests: parseOutput
+// ============================================================
+
+describe('parseOutput', () => {
+  it('parses valid JSON into DriftMonitorOutput', () => {
+    const raw = JSON.stringify(SAMPLE_DRIFT_OUTPUT)
+    const result = parseOutput(raw)
+    expect(result.summary).toBe(SAMPLE_DRIFT_OUTPUT.summary)
+    expect(result.drift_items).toHaveLength(3)
+    expect(result.drift_items[0].item_type).toBe('bet')
+    expect(result.drift_items[0].severity).toBe('high')
+    expect(result.overall_health).toBe('significant_drift')
+  })
+
+  it('strips markdown code fences before parsing', () => {
+    const raw = '```json\n' + JSON.stringify(SAMPLE_DRIFT_OUTPUT) + '\n```'
+    const result = parseOutput(raw)
+    expect(result.summary).toBe(SAMPLE_DRIFT_OUTPUT.summary)
+    expect(result.drift_items).toHaveLength(3)
+  })
+
+  it('strips code fences without language specifier', () => {
+    const raw = '```\n' + JSON.stringify(SAMPLE_DRIFT_OUTPUT) + '\n```'
+    const result = parseOutput(raw)
+    expect(result.summary).toBe(SAMPLE_DRIFT_OUTPUT.summary)
+  })
+
+  it('returns fallback for completely invalid JSON', () => {
+    const raw = 'This is not JSON at all, sorry.'
+    const result = parseOutput(raw)
+    expect(result.summary).toBe('This is not JSON at all, sorry.')
+    expect(result.drift_items).toEqual([])
+    expect(result.overall_health).toBe('healthy')
+  })
+
+  it('truncates raw text to 150 chars for fallback summary', () => {
+    const raw = 'A'.repeat(300)
+    const result = parseOutput(raw)
+    expect(result.summary).toHaveLength(150)
+  })
+
+  it('handles missing summary field gracefully', () => {
+    const raw = JSON.stringify({ drift_items: [], overall_health: 'healthy' })
+    const result = parseOutput(raw)
+    expect(result.summary).toBe('(no summary)')
+  })
+
+  it('handles missing drift_items array gracefully', () => {
+    const raw = JSON.stringify({ summary: 'Test', overall_health: 'healthy' })
+    const result = parseOutput(raw)
+    expect(result.drift_items).toEqual([])
+  })
+
+  it('handles missing overall_health gracefully', () => {
+    const raw = JSON.stringify({ summary: 'Test', drift_items: [] })
+    const result = parseOutput(raw)
+    expect(result.overall_health).toBe('healthy')
+  })
+
+  it('provides defaults for malformed drift items', () => {
+    const raw = JSON.stringify({
+      summary: 'Test',
+      drift_items: [
+        { item_type: 'bogus', item_name: 42, severity: 'extreme', days_silent: 'many', reason: null, suggested_action: 123 },
+      ],
+      overall_health: 'healthy',
+    })
+    const result = parseOutput(raw)
+    expect(result.drift_items).toHaveLength(1)
+    expect(result.drift_items[0].item_type).toBe('entity') // default for invalid type
+    expect(result.drift_items[0].item_name).toBe('(unnamed)')
+    expect(result.drift_items[0].severity).toBe('low') // default for invalid severity
+    expect(result.drift_items[0].days_silent).toBe(0) // default for non-number
+    expect(result.drift_items[0].reason).toBe('')
+    expect(result.drift_items[0].suggested_action).toBe('')
+  })
+
+  it('handles invalid overall_health by defaulting to healthy', () => {
+    const raw = JSON.stringify({ summary: 'Test', drift_items: [], overall_health: 'catastrophic' })
+    const result = parseOutput(raw)
+    expect(result.overall_health).toBe('healthy')
+  })
+
+  it('validates all valid overall_health values', () => {
+    for (const health of ['healthy', 'minor_drift', 'significant_drift', 'critical_drift'] as const) {
+      const raw = JSON.stringify({ summary: 'T', drift_items: [], overall_health: health })
+      expect(parseOutput(raw).overall_health).toBe(health)
+    }
+  })
+
+  it('validates all valid severity values', () => {
+    for (const severity of ['high', 'medium', 'low'] as const) {
+      const raw = JSON.stringify({
+        summary: 'T',
+        drift_items: [{ item_type: 'bet', item_name: 'X', severity, days_silent: 5, reason: 'r', suggested_action: 'a' }],
+        overall_health: 'healthy',
+      })
+      expect(parseOutput(raw).drift_items[0].severity).toBe(severity)
+    }
+  })
+
+  it('validates all valid item_type values', () => {
+    for (const item_type of ['bet', 'commitment', 'entity'] as const) {
+      const raw = JSON.stringify({
+        summary: 'T',
+        drift_items: [{ item_type, item_name: 'X', severity: 'low', days_silent: 1, reason: 'r', suggested_action: 'a' }],
+        overall_health: 'healthy',
+      })
+      expect(parseOutput(raw).drift_items[0].item_type).toBe(item_type)
+    }
+  })
+
+  it('handles empty string input', () => {
+    const result = parseOutput('')
+    expect(result.drift_items).toEqual([])
+    expect(result.overall_health).toBe('healthy')
+  })
+
+  it('skips non-object items in drift_items array', () => {
+    const raw = JSON.stringify({
+      summary: 'Test',
+      drift_items: ['string-item', 42, null, { item_type: 'bet', item_name: 'Real', severity: 'low', days_silent: 1, reason: 'r', suggested_action: 'a' }],
+      overall_health: 'healthy',
+    })
+    const result = parseOutput(raw)
+    expect(result.drift_items).toHaveLength(1)
+    expect(result.drift_items[0].item_name).toBe('Real')
+  })
+})
+
+// ============================================================
+// Tests: query module — fmtDate
+// ============================================================
+
+describe('fmtDate', () => {
+  it('formats a Date as YYYY-MM-DD', () => {
+    expect(fmtDate(new Date('2026-03-10T14:30:00Z'))).toBe('2026-03-10')
+  })
+
+  it('handles year boundaries', () => {
+    expect(fmtDate(new Date('2025-12-31T23:59:59Z'))).toBe('2025-12-31')
+  })
+})
+
+// ============================================================
+// Tests: query module — queryPendingBets
+// ============================================================
+
+describe('queryPendingBets', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls db.execute and returns pending bets', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: SAMPLE_PENDING_BETS }) }
+    const result = await queryPendingBets(mockDb as any)
+    expect(mockDb.execute).toHaveBeenCalledOnce()
+    expect(result).toEqual(SAMPLE_PENDING_BETS)
+  })
+
+  it('returns empty array when no pending bets', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [] }) }
+    const result = await queryPendingBets(mockDb as any)
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array on db error', async () => {
+    const mockDb = { execute: vi.fn().mockRejectedValue(new Error('relation does not exist')) }
+    const result = await queryPendingBets(mockDb as any)
+    expect(result).toEqual([])
+  })
+})
+
+// ============================================================
+// Tests: query module — queryBetActivity
+// ============================================================
+
+describe('queryBetActivity', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns bet with recent activity data', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [{ recent_count: '5', days_since: '3' }] }) }
+    const result = await queryBetActivity(mockDb as any, SAMPLE_PENDING_BETS[0], 14)
+    expect(result.id).toBe('bet-1')
+    expect(result.recent_capture_count).toBe(5)
+    expect(result.days_since_last_mention).toBe(3)
+  })
+
+  it('returns zero activity when no matching captures', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [{ recent_count: '0', days_since: null }] }) }
+    const result = await queryBetActivity(mockDb as any, SAMPLE_PENDING_BETS[0], 14)
+    expect(result.recent_capture_count).toBe(0)
+    expect(result.days_since_last_mention).toBeNull()
+  })
+
+  it('returns zero activity on db error', async () => {
+    const mockDb = { execute: vi.fn().mockRejectedValue(new Error('connection failed')) }
+    const result = await queryBetActivity(mockDb as any, SAMPLE_PENDING_BETS[0], 14)
+    expect(result.recent_capture_count).toBe(0)
+    expect(result.days_since_last_mention).toBeNull()
+    // Preserves original bet data
+    expect(result.statement).toBe(SAMPLE_PENDING_BETS[0].statement)
+  })
+
+  it('rounds days_since to nearest integer', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [{ recent_count: '1', days_since: '4.7' }] }) }
+    const result = await queryBetActivity(mockDb as any, SAMPLE_PENDING_BETS[0], 14)
+    expect(result.days_since_last_mention).toBe(5) // Math.round(4.7) === 5
+  })
+
+  it('handles empty rows array', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [] }) }
+    const result = await queryBetActivity(mockDb as any, SAMPLE_PENDING_BETS[0], 14)
+    expect(result.recent_capture_count).toBe(0)
+    expect(result.days_since_last_mention).toBeNull()
+  })
+})
+
+// ============================================================
+// Tests: query module — queryEntityFrequency
+// ============================================================
+
+describe('queryEntityFrequency', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns entities with frequency decline', async () => {
+    const mockDb = {
+      execute: vi.fn().mockResolvedValue({
+        rows: [
+          { entity_id: 'e1', entity_name: 'SD-WAN', entity_type: 'technology', current_count: '1', previous_count: '5' },
+        ],
+      }),
+    }
+    const result = await queryEntityFrequency(mockDb as any, 7)
+    expect(result).toHaveLength(1)
+    expect(result[0].entity_name).toBe('SD-WAN')
+    expect(result[0].current_count).toBe(1)
+    expect(result[0].previous_count).toBe(5)
+    expect(result[0].change_pct).toBe(-80)
+  })
+
+  it('returns empty array when no declining entities', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [] }) }
+    const result = await queryEntityFrequency(mockDb as any, 7)
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array on db error', async () => {
+    const mockDb = { execute: vi.fn().mockRejectedValue(new Error('relation does not exist')) }
+    const result = await queryEntityFrequency(mockDb as any, 7)
+    expect(result).toEqual([])
+  })
+
+  it('calculates change_pct correctly for complete drop to zero', async () => {
+    const mockDb = {
+      execute: vi.fn().mockResolvedValue({
+        rows: [
+          { entity_id: 'e1', entity_name: 'Ghost', entity_type: 'topic', current_count: '0', previous_count: '4' },
+        ],
+      }),
+    }
+    const result = await queryEntityFrequency(mockDb as any, 7)
+    expect(result[0].change_pct).toBe(-100)
+  })
+})
+
+// ============================================================
+// Tests: query module — queryGovernanceCommitments
+// ============================================================
+
+describe('queryGovernanceCommitments', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns governance commitments from completed sessions', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: SAMPLE_GOVERNANCE_COMMITMENTS }) }
+    const result = await queryGovernanceCommitments(mockDb as any, 30)
+    expect(mockDb.execute).toHaveBeenCalledOnce()
+    expect(result).toEqual(SAMPLE_GOVERNANCE_COMMITMENTS)
+    expect(result[0].session_id).toBe('sess-001-abcdef')
+  })
+
+  it('returns empty array when no governance sessions in window', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [] }) }
+    const result = await queryGovernanceCommitments(mockDb as any, 30)
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array on db error', async () => {
+    const mockDb = { execute: vi.fn().mockRejectedValue(new Error('relation does not exist')) }
+    const result = await queryGovernanceCommitments(mockDb as any, 30)
+    expect(result).toEqual([])
+  })
+})
+
+// ============================================================
+// Tests: query module — formatPendingBets
+// ============================================================
+
+describe('formatPendingBets', () => {
+  it('formats bets with activity data as plain text', () => {
+    const result = formatPendingBets(SAMPLE_BETS_WITH_ACTIVITY)
+    expect(result).toContain('NovaBurger will adopt centralized ordering by Q2')
+    expect(result).toContain('NO recent captures mentioning this bet')
+    expect(result).toContain('confidence: 75')
+    expect(result).toContain('resolution date: 2026-06-30')
+  })
+
+  it('shows recent capture count when bet has activity', () => {
+    const result = formatPendingBets(SAMPLE_BETS_WITH_ACTIVITY)
+    expect(result).toContain('3 recent captures, last mention 2 days ago')
+  })
+
+  it('returns placeholder for empty bets array', () => {
+    const result = formatPendingBets([])
+    expect(result).toBe('(no pending bets)')
+  })
+
+  it('includes domain in bracket prefix', () => {
+    const result = formatPendingBets(SAMPLE_BETS_WITH_ACTIVITY)
+    expect(result).toContain('[client]')
+    expect(result).toContain('[technical]')
+  })
+
+  it('uses "general" for null domain', () => {
+    const bet: BetWithActivity = {
+      ...SAMPLE_PENDING_BETS[0],
+      domain: null,
+      recent_capture_count: 0,
+      days_since_last_mention: null,
+    }
+    const result = formatPendingBets([bet])
+    expect(result).toContain('[general]')
+  })
+
+  it('shows question mark for null days_since_last_mention', () => {
+    const bet: BetWithActivity = {
+      ...SAMPLE_PENDING_BETS[0],
+      recent_capture_count: 2,
+      days_since_last_mention: null,
+    }
+    const result = formatPendingBets([bet])
+    expect(result).toContain('last mention ? days ago')
+  })
+})
+
+// ============================================================
+// Tests: query module — formatGovernanceCommitments
+// ============================================================
+
+describe('formatGovernanceCommitments', () => {
+  it('formats commitments with session info, summary, and closing message', () => {
+    const result = formatGovernanceCommitments(SAMPLE_GOVERNANCE_COMMITMENTS)
+    expect(result).toContain('Session sess-001')
+    expect(result).toContain('2026-02-28')
+    expect(result).toContain('Summary: Reviewed capacity planning')
+    expect(result).toContain('Closing message: Action items:')
+  })
+
+  it('returns placeholder for empty commitments array', () => {
+    const result = formatGovernanceCommitments([])
+    expect(result).toBe('(no governance sessions in window)')
+  })
+
+  it('handles null summary and closing_message', () => {
+    const commitment: GovernanceCommitment = {
+      session_id: 'sess-002',
+      session_date: '2026-03-01T10:00:00Z',
+      summary: null,
+      closing_message: null,
+    }
+    const result = formatGovernanceCommitments([commitment])
+    expect(result).toContain('Session sess-002')
+    expect(result).not.toContain('Summary:')
+    expect(result).not.toContain('Closing message:')
+  })
+
+  it('truncates long summaries at 300 chars', () => {
+    const commitment: GovernanceCommitment = {
+      session_id: 'sess-003',
+      session_date: '2026-03-01T10:00:00Z',
+      summary: 'X'.repeat(500),
+      closing_message: null,
+    }
+    const result = formatGovernanceCommitments([commitment])
+    // The formatted line should contain at most 300 chars of the summary
+    expect(result).toContain('Summary: ' + 'X'.repeat(300))
+    expect(result).not.toContain('X'.repeat(301))
+  })
+
+  it('truncates long closing messages at 500 chars', () => {
+    const commitment: GovernanceCommitment = {
+      session_id: 'sess-004',
+      session_date: '2026-03-01T10:00:00Z',
+      summary: null,
+      closing_message: 'Y'.repeat(700),
+    }
+    const result = formatGovernanceCommitments([commitment])
+    expect(result).toContain('Closing message: ' + 'Y'.repeat(500))
+    expect(result).not.toContain('Y'.repeat(501))
+  })
+})
+
+// ============================================================
+// Tests: query module — formatEntityFrequency
+// ============================================================
+
+describe('formatEntityFrequency', () => {
+  it('formats entities with frequency decline data', () => {
+    const result = formatEntityFrequency(SAMPLE_ENTITY_FREQUENCY)
+    expect(result).toContain('SD-WAN (technology): 5 mentions (previous window)')
+    expect(result).toContain('1 mentions (current window)')
+    expect(result).toContain('-80% change')
+    expect(result).toContain('Stratfield (organization)')
+    expect(result).toContain('-100% change')
+  })
+
+  it('returns placeholder for empty entity frequency array', () => {
+    const result = formatEntityFrequency([])
+    expect(result).toBe('(no significant entity frequency declines detected)')
+  })
+
+  it('formats change percentage without decimals', () => {
+    const entities: EntityFrequency[] = [
+      { entity_id: 'e1', entity_name: 'Test', entity_type: 'topic', current_count: 1, previous_count: 3, change_pct: -66.66666 },
+    ]
+    const result = formatEntityFrequency(entities)
+    expect(result).toContain('-67% change')
+  })
+})
+
+// ============================================================
+// Tests: query module — constants
+// ============================================================
+
+describe('constants', () => {
+  it('DEFAULT_BET_ACTIVITY_DAYS is 14', () => {
+    expect(DEFAULT_BET_ACTIVITY_DAYS).toBe(14)
+  })
+
+  it('DEFAULT_COMMITMENT_DAYS is 30', () => {
+    expect(DEFAULT_COMMITMENT_DAYS).toBe(30)
+  })
+
+  it('DEFAULT_ENTITY_WINDOW_DAYS is 7', () => {
+    expect(DEFAULT_ENTITY_WINDOW_DAYS).toBe(7)
+  })
+})
+
+// ============================================================
+// Tests: DriftMonitorSkill — execute happy path
+// ============================================================
+
+describe('DriftMonitorSkill', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('execute — happy path', () => {
+    it('returns a DriftMonitorResult with drift items and overall health', async () => {
+      const { skill } = makeSkill()
+      const result = await skill.execute()
+
+      expect(result.output.summary).toBe(SAMPLE_DRIFT_OUTPUT.summary)
+      expect(result.output.drift_items).toHaveLength(3)
+      expect(result.output.overall_health).toBe('significant_drift')
+      expect(result.durationMs).toBeGreaterThan(0)
+    })
+
+    it('returns savedCaptureId from Core API response', async () => {
+      const { skill } = makeSkill()
+      const result = await skill.execute()
+      expect(result.savedCaptureId).toBe('saved-drift-id')
+    })
+
+    it('sends Pushover notification when severity >= medium items exist', async () => {
+      const { skill, pushover } = makeSkill()
+      await skill.execute()
+
+      expect(pushover.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining('Drift Monitor'),
+          priority: 1, // high priority because there's a high-severity drift item
+        }),
+      )
+      // Verify message contains summary and drift item lines
+      const sendCall = (pushover.send as MockInstance).mock.calls[0][0]
+      expect(sendCall.message).toContain(SAMPLE_DRIFT_OUTPUT.summary)
+      expect(sendCall.message).toContain('HIGH')
+      expect(sendCall.message).toContain('NovaBurger')
+    })
+
+    it('uses priority 0 when no high-severity items, only medium', async () => {
+      const mediumOnlyOutput: DriftMonitorOutput = {
+        summary: 'Some drift detected.',
+        drift_items: [
+          { item_type: 'commitment', item_name: 'Review capacity', severity: 'medium', days_silent: 10, reason: 'No follow-up', suggested_action: 'Review now' },
+        ],
+        overall_health: 'minor_drift',
+      }
+      const { skill, pushover } = makeSkill({ driftOutput: mediumOnlyOutput })
+      await skill.execute()
+
+      expect(pushover.send).toHaveBeenCalledWith(
+        expect.objectContaining({ priority: 0 }),
+      )
+    })
+
+    it('saves drift report back to brain via Core API POST', async () => {
+      const { skill, mockFetch } = makeSkill()
+      await skill.execute()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/captures',
+        expect.objectContaining({ method: 'POST' }),
+      )
+
+      // Verify capture body
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(fetchBody.capture_type).toBe('reflection')
+      expect(fetchBody.brain_view).toBe('personal')
+      expect(fetchBody.tags).toEqual(['drift', 'skill-output'])
+      expect(fetchBody.metadata.source_metadata.generator).toBe('drift-monitor-skill')
+      expect(fetchBody.metadata.source_metadata.overall_health).toBe('significant_drift')
+    })
+
+    it('writes a skills_log entry', async () => {
+      const { skill, db } = makeSkill()
+      await skill.execute()
+
+      const insertSpy = db.insert as MockInstance
+      expect(insertSpy).toHaveBeenCalled()
+      const valuesSpy = insertSpy.mock.results[0].value.values as MockInstance
+      const logEntry = valuesSpy.mock.calls[0][0]
+      expect(logEntry.skill_name).toBe('drift-monitor')
+      expect(logEntry.input_summary).toContain('bets')
+      expect(logEntry.input_summary).toContain('commitments')
+      expect(logEntry.output_summary).toContain('health:')
+      expect(logEntry.output_summary).toContain('drift_items:')
+      expect(logEntry.result).toBeDefined()
+    })
+
+    it('calls LLM with drift_monitor_v1 template variables substituted', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      await skill.execute()
+
+      const createSpy = mockLitellm.chat.completions.create as MockInstance
+      const callArgs = createSpy.mock.calls[0][0]
+      const prompt: string = callArgs.messages[0].content
+
+      // Template vars should be substituted
+      expect(prompt).not.toContain('{{analysis_date}}')
+      expect(prompt).not.toContain('{{pending_bets}}')
+      expect(prompt).not.toContain('{{governance_commitments}}')
+      expect(prompt).not.toContain('{{entity_frequency}}')
+
+      // Should contain actual bet content
+      expect(prompt).toContain('NovaBurger')
+    })
+
+    it('respects custom option parameters', async () => {
+      const { skill, db } = makeSkill()
+      await skill.execute({ betActivityDays: 30, commitmentDays: 60, entityWindowDays: 14 })
+
+      // db.execute called for queries
+      expect(db.execute).toHaveBeenCalled()
+    })
+
+    it('uses the provided modelAlias in LLM call', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      await skill.execute({ modelAlias: 'custom-model' })
+
+      const createSpy = mockLitellm.chat.completions.create as MockInstance
+      const callArgs = createSpy.mock.calls[0][0]
+      expect(callArgs.model).toBe('custom-model')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // No data to analyze
+  // ----------------------------------------------------------
+
+  describe('execute — no data to analyze', () => {
+    it('returns empty output and skips LLM call when no bets, commitments, or entities', async () => {
+      const { skill, mockLitellm } = makeSkill({
+        pendingBets: [],
+        commitments: [],
+        entityFrequency: [],
+      })
+      const result = await skill.execute()
+
+      expect(result.output.summary).toContain('no drift detected')
+      expect(result.output.drift_items).toEqual([])
+      expect(result.output.overall_health).toBe('healthy')
+      expect(result.savedCaptureId).toBeNull()
+      expect(result.notificationSent).toBe(false)
+      expect(mockLitellm.chat.completions.create).not.toHaveBeenCalled()
+    })
+
+    it('still writes a skills_log entry when no data found', async () => {
+      const { skill, db } = makeSkill({
+        pendingBets: [],
+        commitments: [],
+        entityFrequency: [],
+      })
+      await skill.execute()
+
+      expect(db.insert).toHaveBeenCalled()
+      const valuesSpy = (db.insert as MockInstance).mock.results[0].value.values as MockInstance
+      const logEntry = valuesSpy.mock.calls[0][0]
+      expect(logEntry.output_summary).toContain('Skipped')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // No drift items returned by LLM (all clear)
+  // ----------------------------------------------------------
+
+  describe('execute — all clear (no drift items)', () => {
+    it('does NOT send Pushover when drift_items is empty', async () => {
+      const allClearOutput: DriftMonitorOutput = {
+        summary: 'All tracked items are active — no drift detected.',
+        drift_items: [],
+        overall_health: 'healthy',
+      }
+      const { skill, pushover } = makeSkill({ driftOutput: allClearOutput })
+      await skill.execute()
+      expect(pushover.send).not.toHaveBeenCalled()
+    })
+
+    it('returns notificationSent: false when no medium/high items', async () => {
+      const allClearOutput: DriftMonitorOutput = {
+        summary: 'All tracked items are active.',
+        drift_items: [],
+        overall_health: 'healthy',
+      }
+      const { skill } = makeSkill({ driftOutput: allClearOutput })
+      const result = await skill.execute()
+      expect(result.notificationSent).toBe(false)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Only low-severity drift items (no notification)
+  // ----------------------------------------------------------
+
+  describe('execute — only low-severity drift items', () => {
+    it('does NOT send Pushover when only low-severity items exist', async () => {
+      const lowOnlyOutput: DriftMonitorOutput = {
+        summary: 'Minor declines detected.',
+        drift_items: [
+          { item_type: 'entity', item_name: 'SD-WAN', severity: 'low', days_silent: 5, reason: 'Slight decline', suggested_action: 'Monitor' },
+        ],
+        overall_health: 'healthy',
+      }
+      const { skill, pushover } = makeSkill({ driftOutput: lowOnlyOutput })
+      await skill.execute()
+      expect(pushover.send).not.toHaveBeenCalled()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Delivery failures (non-fatal)
+  // ----------------------------------------------------------
+
+  describe('delivery — non-fatal failures', () => {
+    it('continues if Pushover delivery fails', async () => {
+      const { skill, pushover } = makeSkill()
+      vi.spyOn(pushover, 'send').mockRejectedValue(new Error('Pushover API down'))
+
+      const result = await skill.execute()
+      expect(result.output.summary).toBe(SAMPLE_DRIFT_OUTPUT.summary)
+      // notificationSent should be false because the catch block returns false
+      expect(result.notificationSent).toBe(false)
+    })
+
+    it('continues if Core API save-back fails', async () => {
+      const { skill } = makeSkill({ coreApiResponse: { ok: false, status: 500 } })
+
+      const result = await skill.execute()
+      expect(result.output.summary).toBe(SAMPLE_DRIFT_OUTPUT.summary)
+      expect(result.savedCaptureId).toBeNull()
+    })
+
+    it('continues if skills_log insert fails', async () => {
+      const { skill, db } = makeSkill()
+      ;(db.insert as MockInstance).mockReturnValue({
+        values: vi.fn().mockRejectedValue(new Error('DB write failed')),
+      })
+
+      const result = await skill.execute()
+      expect(result.output.drift_items).toHaveLength(3)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Notification configuration
+  // ----------------------------------------------------------
+
+  describe('notification configuration', () => {
+    it('skips Pushover if not configured', async () => {
+      const { skill, pushover } = makeSkill({ pushoverConfigured: false })
+      await skill.execute()
+      expect(pushover.send).not.toHaveBeenCalled()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // LLM timeout
+  // ----------------------------------------------------------
+
+  describe('execute — LLM timeout', () => {
+    it('propagates LLM timeout error', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      ;(mockLitellm.chat.completions.create as MockInstance).mockRejectedValue(new Error('Request timed out'))
+
+      await expect(skill.execute()).rejects.toThrow('Request timed out')
+    })
+  })
+})
+
+// ============================================================
+// Tests: executeDriftMonitor top-level function
+// ============================================================
+
+describe('executeDriftMonitor', () => {
+  it('is exported and callable (delegates to DriftMonitorSkill)', async () => {
+    const { executeDriftMonitor } = await import('../skills/drift-monitor.js')
+    expect(typeof executeDriftMonitor).toBe('function')
+  })
+})
+
+// ============================================================
+// Tests: Worker dispatcher — drift-monitor case routing
+// ============================================================
+
+describe('skill-execution worker — drift-monitor dispatch', () => {
+  it('drift-monitor case imports executeDriftMonitor correctly', async () => {
+    const mod = await import('../skills/drift-monitor.js')
+    expect(typeof mod.executeDriftMonitor).toBe('function')
+    expect(typeof mod.DriftMonitorSkill).toBe('function')
+    expect(typeof mod.parseOutput).toBe('function')
+  })
+
+  it('skill-execution worker module can be loaded without error', async () => {
+    // Verify the dispatcher module imports drift-monitor
+    const mod = await import('../jobs/skill-execution.js')
+    expect(typeof mod.createSkillExecutionWorker).toBe('function')
+  })
+})

--- a/packages/workers/src/__tests__/drift-monitor.test.ts
+++ b/packages/workers/src/__tests__/drift-monitor.test.ts
@@ -741,7 +741,7 @@ describe('DriftMonitorSkill', () => {
         }),
       )
       // Verify message contains summary and drift item lines
-      const sendCall = (pushover.send as MockInstance).mock.calls[0][0]
+      const sendCall = (pushover.send as unknown as MockInstance).mock.calls[0][0]
       expect(sendCall.message).toContain(SAMPLE_DRIFT_OUTPUT.summary)
       expect(sendCall.message).toContain('HIGH')
       expect(sendCall.message).toContain('NovaBurger')

--- a/packages/workers/src/jobs/skill-execution.ts
+++ b/packages/workers/src/jobs/skill-execution.ts
@@ -4,6 +4,7 @@ import type { Database } from '@open-brain/shared'
 import { logger } from '../lib/logger.js'
 import { executeWeeklyBrief } from '../skills/weekly-brief.js'
 import { executeDailyConnections } from '../skills/daily-connections.js'
+import { executeDriftMonitor } from '../skills/drift-monitor.js'
 import type { SkillExecutionJobData } from '../queues/skill-execution.js'
 
 /**
@@ -62,6 +63,21 @@ export function createSkillExecutionWorker(
           logger.info(
             { skillName, captureCount: result.captureCount, connectionCount: result.output.connections.length, durationMs: result.durationMs },
             '[skill-execution] daily-connections complete',
+          )
+          break
+        }
+
+        case 'drift-monitor': {
+          const result = await executeDriftMonitor(db, {
+            betActivityDays: typeof input?.betActivityDays === 'number' ? input.betActivityDays : undefined,
+            commitmentDays: typeof input?.commitmentDays === 'number' ? input.commitmentDays : undefined,
+            entityWindowDays: typeof input?.entityWindowDays === 'number' ? input.entityWindowDays : undefined,
+            modelAlias: typeof input?.modelAlias === 'string' ? input.modelAlias : undefined,
+          })
+
+          logger.info(
+            { skillName, driftItemCount: result.output.drift_items.length, overallHealth: result.output.overall_health, notificationSent: result.notificationSent, durationMs: result.durationMs },
+            '[skill-execution] drift-monitor complete',
           )
           break
         }

--- a/packages/workers/src/jobs/skill-execution.ts
+++ b/packages/workers/src/jobs/skill-execution.ts
@@ -3,6 +3,7 @@ import type { ConnectionOptions } from 'bullmq'
 import type { Database } from '@open-brain/shared'
 import { logger } from '../lib/logger.js'
 import { executeWeeklyBrief } from '../skills/weekly-brief.js'
+import { executeDailyConnections } from '../skills/daily-connections.js'
 import type { SkillExecutionJobData } from '../queues/skill-execution.js'
 
 /**
@@ -47,6 +48,20 @@ export function createSkillExecutionWorker(
           logger.info(
             { skillName, captureCount: result.captureCount, durationMs: result.durationMs },
             '[skill-execution] weekly-brief complete',
+          )
+          break
+        }
+
+        case 'daily-connections': {
+          const result = await executeDailyConnections(db, {
+            windowDays: typeof input?.windowDays === 'number' ? input.windowDays : undefined,
+            tokenBudget: typeof input?.tokenBudget === 'number' ? input.tokenBudget : undefined,
+            modelAlias: typeof input?.modelAlias === 'string' ? input.modelAlias : undefined,
+          })
+
+          logger.info(
+            { skillName, captureCount: result.captureCount, connectionCount: result.output.connections.length, durationMs: result.durationMs },
+            '[skill-execution] daily-connections complete',
           )
           break
         }

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -4,10 +4,13 @@ import { logger } from './lib/logger.js'
 import type { DailySweepJobData } from './jobs/daily-sweep.js'
 import { createBudgetCheckQueue } from './jobs/budget-check.js'
 import type { BudgetCheckJobData } from './jobs/budget-check.js'
+import { createSkillExecutionQueue } from './queues/skill-execution.js'
+import type { SkillExecutionJobData } from './queues/skill-execution.js'
 
 export interface ScheduledQueues {
   dailySweep: Queue<DailySweepJobData>
   budgetCheck: Queue<BudgetCheckJobData>
+  skillExecution: Queue<SkillExecutionJobData>
 }
 
 /**
@@ -16,6 +19,7 @@ export interface ScheduledQueues {
  * Jobs registered:
  * - daily-sweep: 3:00 AM daily (cron: 0 3 * * *) — re-queues stuck pipeline captures
  * - budget-check: 8:00 AM daily (cron: 0 8 * * *) — checks monthly AI spend vs thresholds
+ * - daily-connections: 9:00 PM daily (cron: 0 21 * * *) — cross-domain pattern detection skill
  *
  * jobId values are stable — BullMQ treats a repeat job with the same jobId as
  * an upsert, so calling this on every startup is safe.
@@ -72,5 +76,26 @@ export async function registerScheduledJobs(
 
   logger.info({ cron: budgetCron }, '[scheduler] budget-check repeatable job registered')
 
-  return { dailySweep: dailySweepQueue, budgetCheck: budgetCheckQueue }
+  // --------------------------------------------------------
+  // Daily connections skill (9:00 PM)
+  // --------------------------------------------------------
+  const connectionsCron = '0 21 * * *'
+
+  const skillExecutionQueue = createSkillExecutionQueue(connection)
+
+  await skillExecutionQueue.add(
+    'daily-connections',
+    {
+      skillName: 'daily-connections',
+      input: {},
+    },
+    {
+      repeat: { pattern: connectionsCron },
+      jobId: 'scheduled_daily-connections',
+    },
+  )
+
+  logger.info({ cron: connectionsCron }, '[scheduler] daily-connections repeatable job registered')
+
+  return { dailySweep: dailySweepQueue, budgetCheck: budgetCheckQueue, skillExecution: skillExecutionQueue }
 }

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -97,5 +97,24 @@ export async function registerScheduledJobs(
 
   logger.info({ cron: connectionsCron }, '[scheduler] daily-connections repeatable job registered')
 
+  // --------------------------------------------------------
+  // Drift monitor skill (8:00 AM)
+  // --------------------------------------------------------
+  const driftCron = '0 8 * * *'
+
+  await skillExecutionQueue.add(
+    'drift-monitor',
+    {
+      skillName: 'drift-monitor',
+      input: {},
+    },
+    {
+      repeat: { pattern: driftCron },
+      jobId: 'scheduled_drift-monitor',
+    },
+  )
+
+  logger.info({ cron: driftCron }, '[scheduler] drift-monitor repeatable job registered')
+
   return { dailySweep: dailySweepQueue, budgetCheck: budgetCheckQueue, skillExecution: skillExecutionQueue }
 }

--- a/packages/workers/src/skills/daily-connections-query.ts
+++ b/packages/workers/src/skills/daily-connections-query.ts
@@ -1,0 +1,246 @@
+import { sql } from 'drizzle-orm'
+import type { Database } from '@open-brain/shared'
+import type { CaptureRecord } from '@open-brain/shared'
+import { logger } from '../lib/logger.js'
+
+// ============================================================
+// Types
+// ============================================================
+
+/**
+ * Structured output from the daily connections AI call.
+ */
+export interface DailyConnectionsOutput {
+  summary: string
+  connections: ConnectionItem[]
+  meta_pattern: string | null
+}
+
+export interface ConnectionItem {
+  theme: string
+  captures: string[]
+  insight: string
+  confidence: 'high' | 'medium' | 'low'
+  domains: string[]
+}
+
+export interface DailyConnectionsResult {
+  output: DailyConnectionsOutput
+  captureCount: number
+  durationMs: number
+  /** UUID of the capture created to store the connections back into the brain */
+  savedCaptureId: string | null
+}
+
+export interface DailyConnectionsOptions {
+  /** How far back to query captures (in days). Default: 7. */
+  windowDays?: number
+  /** Approximate token budget for assembled captures context. Default: 30_000. */
+  tokenBudget?: number
+  /** Override the AI model alias. Default: 'synthesis'. */
+  modelAlias?: string
+}
+
+/**
+ * An entity pair co-occurrence record.
+ */
+export interface EntityCoOccurrence {
+  entity_a_name: string
+  entity_a_type: string
+  entity_b_name: string
+  entity_b_type: string
+  co_occurrence_count: number
+}
+
+// ============================================================
+// Constants
+// ============================================================
+
+/** Rough chars-per-token estimate (English prose). Used for budget enforcement. */
+export const CHARS_PER_TOKEN = 4
+export const DEFAULT_TOKEN_BUDGET = 30_000
+
+/** Brain view display order for context assembly. */
+export const VIEW_ORDER = ['career', 'work-internal', 'client', 'technical', 'personal']
+
+// ============================================================
+// Query functions
+// ============================================================
+
+/**
+ * Fetch all complete captures in the time window, ordered by brain_view then captured_at DESC.
+ * Excludes deleted captures.
+ */
+export async function queryRecentCaptures(
+  db: Database,
+  windowDays: number,
+): Promise<CaptureRecord[]> {
+  const now = new Date()
+  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000)
+
+  const rows = await db.execute<{
+    id: string
+    content: string
+    capture_type: string
+    brain_view: string
+    source: string
+    tags: string[]
+    captured_at: string
+    created_at: string
+    updated_at: string
+    pipeline_status: string
+    pipeline_attempts: number
+    content_hash: string
+  }>(sql`
+    SELECT id, content, capture_type, brain_view, source, tags, captured_at, created_at, updated_at,
+           pipeline_status, pipeline_attempts, content_hash
+    FROM captures
+    WHERE captured_at >= ${windowStart.toISOString()}::timestamptz
+      AND captured_at <= ${now.toISOString()}::timestamptz
+      AND pipeline_status = 'complete'
+      AND deleted_at IS NULL
+    ORDER BY brain_view ASC, captured_at DESC
+  `)
+
+  return rows.rows as unknown as CaptureRecord[]
+}
+
+/**
+ * Build entity co-occurrence data from entity_links for the given capture IDs.
+ *
+ * Queries entity_links joined with entities to find entity pairs that appear
+ * together across different captures. Returns the top N pairs by co-occurrence count.
+ *
+ * Uses the entity_relationships table (pre-computed co-occurrence graph) filtered
+ * to entities appearing in the provided capture set.
+ */
+export async function buildEntityCoOccurrence(
+  db: Database,
+  captureIds: string[],
+  topN: number = 10,
+): Promise<EntityCoOccurrence[]> {
+  if (captureIds.length === 0) return []
+
+  try {
+    const rows = await db.execute<{
+      entity_a_name: string
+      entity_a_type: string
+      entity_b_name: string
+      entity_b_type: string
+      co_occurrence_count: number
+    }>(sql`
+      WITH relevant_entities AS (
+        SELECT DISTINCT el.entity_id
+        FROM entity_links el
+        WHERE el.capture_id = ANY(${captureIds}::uuid[])
+      )
+      SELECT
+        ea.name AS entity_a_name,
+        ea.entity_type AS entity_a_type,
+        eb.name AS entity_b_name,
+        eb.entity_type AS entity_b_type,
+        er.co_occurrence_count
+      FROM entity_relationships er
+      JOIN entities ea ON ea.id = er.entity_id_a
+      JOIN entities eb ON eb.id = er.entity_id_b
+      WHERE er.entity_id_a IN (SELECT entity_id FROM relevant_entities)
+        AND er.entity_id_b IN (SELECT entity_id FROM relevant_entities)
+      ORDER BY er.co_occurrence_count DESC
+      LIMIT ${topN}
+    `)
+
+    return rows.rows as EntityCoOccurrence[]
+  } catch (err) {
+    logger.warn({ err }, '[daily-connections] failed to query entity co-occurrence — returning empty')
+    return []
+  }
+}
+
+// ============================================================
+// Context assembly
+// ============================================================
+
+export interface AssembledContext {
+  contextText: string
+  capturesByView: Record<string, number>
+}
+
+/**
+ * Group captures by brain_view, format each capture as plain text,
+ * and concatenate into a context string that fits within the char budget.
+ *
+ * Truncation strategy: process views in priority order. Within each view,
+ * captures are newest-first. Drop from the end of each view's list until
+ * under budget.
+ */
+export function assembleContext(
+  captures: CaptureRecord[],
+  maxChars: number,
+): AssembledContext {
+  // Group by view
+  const byView = new Map<string, CaptureRecord[]>()
+  for (const c of captures) {
+    const view = c.brain_view ?? 'unknown'
+    if (!byView.has(view)) byView.set(view, [])
+    byView.get(view)!.push(c)
+  }
+
+  // Determine display order (configured views first, then any extras alphabetically)
+  const allViews = [...byView.keys()]
+  const orderedViews = [
+    ...VIEW_ORDER.filter(v => byView.has(v)),
+    ...allViews.filter(v => !VIEW_ORDER.includes(v)).sort(),
+  ]
+
+  const capturesByView: Record<string, number> = {}
+  const sections: string[] = []
+  let totalChars = 0
+
+  for (const view of orderedViews) {
+    const viewCaptures = byView.get(view) ?? []
+    capturesByView[view] = viewCaptures.length
+
+    const lines: string[] = []
+    for (const c of viewCaptures) {
+      const line = formatCapture(c)
+      if (totalChars + line.length > maxChars) {
+        logger.debug({ view, truncatedAt: lines.length }, '[daily-connections] context budget reached — truncating')
+        break
+      }
+      lines.push(line)
+      totalChars += line.length
+    }
+
+    if (lines.length > 0) {
+      sections.push(`=== ${view.toUpperCase()} (${lines.length} captures) ===\n${lines.join('\n')}`)
+    }
+  }
+
+  return { contextText: sections.join('\n\n'), capturesByView }
+}
+
+/**
+ * Format entity co-occurrence data as plain text for LLM context.
+ */
+export function formatCoOccurrence(pairs: EntityCoOccurrence[]): string {
+  if (pairs.length === 0) return '(no entity co-occurrence data available)'
+
+  const lines = pairs.map(
+    p => `- ${p.entity_a_name} (${p.entity_a_type}) + ${p.entity_b_name} (${p.entity_b_type}): ${p.co_occurrence_count} co-occurrences`,
+  )
+  return lines.join('\n')
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+export function fmtDate(d: Date): string {
+  return d.toISOString().slice(0, 10) // YYYY-MM-DD
+}
+
+export function formatCapture(c: CaptureRecord): string {
+  const date = fmtDate(new Date(c.captured_at))
+  const tags = c.tags && c.tags.length > 0 ? ` [${c.tags.join(', ')}]` : ''
+  return `[${date}] [${c.capture_type}]${tags} ${c.content}\n`
+}

--- a/packages/workers/src/skills/daily-connections.ts
+++ b/packages/workers/src/skills/daily-connections.ts
@@ -1,0 +1,361 @@
+import { join } from 'node:path'
+import OpenAI from 'openai'
+import type { Database } from '@open-brain/shared'
+import { skills_log, loadAndRenderPromptTemplate } from '@open-brain/shared'
+import { logger } from '../lib/logger.js'
+import { PushoverService } from '../services/pushover.js'
+import {
+  queryRecentCaptures,
+  buildEntityCoOccurrence,
+  assembleContext,
+  formatCoOccurrence,
+  fmtDate,
+  CHARS_PER_TOKEN,
+} from './daily-connections-query.js'
+import type {
+  DailyConnectionsOutput,
+  DailyConnectionsResult,
+  DailyConnectionsOptions,
+  ConnectionItem,
+} from './daily-connections-query.js'
+
+// Re-export types so consumers can import from this file
+export type { DailyConnectionsOutput, DailyConnectionsResult, DailyConnectionsOptions } from './daily-connections-query.js'
+
+const DEFAULT_WINDOW_DAYS = 7
+const DEFAULT_TOKEN_BUDGET = 30_000
+const LLM_TIMEOUT_MS = 120_000
+
+/**
+ * DailyConnectionsSkill — surfaces non-obvious cross-domain connections
+ * across recent captures using entity co-occurrence data and LLM synthesis.
+ *
+ * Follows the WeeklyBriefSkill pattern: query data, assemble context,
+ * call LLM, parse output, deliver via Pushover, save as capture, log to skills_log.
+ */
+export class DailyConnectionsSkill {
+  private db: Database
+  private litellmClient: OpenAI
+  private pushover: PushoverService
+  private promptsDir: string
+  private coreApiUrl: string
+
+  constructor(opts: {
+    db: Database
+    litellmBaseUrl?: string
+    litellmApiKey?: string
+    pushover?: PushoverService
+    promptsDir?: string
+    coreApiUrl?: string
+  }) {
+    this.db = opts.db
+    this.litellmClient = new OpenAI({
+      baseURL: opts.litellmBaseUrl ?? process.env.LITELLM_URL ?? 'https://llm.k4jda.net',
+      apiKey: opts.litellmApiKey ?? process.env.LITELLM_API_KEY ?? 'no-key',
+      timeout: LLM_TIMEOUT_MS,
+    })
+    this.pushover = opts.pushover ?? new PushoverService()
+    this.promptsDir = opts.promptsDir ?? join(process.cwd(), 'config', 'prompts')
+    this.coreApiUrl = opts.coreApiUrl ?? process.env.OPEN_BRAIN_API_URL ?? 'http://localhost:3000'
+  }
+
+  async execute(options: DailyConnectionsOptions = {}): Promise<DailyConnectionsResult> {
+    const {
+      windowDays = DEFAULT_WINDOW_DAYS,
+      tokenBudget = DEFAULT_TOKEN_BUDGET,
+      modelAlias = 'synthesis',
+    } = options
+
+    const startMs = Date.now()
+    const now = new Date()
+    const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000)
+    logger.info({ windowDays, windowStart }, '[daily-connections] starting execution')
+
+    // Step 1: Query recent captures
+    const captures = await queryRecentCaptures(this.db, windowDays)
+    const captureCount = captures.length
+    logger.info({ captureCount }, '[daily-connections] captures fetched')
+
+    if (captureCount === 0) {
+      logger.info('[daily-connections] no captures in window — skipping LLM call')
+      await this.logToSkillsLog({
+        inputSummary: `0 captures in last ${windowDays} days`,
+        outputSummary: 'Skipped — no captures',
+        durationMs: Date.now() - startMs,
+      })
+      return {
+        output: emptyOutput(),
+        captureCount: 0,
+        durationMs: Date.now() - startMs,
+        savedCaptureId: null,
+      }
+    }
+
+    // Step 2: Build entity co-occurrence data
+    const captureIds = captures.map(c => c.id)
+    const coOccurrence = await buildEntityCoOccurrence(this.db, captureIds)
+    logger.info({ coOccurrencePairs: coOccurrence.length }, '[daily-connections] entity co-occurrence built')
+
+    // Step 3: Assemble context within token budget
+    const { contextText } = assembleContext(captures, tokenBudget * CHARS_PER_TOKEN)
+    const coOccurrenceText = formatCoOccurrence(coOccurrence)
+    const dateRange = `${fmtDate(windowStart)} to ${fmtDate(now)}`
+
+    // Step 4: Call LLM
+    const rawOutput = await this.callLLM(contextText, coOccurrenceText, dateRange, captureCount, modelAlias)
+    const output = parseOutput(rawOutput)
+    const durationMs = Date.now() - startMs
+
+    // Step 5: Deliver Pushover notification (top 3 connections summary)
+    await this.deliverPushover(output)
+
+    // Step 6: Save as capture back into the brain
+    const savedCaptureId = await this.saveConnectionsCapture(output, fmtDate(windowStart), fmtDate(now))
+
+    // Step 7: Log to skills_log
+    await this.logToSkillsLog({
+      inputSummary: `${captureCount} captures from ${dateRange}, ${coOccurrence.length} entity pairs`,
+      outputSummary: `summary: "${output.summary}" | connections:${output.connections.length} | meta_pattern:${output.meta_pattern ? 'yes' : 'none'}`,
+      durationMs,
+      captureId: savedCaptureId ?? undefined,
+      result: output,
+    })
+
+    logger.info({ captureCount, connectionCount: output.connections.length, durationMs, savedCaptureId }, '[daily-connections] execution complete')
+
+    return { output, captureCount, durationMs, savedCaptureId }
+  }
+
+  // ----------------------------------------------------------
+  // Private: LLM call
+  // ----------------------------------------------------------
+
+  private async callLLM(
+    contextText: string,
+    coOccurrenceText: string,
+    dateRange: string,
+    captureCount: number,
+    modelAlias: string,
+  ): Promise<string> {
+    const prompt = loadAndRenderPromptTemplate(this.promptsDir, 'daily_connections_v1.txt', {
+      date_range: dateRange,
+      capture_count: String(captureCount),
+      captures: contextText,
+      entity_cooccurrence: coOccurrenceText,
+    })
+    logger.debug({ modelAlias, promptLength: prompt.length }, '[daily-connections] calling LLM')
+
+    const response = await this.litellmClient.chat.completions.create({
+      model: modelAlias,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.4,
+      max_tokens: 2048,
+      extra_body: { chat_template_kwargs: { enable_thinking: false } },
+    } as any)
+
+    const text = response.choices[0]?.message?.content ?? ''
+    logger.info(
+      { promptTokens: response.usage?.prompt_tokens, completionTokens: response.usage?.completion_tokens },
+      '[daily-connections] LLM call complete',
+    )
+    return text
+  }
+
+  // ----------------------------------------------------------
+  // Private: Pushover delivery
+  // ----------------------------------------------------------
+
+  private async deliverPushover(output: DailyConnectionsOutput): Promise<void> {
+    if (!this.pushover.isConfigured) return
+    if (output.connections.length === 0) return
+
+    const top3 = output.connections.slice(0, 3)
+    const lines = [
+      output.summary,
+      '',
+      ...top3.map((c, i) => `${i + 1}. ${c.theme}: ${c.insight.slice(0, 100)}`),
+    ]
+
+    try {
+      await this.pushover.send({
+        title: 'Daily Connections',
+        message: lines.join('\n'),
+        priority: 0,
+      })
+    } catch {
+      // Pushover delivery is non-fatal
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Private: Save as capture
+  // ----------------------------------------------------------
+
+  private async saveConnectionsCapture(
+    output: DailyConnectionsOutput,
+    windowStart: string,
+    windowEnd: string,
+  ): Promise<string | null> {
+    try {
+      const content = buildConnectionsText(output, windowStart, windowEnd)
+      const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content,
+          capture_type: 'reflection',
+          brain_view: 'personal',
+          source: 'api',
+          tags: ['connections', 'skill-output'],
+          metadata: {
+            source_metadata: {
+              generator: 'daily-connections-skill',
+              window_start: windowStart,
+              window_end: windowEnd,
+            },
+          },
+        }),
+        signal: AbortSignal.timeout(15_000),
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as { id?: string; data?: { id?: string } }
+      return data.id ?? data.data?.id ?? null
+    } catch {
+      return null
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Private: skills_log
+  // ----------------------------------------------------------
+
+  private async logToSkillsLog(params: {
+    inputSummary: string
+    outputSummary: string
+    durationMs: number
+    captureId?: string
+    result?: DailyConnectionsOutput
+  }): Promise<void> {
+    try {
+      await this.db.insert(skills_log).values({
+        skill_name: 'daily-connections',
+        capture_id: params.captureId ?? null,
+        input_summary: params.inputSummary,
+        output_summary: params.outputSummary,
+        result: params.result ?? null,
+        duration_ms: params.durationMs,
+      })
+    } catch {
+      // skills_log failure is non-fatal
+    }
+  }
+}
+
+// ============================================================
+// Top-level entry point — called by BullMQ worker dispatcher
+// ============================================================
+
+/** Top-level entry point called by BullMQ worker. */
+export async function executeDailyConnections(
+  db: Database,
+  options: DailyConnectionsOptions = {},
+): Promise<DailyConnectionsResult> {
+  return new DailyConnectionsSkill({ db }).execute(options)
+}
+
+// ============================================================
+// Output parsing
+// ============================================================
+
+function emptyOutput(): DailyConnectionsOutput {
+  return { summary: '', connections: [], meta_pattern: null }
+}
+
+/**
+ * Parses LLM JSON output into a DailyConnectionsOutput.
+ * Handles markdown code fences and malformed output gracefully.
+ * Exported for testing.
+ */
+export function parseOutput(raw: string): DailyConnectionsOutput {
+  let cleaned = raw.trim()
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
+  }
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(cleaned)
+  } catch (err) {
+    logger.warn({ raw: raw.slice(0, 500), err }, '[daily-connections] failed to parse LLM output as JSON — saving raw text')
+    // Graceful fallback: return the raw text as the summary so it's still saved
+    return {
+      summary: raw.slice(0, 150),
+      connections: [],
+      meta_pattern: null,
+    }
+  }
+
+  const summary = typeof parsed.summary === 'string' ? parsed.summary : '(no summary)'
+  const meta_pattern = typeof parsed.meta_pattern === 'string' ? parsed.meta_pattern : null
+
+  // Parse connections array
+  const connections: ConnectionItem[] = []
+  if (Array.isArray(parsed.connections)) {
+    for (const item of parsed.connections) {
+      if (typeof item === 'object' && item !== null) {
+        const conn = item as Record<string, unknown>
+        connections.push({
+          theme: typeof conn.theme === 'string' ? conn.theme : '(unnamed)',
+          captures: Array.isArray(conn.captures)
+            ? conn.captures.filter((c): c is string => typeof c === 'string')
+            : [],
+          insight: typeof conn.insight === 'string' ? conn.insight : '',
+          confidence: isValidConfidence(conn.confidence) ? conn.confidence : 'low',
+          domains: Array.isArray(conn.domains)
+            ? conn.domains.filter((d): d is string => typeof d === 'string')
+            : [],
+        })
+      }
+    }
+  }
+
+  return { summary, connections, meta_pattern }
+}
+
+function isValidConfidence(val: unknown): val is 'high' | 'medium' | 'low' {
+  return val === 'high' || val === 'medium' || val === 'low'
+}
+
+// ============================================================
+// Text rendering (for capture-back-to-brain)
+// ============================================================
+
+function buildConnectionsText(
+  output: DailyConnectionsOutput,
+  windowStart: string,
+  windowEnd: string,
+): string {
+  const lines: string[] = [
+    `Daily Connections — ${windowStart} to ${windowEnd}`,
+    '',
+    output.summary,
+    '',
+  ]
+
+  if (output.connections.length > 0) {
+    lines.push('Connections:')
+    for (const conn of output.connections) {
+      lines.push(`- [${conn.confidence}] ${conn.theme} (${conn.domains.join(', ')})`)
+      lines.push(`  ${conn.insight}`)
+    }
+    lines.push('')
+  }
+
+  if (output.meta_pattern) {
+    lines.push('Meta-pattern:')
+    lines.push(output.meta_pattern)
+    lines.push('')
+  }
+
+  return lines.join('\n').trim()
+}

--- a/packages/workers/src/skills/daily-connections.ts
+++ b/packages/workers/src/skills/daily-connections.ts
@@ -61,10 +61,12 @@ export class DailyConnectionsSkill {
 
   async execute(options: DailyConnectionsOptions = {}): Promise<DailyConnectionsResult> {
     const {
-      windowDays = DEFAULT_WINDOW_DAYS,
-      tokenBudget = DEFAULT_TOKEN_BUDGET,
+      windowDays: rawWindowDays = DEFAULT_WINDOW_DAYS,
+      tokenBudget: rawTokenBudget = DEFAULT_TOKEN_BUDGET,
       modelAlias = 'synthesis',
     } = options
+    const windowDays = Math.max(1, Math.min(rawWindowDays, 365))
+    const tokenBudget = Math.max(1_000, Math.min(rawTokenBudget, 100_000))
 
     const startMs = Date.now()
     const now = new Date()

--- a/packages/workers/src/skills/drift-monitor-query.ts
+++ b/packages/workers/src/skills/drift-monitor-query.ts
@@ -1,0 +1,326 @@
+import { sql } from 'drizzle-orm'
+import type { Database } from '@open-brain/shared'
+import { logger } from '../lib/logger.js'
+
+// ============================================================
+// Types
+// ============================================================
+
+/**
+ * Structured output from the drift monitor AI call.
+ */
+export interface DriftMonitorOutput {
+  summary: string
+  drift_items: DriftItem[]
+  overall_health: 'healthy' | 'minor_drift' | 'significant_drift' | 'critical_drift'
+}
+
+export interface DriftItem {
+  item_type: 'bet' | 'commitment' | 'entity'
+  item_name: string
+  severity: 'high' | 'medium' | 'low'
+  days_silent: number
+  reason: string
+  suggested_action: string
+}
+
+export interface DriftMonitorResult {
+  output: DriftMonitorOutput
+  durationMs: number
+  /** UUID of the capture created to store the drift report back into the brain */
+  savedCaptureId: string | null
+  /** Whether a Pushover notification was sent (only if severity >= medium items exist) */
+  notificationSent: boolean
+}
+
+export interface DriftMonitorOptions {
+  /** How many days back to check for bet activity. Default: 14. */
+  betActivityDays?: number
+  /** How many days of governance sessions to scan for commitments. Default: 30. */
+  commitmentDays?: number
+  /** Rolling window for entity frequency comparison (in days). Default: 7. */
+  entityWindowDays?: number
+  /** Override the AI model alias. Default: 'synthesis'. */
+  modelAlias?: string
+}
+
+// ============================================================
+// Pending bet with activity data
+// ============================================================
+
+export interface PendingBet {
+  id: string
+  statement: string
+  confidence: number
+  domain: string | null
+  resolution_date: string | null
+  created_at: string
+}
+
+export interface BetWithActivity extends PendingBet {
+  recent_capture_count: number
+  days_since_last_mention: number | null
+}
+
+// ============================================================
+// Entity frequency data
+// ============================================================
+
+export interface EntityFrequency {
+  entity_id: string
+  entity_name: string
+  entity_type: string
+  current_count: number
+  previous_count: number
+  /** Percentage change: negative means decline */
+  change_pct: number
+}
+
+// ============================================================
+// Governance commitment data
+// ============================================================
+
+export interface GovernanceCommitment {
+  session_id: string
+  session_date: string
+  summary: string | null
+  /** Last assistant message from the session — often contains action items */
+  closing_message: string | null
+}
+
+// ============================================================
+// Constants
+// ============================================================
+
+export const DEFAULT_BET_ACTIVITY_DAYS = 14
+export const DEFAULT_COMMITMENT_DAYS = 30
+export const DEFAULT_ENTITY_WINDOW_DAYS = 7
+
+// ============================================================
+// Query functions
+// ============================================================
+
+/**
+ * Fetch all pending bets (resolution = 'pending' or null).
+ */
+export async function queryPendingBets(db: Database): Promise<PendingBet[]> {
+  try {
+    const rows = await db.execute<{
+      id: string
+      statement: string
+      confidence: number
+      domain: string | null
+      resolution_date: string | null
+      created_at: string
+    }>(sql`
+      SELECT id, statement, confidence, domain, resolution_date, created_at
+      FROM bets
+      WHERE resolution = 'pending' OR resolution IS NULL
+      ORDER BY created_at DESC
+    `)
+    return rows.rows as PendingBet[]
+  } catch (err) {
+    logger.warn({ err }, '[drift-monitor] failed to query pending bets')
+    return []
+  }
+}
+
+/**
+ * For each pending bet, count recent captures that mention the bet's statement
+ * (via full-text search) and find the most recent mention date.
+ *
+ * Uses FTS `to_tsquery` with the first few significant words of the bet statement.
+ */
+export async function queryBetActivity(
+  db: Database,
+  bet: PendingBet,
+  days: number,
+): Promise<BetWithActivity> {
+  try {
+    const rows = await db.execute<{
+      recent_count: string
+      days_since: string | null
+    }>(sql`
+      SELECT
+        COUNT(*)::text AS recent_count,
+        EXTRACT(DAY FROM (NOW() - MAX(captured_at)))::text AS days_since
+      FROM captures
+      WHERE deleted_at IS NULL
+        AND pipeline_status = 'complete'
+        AND captured_at >= (NOW() - ${days + ' days'}::interval)
+        AND to_tsvector('english', content) @@ plainto_tsquery('english', ${bet.statement})
+    `)
+
+    const row = rows.rows[0]
+    return {
+      ...bet,
+      recent_capture_count: row ? parseInt(row.recent_count, 10) : 0,
+      days_since_last_mention: row?.days_since != null ? Math.round(parseFloat(row.days_since)) : null,
+    }
+  } catch (err) {
+    logger.warn({ err, betId: bet.id }, '[drift-monitor] failed to query bet activity')
+    return { ...bet, recent_capture_count: 0, days_since_last_mention: null }
+  }
+}
+
+/**
+ * Compare entity mention frequency between the current window and the previous window.
+ * Returns entities with >50% decline in mention count.
+ *
+ * Only includes entities with at least 2 mentions in the previous window (filters out
+ * one-off mentions that naturally drop to zero).
+ */
+export async function queryEntityFrequency(
+  db: Database,
+  windowDays: number,
+): Promise<EntityFrequency[]> {
+  try {
+    const rows = await db.execute<{
+      entity_id: string
+      entity_name: string
+      entity_type: string
+      current_count: string
+      previous_count: string
+    }>(sql`
+      WITH current_window AS (
+        SELECT el.entity_id, COUNT(*)::int AS cnt
+        FROM entity_links el
+        JOIN captures c ON c.id = el.capture_id
+        WHERE c.deleted_at IS NULL
+          AND c.captured_at >= (NOW() - ${windowDays + ' days'}::interval)
+        GROUP BY el.entity_id
+      ),
+      previous_window AS (
+        SELECT el.entity_id, COUNT(*)::int AS cnt
+        FROM entity_links el
+        JOIN captures c ON c.id = el.capture_id
+        WHERE c.deleted_at IS NULL
+          AND c.captured_at >= (NOW() - ${(windowDays * 2) + ' days'}::interval)
+          AND c.captured_at < (NOW() - ${windowDays + ' days'}::interval)
+        GROUP BY el.entity_id
+      )
+      SELECT
+        e.id AS entity_id,
+        e.name AS entity_name,
+        e.entity_type,
+        COALESCE(cw.cnt, 0)::text AS current_count,
+        pw.cnt::text AS previous_count
+      FROM previous_window pw
+      JOIN entities e ON e.id = pw.entity_id
+      LEFT JOIN current_window cw ON cw.entity_id = pw.entity_id
+      WHERE pw.cnt >= 2
+        AND (COALESCE(cw.cnt, 0)::float / pw.cnt::float) < 0.5
+      ORDER BY pw.cnt DESC
+      LIMIT 20
+    `)
+
+    return rows.rows.map(r => {
+      const current = parseInt(r.current_count, 10)
+      const previous = parseInt(r.previous_count, 10)
+      return {
+        entity_id: r.entity_id,
+        entity_name: r.entity_name,
+        entity_type: r.entity_type,
+        current_count: current,
+        previous_count: previous,
+        change_pct: previous > 0 ? ((current - previous) / previous) * 100 : 0,
+      }
+    })
+  } catch (err) {
+    logger.warn({ err }, '[drift-monitor] failed to query entity frequency')
+    return []
+  }
+}
+
+/**
+ * Fetch completed governance sessions from the last N days, including their summary
+ * and the last assistant message (which often contains commitments/action items).
+ */
+export async function queryGovernanceCommitments(
+  db: Database,
+  days: number,
+): Promise<GovernanceCommitment[]> {
+  try {
+    const rows = await db.execute<{
+      session_id: string
+      session_date: string
+      summary: string | null
+      closing_message: string | null
+    }>(sql`
+      SELECT
+        s.id AS session_id,
+        s.completed_at::text AS session_date,
+        s.summary,
+        (
+          SELECT sm.content
+          FROM session_messages sm
+          WHERE sm.session_id = s.id AND sm.role = 'assistant'
+          ORDER BY sm.created_at DESC
+          LIMIT 1
+        ) AS closing_message
+      FROM sessions s
+      WHERE s.session_type = 'governance'
+        AND s.status = 'complete'
+        AND s.completed_at >= (NOW() - ${days + ' days'}::interval)
+      ORDER BY s.completed_at DESC
+    `)
+
+    return rows.rows as GovernanceCommitment[]
+  } catch (err) {
+    logger.warn({ err }, '[drift-monitor] failed to query governance commitments')
+    return []
+  }
+}
+
+// ============================================================
+// Context formatting
+// ============================================================
+
+/**
+ * Format pending bets with activity data as plain text for LLM context.
+ */
+export function formatPendingBets(betsWithActivity: BetWithActivity[]): string {
+  if (betsWithActivity.length === 0) return '(no pending bets)'
+
+  return betsWithActivity.map(b => {
+    const resDate = b.resolution_date ? ` | resolution date: ${b.resolution_date.slice(0, 10)}` : ''
+    const activity = b.recent_capture_count > 0
+      ? `${b.recent_capture_count} recent captures, last mention ${b.days_since_last_mention ?? '?'} days ago`
+      : 'NO recent captures mentioning this bet'
+    return `- [${b.domain ?? 'general'}] "${b.statement}" (confidence: ${b.confidence}${resDate}) — created ${b.created_at.slice(0, 10)} — Activity: ${activity}`
+  }).join('\n')
+}
+
+/**
+ * Format governance commitments as plain text for LLM context.
+ */
+export function formatGovernanceCommitments(commitments: GovernanceCommitment[]): string {
+  if (commitments.length === 0) return '(no governance sessions in window)'
+
+  return commitments.map(c => {
+    const lines: string[] = []
+    lines.push(`Session ${c.session_id.slice(0, 8)} (${c.session_date?.slice(0, 10) ?? 'unknown date'}):`)
+    if (c.summary) lines.push(`  Summary: ${c.summary.slice(0, 300)}`)
+    if (c.closing_message) lines.push(`  Closing message: ${c.closing_message.slice(0, 500)}`)
+    return lines.join('\n')
+  }).join('\n\n')
+}
+
+/**
+ * Format entity frequency data as plain text for LLM context.
+ */
+export function formatEntityFrequency(entities: EntityFrequency[]): string {
+  if (entities.length === 0) return '(no significant entity frequency declines detected)'
+
+  return entities.map(e =>
+    `- ${e.entity_name} (${e.entity_type}): ${e.previous_count} mentions (previous window) → ${e.current_count} mentions (current window) [${e.change_pct.toFixed(0)}% change]`,
+  ).join('\n')
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+export function fmtDate(d: Date): string {
+  return d.toISOString().slice(0, 10) // YYYY-MM-DD
+}

--- a/packages/workers/src/skills/drift-monitor.ts
+++ b/packages/workers/src/skills/drift-monitor.ts
@@ -67,11 +67,14 @@ export class DriftMonitorSkill {
 
   async execute(options: DriftMonitorOptions = {}): Promise<DriftMonitorResult> {
     const {
-      betActivityDays = DEFAULT_BET_ACTIVITY_DAYS,
-      commitmentDays = DEFAULT_COMMITMENT_DAYS,
-      entityWindowDays = DEFAULT_ENTITY_WINDOW_DAYS,
+      betActivityDays: rawBetDays = DEFAULT_BET_ACTIVITY_DAYS,
+      commitmentDays: rawCommitDays = DEFAULT_COMMITMENT_DAYS,
+      entityWindowDays: rawEntityDays = DEFAULT_ENTITY_WINDOW_DAYS,
       modelAlias = 'synthesis',
     } = options
+    const betActivityDays = Math.max(1, Math.min(rawBetDays, 365))
+    const commitmentDays = Math.max(1, Math.min(rawCommitDays, 365))
+    const entityWindowDays = Math.max(1, Math.min(rawEntityDays, 365))
 
     const startMs = Date.now()
     const now = new Date()

--- a/packages/workers/src/skills/drift-monitor.ts
+++ b/packages/workers/src/skills/drift-monitor.ts
@@ -1,0 +1,391 @@
+import { join } from 'node:path'
+import OpenAI from 'openai'
+import type { Database } from '@open-brain/shared'
+import { skills_log, loadAndRenderPromptTemplate } from '@open-brain/shared'
+import { logger } from '../lib/logger.js'
+import { PushoverService } from '../services/pushover.js'
+import {
+  queryPendingBets,
+  queryBetActivity,
+  queryEntityFrequency,
+  queryGovernanceCommitments,
+  formatPendingBets,
+  formatGovernanceCommitments,
+  formatEntityFrequency,
+  fmtDate,
+  DEFAULT_BET_ACTIVITY_DAYS,
+  DEFAULT_COMMITMENT_DAYS,
+  DEFAULT_ENTITY_WINDOW_DAYS,
+} from './drift-monitor-query.js'
+import type {
+  DriftMonitorOutput,
+  DriftMonitorResult,
+  DriftMonitorOptions,
+  DriftItem,
+  BetWithActivity,
+} from './drift-monitor-query.js'
+
+// Re-export types so consumers can import from this file
+export type { DriftMonitorOutput, DriftMonitorResult, DriftMonitorOptions } from './drift-monitor-query.js'
+
+const LLM_TIMEOUT_MS = 120_000
+
+/**
+ * DriftMonitorSkill — detects when tracked commitments, bets, or projects go silent.
+ *
+ * Follows the DailyConnectionsSkill pattern: query data, assemble context,
+ * call LLM, parse output, conditionally deliver via Pushover, save as capture, log to skills_log.
+ *
+ * Key difference from DailyConnectionsSkill: Pushover notification is only sent
+ * when drift items with severity >= medium exist.
+ */
+export class DriftMonitorSkill {
+  private db: Database
+  private litellmClient: OpenAI
+  private pushover: PushoverService
+  private promptsDir: string
+  private coreApiUrl: string
+
+  constructor(opts: {
+    db: Database
+    litellmBaseUrl?: string
+    litellmApiKey?: string
+    pushover?: PushoverService
+    promptsDir?: string
+    coreApiUrl?: string
+  }) {
+    this.db = opts.db
+    this.litellmClient = new OpenAI({
+      baseURL: opts.litellmBaseUrl ?? process.env.LITELLM_URL ?? 'https://llm.k4jda.net',
+      apiKey: opts.litellmApiKey ?? process.env.LITELLM_API_KEY ?? 'no-key',
+      timeout: LLM_TIMEOUT_MS,
+    })
+    this.pushover = opts.pushover ?? new PushoverService()
+    this.promptsDir = opts.promptsDir ?? join(process.cwd(), 'config', 'prompts')
+    this.coreApiUrl = opts.coreApiUrl ?? process.env.OPEN_BRAIN_API_URL ?? 'http://localhost:3000'
+  }
+
+  async execute(options: DriftMonitorOptions = {}): Promise<DriftMonitorResult> {
+    const {
+      betActivityDays = DEFAULT_BET_ACTIVITY_DAYS,
+      commitmentDays = DEFAULT_COMMITMENT_DAYS,
+      entityWindowDays = DEFAULT_ENTITY_WINDOW_DAYS,
+      modelAlias = 'synthesis',
+    } = options
+
+    const startMs = Date.now()
+    const now = new Date()
+    logger.info({ betActivityDays, commitmentDays, entityWindowDays }, '[drift-monitor] starting execution')
+
+    // Step 1: Query pending bets and their activity
+    const pendingBets = await queryPendingBets(this.db)
+    const betsWithActivity: BetWithActivity[] = await Promise.all(
+      pendingBets.map(bet => queryBetActivity(this.db, bet, betActivityDays)),
+    )
+    logger.info({ pendingBetCount: pendingBets.length }, '[drift-monitor] bets queried')
+
+    // Step 2: Query governance commitments
+    const commitments = await queryGovernanceCommitments(this.db, commitmentDays)
+    logger.info({ commitmentCount: commitments.length }, '[drift-monitor] governance commitments queried')
+
+    // Step 3: Query entity frequency trends
+    const entityFrequency = await queryEntityFrequency(this.db, entityWindowDays)
+    logger.info({ decliningEntityCount: entityFrequency.length }, '[drift-monitor] entity frequency queried')
+
+    // Step 4: Check if there's anything to analyze
+    const hasData = betsWithActivity.length > 0 || commitments.length > 0 || entityFrequency.length > 0
+    if (!hasData) {
+      logger.info('[drift-monitor] no bets, commitments, or declining entities — skipping LLM call')
+      const emptyResult = emptyOutput()
+      await this.logToSkillsLog({
+        inputSummary: 'No pending bets, no governance commitments, no entity frequency data',
+        outputSummary: 'Skipped — no data to analyze',
+        durationMs: Date.now() - startMs,
+      })
+      return {
+        output: emptyResult,
+        durationMs: Date.now() - startMs,
+        savedCaptureId: null,
+        notificationSent: false,
+      }
+    }
+
+    // Step 5: Assemble context and call LLM
+    const pendingBetsText = formatPendingBets(betsWithActivity)
+    const commitmentsText = formatGovernanceCommitments(commitments)
+    const entityFrequencyText = formatEntityFrequency(entityFrequency)
+    const analysisDate = fmtDate(now)
+
+    const rawOutput = await this.callLLM(pendingBetsText, commitmentsText, entityFrequencyText, analysisDate, modelAlias)
+    const output = parseOutput(rawOutput)
+    const durationMs = Date.now() - startMs
+
+    // Step 6: Conditional Pushover — only if severity >= medium items exist
+    const hasMediumOrAbove = output.drift_items.some(d => d.severity === 'high' || d.severity === 'medium')
+    let notificationSent = false
+    if (hasMediumOrAbove) {
+      notificationSent = await this.deliverPushover(output)
+    }
+
+    // Step 7: Save as capture back into the brain
+    const savedCaptureId = await this.saveDriftCapture(output, analysisDate)
+
+    // Step 8: Log to skills_log
+    await this.logToSkillsLog({
+      inputSummary: `${betsWithActivity.length} bets, ${commitments.length} commitments, ${entityFrequency.length} declining entities`,
+      outputSummary: `health: ${output.overall_health} | drift_items: ${output.drift_items.length} | high: ${output.drift_items.filter(d => d.severity === 'high').length} | medium: ${output.drift_items.filter(d => d.severity === 'medium').length} | notified: ${notificationSent}`,
+      durationMs,
+      captureId: savedCaptureId ?? undefined,
+      result: output,
+    })
+
+    logger.info(
+      { driftItemCount: output.drift_items.length, overallHealth: output.overall_health, durationMs, notificationSent, savedCaptureId },
+      '[drift-monitor] execution complete',
+    )
+
+    return { output, durationMs, savedCaptureId, notificationSent }
+  }
+
+  // ----------------------------------------------------------
+  // Private: LLM call
+  // ----------------------------------------------------------
+
+  private async callLLM(
+    pendingBetsText: string,
+    commitmentsText: string,
+    entityFrequencyText: string,
+    analysisDate: string,
+    modelAlias: string,
+  ): Promise<string> {
+    const prompt = loadAndRenderPromptTemplate(this.promptsDir, 'drift_monitor_v1.txt', {
+      analysis_date: analysisDate,
+      pending_bets: pendingBetsText,
+      governance_commitments: commitmentsText,
+      entity_frequency: entityFrequencyText,
+    })
+    logger.debug({ modelAlias, promptLength: prompt.length }, '[drift-monitor] calling LLM')
+
+    const response = await this.litellmClient.chat.completions.create({
+      model: modelAlias,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.3,
+      max_tokens: 2048,
+      extra_body: { chat_template_kwargs: { enable_thinking: false } },
+    } as any)
+
+    const text = response.choices[0]?.message?.content ?? ''
+    logger.info(
+      { promptTokens: response.usage?.prompt_tokens, completionTokens: response.usage?.completion_tokens },
+      '[drift-monitor] LLM call complete',
+    )
+    return text
+  }
+
+  // ----------------------------------------------------------
+  // Private: Conditional Pushover delivery
+  // ----------------------------------------------------------
+
+  private async deliverPushover(output: DriftMonitorOutput): Promise<boolean> {
+    if (!this.pushover.isConfigured) return false
+
+    const mediumAndAbove = output.drift_items.filter(d => d.severity === 'high' || d.severity === 'medium')
+    if (mediumAndAbove.length === 0) return false
+
+    const highCount = mediumAndAbove.filter(d => d.severity === 'high').length
+    const priority = highCount > 0 ? 1 : 0 // high priority for Pushover if any high-severity drift items
+
+    const lines = [
+      output.summary,
+      '',
+      ...mediumAndAbove.slice(0, 5).map((d, i) =>
+        `${i + 1}. [${d.severity.toUpperCase()}] ${d.item_name.slice(0, 60)} — ${d.days_silent}d silent`,
+      ),
+    ]
+
+    try {
+      await this.pushover.send({
+        title: `Drift Monitor: ${output.overall_health.replace(/_/g, ' ')}`,
+        message: lines.join('\n'),
+        priority: priority as 0 | 1,
+      })
+      return true
+    } catch {
+      // Pushover delivery is non-fatal
+      return false
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Private: Save as capture
+  // ----------------------------------------------------------
+
+  private async saveDriftCapture(
+    output: DriftMonitorOutput,
+    analysisDate: string,
+  ): Promise<string | null> {
+    try {
+      const content = buildDriftText(output, analysisDate)
+      const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content,
+          capture_type: 'reflection',
+          brain_view: 'personal',
+          source: 'api',
+          tags: ['drift', 'skill-output'],
+          metadata: {
+            source_metadata: {
+              generator: 'drift-monitor-skill',
+              analysis_date: analysisDate,
+              overall_health: output.overall_health,
+            },
+          },
+        }),
+        signal: AbortSignal.timeout(15_000),
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as { id?: string; data?: { id?: string } }
+      return data.id ?? data.data?.id ?? null
+    } catch {
+      return null
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Private: skills_log
+  // ----------------------------------------------------------
+
+  private async logToSkillsLog(params: {
+    inputSummary: string
+    outputSummary: string
+    durationMs: number
+    captureId?: string
+    result?: DriftMonitorOutput
+  }): Promise<void> {
+    try {
+      await this.db.insert(skills_log).values({
+        skill_name: 'drift-monitor',
+        capture_id: params.captureId ?? null,
+        input_summary: params.inputSummary,
+        output_summary: params.outputSummary,
+        result: params.result ?? null,
+        duration_ms: params.durationMs,
+      })
+    } catch {
+      // skills_log failure is non-fatal
+    }
+  }
+}
+
+// ============================================================
+// Top-level entry point — called by BullMQ worker dispatcher
+// ============================================================
+
+/** Top-level entry point called by BullMQ worker. */
+export async function executeDriftMonitor(
+  db: Database,
+  options: DriftMonitorOptions = {},
+): Promise<DriftMonitorResult> {
+  return new DriftMonitorSkill({ db }).execute(options)
+}
+
+// ============================================================
+// Output parsing
+// ============================================================
+
+function emptyOutput(): DriftMonitorOutput {
+  return { summary: 'All tracked items are active — no drift detected.', drift_items: [], overall_health: 'healthy' }
+}
+
+/**
+ * Parses LLM JSON output into a DriftMonitorOutput.
+ * Handles markdown code fences and malformed output gracefully.
+ * Exported for testing.
+ */
+export function parseOutput(raw: string): DriftMonitorOutput {
+  let cleaned = raw.trim()
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
+  }
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(cleaned)
+  } catch (err) {
+    logger.warn({ raw: raw.slice(0, 500), err }, '[drift-monitor] failed to parse LLM output as JSON — saving raw text')
+    return {
+      summary: raw.slice(0, 150),
+      drift_items: [],
+      overall_health: 'healthy',
+    }
+  }
+
+  const summary = typeof parsed.summary === 'string' ? parsed.summary : '(no summary)'
+  const overall_health = isValidHealth(parsed.overall_health) ? parsed.overall_health : 'healthy'
+
+  // Parse drift_items array
+  const drift_items: DriftItem[] = []
+  if (Array.isArray(parsed.drift_items)) {
+    for (const item of parsed.drift_items) {
+      if (typeof item === 'object' && item !== null) {
+        const d = item as Record<string, unknown>
+        drift_items.push({
+          item_type: isValidItemType(d.item_type) ? d.item_type : 'entity',
+          item_name: typeof d.item_name === 'string' ? d.item_name : '(unnamed)',
+          severity: isValidSeverity(d.severity) ? d.severity : 'low',
+          days_silent: typeof d.days_silent === 'number' ? d.days_silent : 0,
+          reason: typeof d.reason === 'string' ? d.reason : '',
+          suggested_action: typeof d.suggested_action === 'string' ? d.suggested_action : '',
+        })
+      }
+    }
+  }
+
+  return { summary, drift_items, overall_health }
+}
+
+function isValidHealth(val: unknown): val is DriftMonitorOutput['overall_health'] {
+  return val === 'healthy' || val === 'minor_drift' || val === 'significant_drift' || val === 'critical_drift'
+}
+
+function isValidSeverity(val: unknown): val is 'high' | 'medium' | 'low' {
+  return val === 'high' || val === 'medium' || val === 'low'
+}
+
+function isValidItemType(val: unknown): val is 'bet' | 'commitment' | 'entity' {
+  return val === 'bet' || val === 'commitment' || val === 'entity'
+}
+
+// ============================================================
+// Text rendering (for capture-back-to-brain)
+// ============================================================
+
+function buildDriftText(
+  output: DriftMonitorOutput,
+  analysisDate: string,
+): string {
+  const lines: string[] = [
+    `Drift Monitor Report — ${analysisDate}`,
+    `Overall health: ${output.overall_health.replace(/_/g, ' ')}`,
+    '',
+    output.summary,
+    '',
+  ]
+
+  if (output.drift_items.length > 0) {
+    lines.push('Drift items:')
+    for (const item of output.drift_items) {
+      lines.push(`- [${item.severity.toUpperCase()}] [${item.item_type}] ${item.item_name}`)
+      lines.push(`  Silent: ${item.days_silent} days | ${item.reason}`)
+      lines.push(`  Action: ${item.suggested_action}`)
+    }
+    lines.push('')
+  } else {
+    lines.push('No drift items detected — all tracked items are active.')
+    lines.push('')
+  }
+
+  return lines.join('\n').trim()
+}

--- a/scripts/regression-test.mjs
+++ b/scripts/regression-test.mjs
@@ -896,6 +896,77 @@ section('9. Skills');
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
+// SECTION 9b: Intelligence API
+// ═════════════════════════════════════════════════════════════════════════════
+
+section('9b. Intelligence API');
+
+{
+  // Summary endpoint
+  const summary = await GET('/api/v1/intelligence/summary');
+  if (summary.status === 200 && summary.data) {
+    pass('TC-API-100', 'GET /api/v1/intelligence/summary → 200',
+      `keys=${Object.keys(summary.data).join(',')}`);
+    if ('connections' in summary.data && 'drift' in summary.data) {
+      pass('TC-API-100b', 'Summary includes connections + drift sections');
+    } else {
+      fail('TC-API-100b', 'Summary missing expected sections', Object.keys(summary.data).join(','));
+    }
+  } else {
+    fail('TC-API-100', 'GET /api/v1/intelligence/summary', `status=${summary.status}`);
+  }
+
+  // Connections latest
+  const connLatest = await GET('/api/v1/intelligence/connections/latest');
+  if (connLatest.status === 200) {
+    pass('TC-API-101', 'GET /api/v1/intelligence/connections/latest → 200');
+  } else {
+    fail('TC-API-101', 'Intelligence connections latest', `status=${connLatest.status}`);
+  }
+
+  // Connections history
+  const connHistory = await GET('/api/v1/intelligence/connections/history');
+  if (connHistory.status === 200 && Array.isArray(connHistory.data?.data || connHistory.data)) {
+    pass('TC-API-102', 'GET /api/v1/intelligence/connections/history → 200 with array');
+  } else {
+    fail('TC-API-102', 'Intelligence connections history', `status=${connHistory.status}`);
+  }
+
+  // Drift latest
+  const driftLatest = await GET('/api/v1/intelligence/drift/latest');
+  if (driftLatest.status === 200) {
+    pass('TC-API-103', 'GET /api/v1/intelligence/drift/latest → 200');
+  } else {
+    fail('TC-API-103', 'Intelligence drift latest', `status=${driftLatest.status}`);
+  }
+
+  // Drift history
+  const driftHistory = await GET('/api/v1/intelligence/drift/history');
+  if (driftHistory.status === 200 && Array.isArray(driftHistory.data?.data || driftHistory.data)) {
+    pass('TC-API-104', 'GET /api/v1/intelligence/drift/history → 200 with array');
+  } else {
+    fail('TC-API-104', 'Intelligence drift history', `status=${driftHistory.status}`);
+  }
+
+  // Trigger — valid skill
+  const triggerConn = await POST('/api/v1/intelligence/daily-connections/trigger', {});
+  if (triggerConn.status === 200 || triggerConn.status === 202) {
+    pass('TC-API-105', 'POST /api/v1/intelligence/daily-connections/trigger → queued');
+  } else {
+    fail('TC-API-105', 'Intelligence trigger daily-connections', `status=${triggerConn.status}`);
+  }
+
+  // Trigger — invalid skill should 400/404
+  const triggerBad = await POST('/api/v1/intelligence/fake-skill/trigger', {});
+  if (triggerBad.status === 400 || triggerBad.status === 404) {
+    pass('TC-API-106', 'POST /api/v1/intelligence/fake-skill/trigger → rejected',
+      `status=${triggerBad.status}`);
+  } else {
+    fail('TC-API-106', 'Intelligence trigger invalid skill should reject', `status=${triggerBad.status}`);
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
 // SECTION 10: Admin
 // ═════════════════════════════════════════════════════════════════════════════
 

--- a/scripts/regression-test.mjs
+++ b/scripts/regression-test.mjs
@@ -780,6 +780,58 @@ section('9. Skills');
     fail('TC-API-082', 'GET /api/v1/skills/weekly-brief/logs', `status=${logs.status}`);
   }
 
+  // Verify daily-connections appears in skills list
+  {
+    const skillsList = await GET('/api/v1/skills');
+    const skills = skillsList.data?.skills || skillsList.data?.items || skillsList.data;
+    const dcSkill = Array.isArray(skills) ? skills.find(s => s.name === 'daily-connections' || s.skill_name === 'daily-connections') : null;
+    if (dcSkill) {
+      pass('TC-API-085', 'daily-connections skill listed in GET /api/v1/skills',
+        `schedule=${dcSkill.schedule || 'none'}`);
+    } else {
+      fail('TC-API-085', 'daily-connections skill missing from skills list');
+    }
+  }
+
+  // Trigger daily-connections skill
+  {
+    const dcTrigger = await POST('/api/v1/skills/daily-connections/trigger', {});
+    if (dcTrigger.status === 200 || dcTrigger.status === 202) {
+      pass('TC-API-086', 'POST /api/v1/skills/daily-connections/trigger → queued');
+    } else if (dcTrigger.status === 404) {
+      bug('TC-API-086', 'POST /api/v1/skills/daily-connections/trigger → 404',
+        'Skill trigger endpoint missing for daily-connections');
+    } else {
+      fail('TC-API-086', 'Skills daily-connections/trigger', `status=${dcTrigger.status}`);
+    }
+  }
+
+  // Wait for daily-connections to process, then check logs
+  await sleep(12000);
+
+  {
+    const dcLogs = await GET('/api/v1/skills/daily-connections/logs');
+    if (dcLogs.status === 200 && dcLogs.data?.data) {
+      const entries = dcLogs.data.data;
+      pass('TC-API-087', 'GET /api/v1/skills/daily-connections/logs → {data:[...]}',
+        `count=${entries.length}`);
+      const latest = entries[0];
+      if (!latest) {
+        skip('TC-API-088', 'daily-connections has no log entries yet');
+      } else if (latest?.output === 'Skipped — no captures' || latest?.output?.includes('no captures')) {
+        skip('TC-API-088', 'daily-connections skipped — no captures in window',
+          'Expected on fresh deployment');
+      } else if (latest?.result || latest?.output) {
+        pass('TC-API-088', 'daily-connections ran and produced output',
+          (latest.output ?? '').slice(0, 80));
+      } else {
+        fail('TC-API-088', 'daily-connections log entry has no output', JSON.stringify(latest)?.slice(0,80));
+      }
+    } else {
+      fail('TC-API-087', 'GET /api/v1/skills/daily-connections/logs', `status=${dcLogs.status}`);
+    }
+  }
+
   // /skills/last-run is by-design non-existent (Slack bot now uses /skills/:name/logs?limit=1)
   const lastRun = await GET('/api/v1/skills/last-run');
   if (lastRun.status === 404) {
@@ -895,6 +947,7 @@ if (RUN_SLACK) {
     ['!board quick', 'quick board check', 'TC-SLK-005', '!board quick starts governance session'],
     ['!board\n', 'Usage', 'TC-SLK-006', 'bare !board shows usage message'],
     ['!brief last', 'brief', 'TC-SLK-008', '!brief last shows last brief run (Slack bot fixed)'],
+    ['!connections', 'connections', 'TC-SLK-011', '!connections triggers daily connections skill'],
   ];
 
   for (const [searchText, expectedInReply, tcId, desc] of checks) {

--- a/scripts/regression-test.mjs
+++ b/scripts/regression-test.mjs
@@ -832,6 +832,58 @@ section('9. Skills');
     }
   }
 
+  // Verify drift-monitor appears in skills list
+  {
+    const skillsList2 = await GET('/api/v1/skills');
+    const skills2 = skillsList2.data?.skills || skillsList2.data?.items || skillsList2.data;
+    const dmSkill = Array.isArray(skills2) ? skills2.find(s => s.name === 'drift-monitor' || s.skill_name === 'drift-monitor') : null;
+    if (dmSkill) {
+      pass('TC-API-089', 'drift-monitor skill listed in GET /api/v1/skills',
+        `schedule=${dmSkill.schedule || 'none'}`);
+    } else {
+      fail('TC-API-089', 'drift-monitor skill missing from skills list');
+    }
+  }
+
+  // Trigger drift-monitor skill
+  {
+    const dmTrigger = await POST('/api/v1/skills/drift-monitor/trigger', {});
+    if (dmTrigger.status === 200 || dmTrigger.status === 202) {
+      pass('TC-API-089b', 'POST /api/v1/skills/drift-monitor/trigger → queued');
+    } else if (dmTrigger.status === 404) {
+      bug('TC-API-089b', 'POST /api/v1/skills/drift-monitor/trigger → 404',
+        'Skill trigger endpoint missing for drift-monitor');
+    } else {
+      fail('TC-API-089b', 'Skills drift-monitor/trigger', `status=${dmTrigger.status}`);
+    }
+  }
+
+  // Wait for drift-monitor to process, then check logs
+  await sleep(12000);
+
+  {
+    const dmLogs = await GET('/api/v1/skills/drift-monitor/logs');
+    if (dmLogs.status === 200 && dmLogs.data?.data) {
+      const entries = dmLogs.data.data;
+      pass('TC-API-089c', 'GET /api/v1/skills/drift-monitor/logs → {data:[...]}',
+        `count=${entries.length}`);
+      const latest = entries[0];
+      if (!latest) {
+        skip('TC-API-089d', 'drift-monitor has no log entries yet');
+      } else if (latest?.output?.includes('no ') || latest?.output?.includes('Skipped')) {
+        skip('TC-API-089d', 'drift-monitor skipped — insufficient data',
+          'Expected on fresh deployment');
+      } else if (latest?.result || latest?.output) {
+        pass('TC-API-089d', 'drift-monitor ran and produced output',
+          (latest.output ?? '').slice(0, 80));
+      } else {
+        fail('TC-API-089d', 'drift-monitor log entry has no output', JSON.stringify(latest)?.slice(0,80));
+      }
+    } else {
+      fail('TC-API-089c', 'GET /api/v1/skills/drift-monitor/logs', `status=${dmLogs.status}`);
+    }
+  }
+
   // /skills/last-run is by-design non-existent (Slack bot now uses /skills/:name/logs?limit=1)
   const lastRun = await GET('/api/v1/skills/last-run');
   if (lastRun.status === 404) {
@@ -948,6 +1000,7 @@ if (RUN_SLACK) {
     ['!board\n', 'Usage', 'TC-SLK-006', 'bare !board shows usage message'],
     ['!brief last', 'brief', 'TC-SLK-008', '!brief last shows last brief run (Slack bot fixed)'],
     ['!connections', 'connections', 'TC-SLK-011', '!connections triggers daily connections skill'],
+    ['!drift', 'drift', 'TC-SLK-012', '!drift triggers drift monitor skill'],
   ];
 
   for (const [searchText, expectedInReply, tcId, desc] of checks) {


### PR DESCRIPTION
## Summary

Implements Phase 5 (F21, F22, F24) — three new intelligence features across 13 work items in 3 phases:

### Phase 17: Daily Connections Skill (F21)
- **DailyConnectionsSkill** — queries recent captures, builds entity co-occurrence matrix, synthesizes cross-domain connections via LLM, delivers via Pushover
- **Prompt template** (`daily_connections_v1.txt`) with JSON output schema and anti-fluff rules
- **BullMQ scheduling** at 9 PM daily with `!connections [days]` Slack command
- 60 unit tests + 4 regression test cases

### Phase 18: Drift Monitor Skill (F22)
- **DriftMonitorSkill** — monitors pending bets, governance commitments, and entity mention frequency for drift/neglect
- **Conditional Pushover** — only notifies when severity >= medium, escalates priority for high-severity items
- **BullMQ scheduling** at 8 AM daily with `!drift` Slack command
- 55 unit tests + 5 regression test cases

### Phase 19: Web Dashboard Intelligence Tab (F24)
- **Intelligence API** — 6 endpoints (summary, connections/drift latest+history, trigger) with skill allowlisting
- **Intelligence page** with lazy-loaded route, sidebar nav, two-column card grid
- **ConnectionsCard** — structured rendering with confidence badges, cross-domain indicators
- **DriftCard** — health score badge, severity dots, item type badges, suggested actions
- **SkillHistoryCard** — reusable history panel with lazy-load and expandable rows
- 62 unit tests + 7 regression test cases

### Test Coverage
- **211 new tests** (1,146 → 1,357 total)
- **16 new regression test cases** (TC-API-085..106, TC-SLK-011..012)
- All 1,357 tests passing across 65 test files in 6 packages

## Test plan
- [x] All unit tests pass (`pnpm test` — 1,357 tests)
- [x] CI lint passes (TypeScript `tsc --noEmit`)
- [ ] Run regression test against homeserver after deploy (`node scripts/regression-test.mjs`)
- [ ] Verify Intelligence tab renders at brain.troy-davis.com/intelligence
- [ ] Verify `!connections` and `!drift` Slack commands queue jobs
- [ ] Verify scheduled jobs appear in BullMQ dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)