### PR TITLE
fix: trigger delete now hard-deletes instead of soft-deactivate

### DIFF
--- a/packages/core-api/src/__tests__/trigger-service.test.ts
+++ b/packages/core-api/src/__tests__/trigger-service.test.ts
@@ -234,13 +234,11 @@ describe('TriggerService.list', () => {
 // ---------------------------------------------------------------------------
 
 describe('TriggerService.delete', () => {
-  it('soft-deactivates trigger by ID (sets enabled = false)', async () => {
+  it('hard-deletes trigger by ID', async () => {
     const db = {
       select: vi.fn().mockImplementation(() => selectChain([{ id: 'trigger-1' }])),
-      update: vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([]),
-        }),
+      delete: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
       }),
       insert: vi.fn(),
       execute: vi.fn().mockResolvedValue({ rows: [] }),
@@ -251,7 +249,7 @@ describe('TriggerService.delete', () => {
 
     await service.delete('trigger-1')
 
-    expect(db.update).toHaveBeenCalled()
+    expect(db.delete).toHaveBeenCalled()
   })
 
   it('throws NotFoundError when trigger does not exist', async () => {

--- a/packages/core-api/src/routes/triggers.ts
+++ b/packages/core-api/src/routes/triggers.ts
@@ -71,18 +71,18 @@ export function registerTriggerRoutes(app: Hono, triggerService: TriggerService)
 
   // -----------------------------------------------------------------------
   // DELETE /api/v1/triggers/:id
-  // Soft-deactivates a trigger (sets enabled = false). Accepts name or UUID.
+  // Hard-deletes a trigger. Accepts name or UUID.
   // -----------------------------------------------------------------------
   app.delete('/api/v1/triggers/:id', async (c) => {
     const id = c.req.param('id')
 
-    logger.info({ id }, '[triggers-api] deactivating trigger')
+    logger.info({ id }, '[triggers-api] deleting trigger')
 
     await triggerService.delete(id)
 
-    logger.info({ id }, '[triggers-api] trigger deactivated')
+    logger.info({ id }, '[triggers-api] trigger deleted')
 
-    return c.json({ message: `Trigger '${id}' deactivated` })
+    return c.json({ message: `Trigger '${id}' deleted` })
   })
 
   // -----------------------------------------------------------------------

--- a/packages/core-api/src/services/trigger.ts
+++ b/packages/core-api/src/services/trigger.ts
@@ -150,7 +150,7 @@ export class TriggerService {
   }
 
   /**
-   * Soft-deactivate a trigger by name or ID (sets enabled = false).
+   * Hard-delete a trigger by name or ID.
    */
   async delete(nameOrId: string): Promise<void> {
     // Try by ID first, then by name
@@ -173,8 +173,7 @@ export class TriggerService {
     }
 
     await this.db
-      .update(triggers)
-      .set({ enabled: false, updated_at: new Date() })
+      .delete(triggers)
       .where(eq(triggers.id, byName.id))
   }
 


### PR DESCRIPTION
## Summary
- DELETE /api/v1/triggers/:id was soft-deleting (setting enabled=false) but the list endpoint still returned disabled triggers
- The trash icon in Settings appeared to do nothing because the trigger reappeared in the refreshed list
- Changed to hard delete (actually removes the row from the database)
- Updated unit test to match new behavior

## Test plan
- [x] 416 core-api unit tests passing
- [x] Verified via browser: delete button now removes trigger from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)