### PR TITLE
fix: Slack channel cleanup falls back to SLACK_BOT_TOKEN

### DIFF
--- a/packages/core-api/src/__tests__/slack-channel-routes.test.ts
+++ b/packages/core-api/src/__tests__/slack-channel-routes.test.ts
@@ -182,13 +182,15 @@ describe('Slack Channel Routes — with SLACK_USER_TOKEN', () => {
   })
 })
 
-describe('Slack Channel Routes — without SLACK_USER_TOKEN', () => {
+describe('Slack Channel Routes — without any Slack token', () => {
   let app: Hono
-  const originalEnv = process.env.SLACK_USER_TOKEN
+  const originalUserToken = process.env.SLACK_USER_TOKEN
+  const originalBotToken = process.env.SLACK_BOT_TOKEN
 
   beforeEach(async () => {
     vi.clearAllMocks()
     delete process.env.SLACK_USER_TOKEN
+    delete process.env.SLACK_BOT_TOKEN
     vi.resetModules()
 
     // Re-mock after resetModules
@@ -226,22 +228,27 @@ describe('Slack Channel Routes — without SLACK_USER_TOKEN', () => {
   })
 
   afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env.SLACK_USER_TOKEN = originalEnv
+    if (originalUserToken !== undefined) {
+      process.env.SLACK_USER_TOKEN = originalUserToken
     } else {
       delete process.env.SLACK_USER_TOKEN
     }
+    if (originalBotToken !== undefined) {
+      process.env.SLACK_BOT_TOKEN = originalBotToken
+    } else {
+      delete process.env.SLACK_BOT_TOKEN
+    }
   })
 
-  it('GET /admin/slack/channels returns 503 when token is missing', async () => {
+  it('GET /admin/slack/channels returns 503 when no token is available', async () => {
     const res = await app.request('/api/v1/admin/slack/channels')
     expect(res.status).toBe(503)
     const body = await res.json()
     expect(body.error).toBe('Service unavailable')
-    expect(body.message).toContain('SLACK_USER_TOKEN')
+    expect(body.message).toContain('Slack token')
   })
 
-  it('POST /admin/slack/channels/:id/archive returns 503 when token is missing', async () => {
+  it('POST /admin/slack/channels/:id/archive returns 503 when no token is available', async () => {
     const res = await app.request('/api/v1/admin/slack/channels/C001/archive', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -250,6 +257,6 @@ describe('Slack Channel Routes — without SLACK_USER_TOKEN', () => {
     expect(res.status).toBe(503)
     const body = await res.json()
     expect(body.error).toBe('Service unavailable')
-    expect(body.message).toContain('SLACK_USER_TOKEN')
+    expect(body.message).toContain('Slack token')
   })
 })

--- a/packages/core-api/src/routes/admin.ts
+++ b/packages/core-api/src/routes/admin.ts
@@ -284,9 +284,9 @@ export function createAdminRouter({ configService, redisConnection, db }: AdminR
   // No adminAuth — web UI cannot send Bearer tokens. Protected by POST method
   // for archive and the admin rate limiter on /api/v1/admin/*.
 
-  const slackUserToken = process.env.SLACK_USER_TOKEN
-  if (slackUserToken) {
-    const slackChannelService = new SlackChannelService(slackUserToken)
+  const slackToken = process.env.SLACK_USER_TOKEN || process.env.SLACK_BOT_TOKEN
+  if (slackToken) {
+    const slackChannelService = new SlackChannelService(slackToken)
 
     router.get('/slack/channels', async (c) => {
       try {
@@ -321,14 +321,14 @@ export function createAdminRouter({ configService, redisConnection, db }: AdminR
     router.get('/slack/channels', (c) => {
       return c.json({
         error: 'Service unavailable',
-        message: 'SLACK_USER_TOKEN environment variable is not configured. Set it to a Slack user token (xoxp-...) with channels:read, channels:history, and channels:write scopes.',
+        message: 'No Slack token available. Set SLACK_BOT_TOKEN or SLACK_USER_TOKEN.',
       }, 503)
     })
 
     router.post('/slack/channels/:id/archive', (c) => {
       return c.json({
         error: 'Service unavailable',
-        message: 'SLACK_USER_TOKEN environment variable is not configured.',
+        message: 'No Slack token available. Set SLACK_BOT_TOKEN or SLACK_USER_TOKEN.',
       }, 503)
     })
   }

--- a/packages/core-api/src/services/slack-channel.ts
+++ b/packages/core-api/src/services/slack-channel.ts
@@ -20,8 +20,8 @@ export interface ArchiveResult {
 
 /**
  * Service for listing and archiving Slack channels.
- * Uses a Slack user token (xoxp-...) which requires scopes:
- *   channels:read, channels:history, channels:write (for archive)
+ * Accepts either a user token (xoxp-...) or bot token (xoxb-...).
+ * Bot tokens may not have access to history for channels the bot isn't in.
  */
 export class SlackChannelService {
   private client: WebClient


### PR DESCRIPTION
## Summary
- Slack channel cleanup required SLACK_USER_TOKEN (xoxp-...) which wasn't configured
- Now falls back to SLACK_BOT_TOKEN when user token is unavailable
- Bot token can list/archive channels; history for non-member channels gracefully handled
- Updated 503 message and unit tests

## Test plan
- [x] 416 core-api unit tests passing
- [x] Will verify in browser after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)