### PR TITLE
chore: bump to v1.2.0 and sync documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.0] — 2026-03-12
+
+### Added
+- **Queue management UI**: Per-queue clear buttons for failed jobs (`POST /admin/queues/:name/clear`).
+- **Skill schedule editing**: Inline cron editing with YAML write-back (`PATCH /api/v1/skills/:name`).
+- **In-app help page**: Tabbed markdown rendering with table of contents at `/help`.
+- **Slack channel cleanup**: Channel listing with activity metadata and archive capability (`GET/POST /admin/slack/channels`).
+- **Dark mode toggle**: System preference detection with `localStorage` persistence.
+- **Settings page reorganization**: Focused sections for system health, skills, triggers, and danger zone.
+- **Trigger delete fix**: Delete button now works on Settings page.
+- 13 new regression test cases covering Phase 6 endpoints (queue management, skill schedules, Slack channels).
+
+---
+
 ## [1.1.0] — 2026-03-11
 
 ### Added
@@ -117,6 +131,7 @@ Initial complete implementation of all 16 phases.
 
 ---
 
-[Unreleased]: https://github.com/davistroy/open-brain/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/davistroy/open-brain/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/davistroy/open-brain/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/davistroy/open-brain/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/davistroy/open-brain/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ After any non-trivial finding during deployment, testing, or debugging:
 
 Self-hosted personal AI knowledge infrastructure. Ingests from voice memos, Slack, documents; stores in Postgres+pgvector; provides semantic search, AI synthesis, weekly briefs, and governance sessions.
 
-**Status**: v1.1.0 — All 20 phases complete (Phases 1-16 shipped 2026-03-05, hardening PR #25 merged 2026-03-11, Phase 5 intelligence features PR #27 merged 2026-03-11). 1,357 unit tests + 83 regression tests passing. Deployed to homeserver.
+**Status**: v1.2.0 — All 25 phases complete (Phases 1-16 shipped 2026-03-05, hardening PR #25 merged 2026-03-11, Phase 5 intelligence features PR #27 merged 2026-03-11, Phase 6 UX polish PR #28 merged 2026-03-12). 1,407 unit tests + 95 regression tests passing. Deployed to homeserver.
 
 ## Key Architecture Decisions
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Single `open-brain` Docker network. All services defined in `docker-compose.yml`
 | `open-brain-workers` | build: target=workers | BullMQ workers — embed, classify, extract entities, triggers, skills |
 | `open-brain-slack-bot` | build: target=slack-bot | @slack/bolt Socket Mode — capture + query + commands |
 | `open-brain-voice-capture` | build: target=voice-capture | HTTP endpoint for iOS Shortcut; proxies to faster-whisper |
-| `open-brain-faster-whisper` | fedirz/faster-whisper-server:0.4.1 | Speech-to-text (large-v3, CPU int8) |
+| `open-brain-faster-whisper` | fedirz/faster-whisper-server:0.5.0-cpu | Speech-to-text (large-v3, CPU int8) |
 | `open-brain-web` | build: packages/web/Dockerfile | Vite + React + shadcn/ui dashboard (nginx, PWA) |
 | `open-brain-cloudflared` | cloudflare/cloudflared:latest | Cloudflare Tunnel — exposes brain.troy-davis.com |
 
@@ -245,8 +245,8 @@ Configure `config/cloudflare/tunnel.yaml` with your tunnel ID and credentials, t
 | `CHANGELOG.md` | Version history and recent changes |
 | `IMPLEMENTATION_PLAN-PHASE5.md` | Phases 17–20 (Intelligence features) — complete |
 | `IMPLEMENTATION_PLAN-PHASE6.md` | Phases 21–25 (UX polish + admin tools) — complete |
-| `docs/PRD.md` | Product requirements (v0.8) |
-| `docs/TDD.md` | Technical design (v0.7) |
+| `docs/PRD.md` | Product requirements (v0.6) |
+| `docs/TDD.md` | Technical design (v0.6) |
 | `docs/USER_TEST_PLAN.md` | End-to-end test plan for all phases |
 | `docs/TEST_RESULTS_2026-03-09.md` | Deployment validation test results (all passing) |
 | `docs/ios-shortcut.md` | iOS Shortcut setup for Apple Watch voice capture |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-brain",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add CHANGELOG v1.2.0 entry for Phase 6 (Phases 21-25) shipped features
- Fix README faster-whisper image tag (0.4.1 → 0.5.0-cpu) to match docker-compose.yml
- Fix README PRD/TDD version refs to match actual doc files (v0.6)
- Update CLAUDE.md status to v1.2.0 with correct phase and test counts
- Bump root package.json version from 1.1.0 to 1.2.0

## Test plan
- [x] No code changes — documentation and version metadata only
- [x] All version references consistent across files

🤖 Generated with [Claude Code](https://claude.com/claude-code)