### PR TITLE
feat: optional GPS location on voice captures

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -32,13 +32,13 @@ Full data flow traced: iOS → voice-capture → core-api → Postgres → pipel
 ## Phase 1: Voice Capture Endpoint
 
 **File:** `packages/voice-capture/src/server.ts`
-**Status:** PENDING
+**Status:** COMPLETE 2026-03-30
 
 ### Items
 
-- [ ] **1.1** Parse optional form fields: `latitude` (string→float), `longitude` (string→float), `location_name` (string), `location_accuracy` (string→float, meters)
-- [ ] **1.2** Validate coordinate ranges: latitude -90 to +90, longitude -180 to +180. Reject with 400 if out of range. Require both lat+lng or neither (no partial coordinates).
-- [ ] **1.3** Include in `source_metadata` when present:
+- [x] **1.1** Parse optional form fields: `latitude` (string→float), `longitude` (string→float), `location_name` (string), `location_accuracy` (string→float, meters) — COMPLETE 2026-03-30
+- [x] **1.2** Validate coordinate ranges: latitude -90 to +90, longitude -180 to +180. Reject with 400 if out of range. Require both lat+lng or neither (no partial coordinates). — COMPLETE 2026-03-30
+- [x] **1.3** Include in `source_metadata` when present: — COMPLETE 2026-03-30
   ```json
   {
     "device": "apple_watch",
@@ -53,7 +53,7 @@ Full data flow traced: iOS → voice-capture → core-api → Postgres → pipel
     }
   }
   ```
-- [ ] **1.4** Location fields are fully optional — omission is the normal case for captures without location. No change to existing behavior when fields are absent.
+- [x] **1.4** Location fields are fully optional — omission is the normal case for captures without location. No change to existing behavior when fields are absent. — COMPLETE 2026-03-30
 
 ### Notes
 
@@ -88,17 +88,17 @@ Full data flow traced: iOS → voice-capture → core-api → Postgres → pipel
 ## Phase 3: iOS Shortcut Documentation
 
 **File:** `docs/ios-shortcut.md`
-**Status:** PENDING
+**Status:** COMPLETE 2026-03-30
 
 ### Items
 
-- [ ] **3.1** Add "Get Current Location" action between "Record Audio" and "Get Contents of URL" in the Shortcut steps.
-- [ ] **3.2** Document 3 new form fields in the "Get Contents of URL" action:
+- [x] **3.1** Add "Get Current Location" action between "Record Audio" and "Get Contents of URL" in the Shortcut steps. — COMPLETE 2026-03-30
+- [x] **3.2** Document 3 new form fields in the "Get Contents of URL" action: — COMPLETE 2026-03-30
   - `latitude` — from Location.Latitude
   - `longitude` — from Location.Longitude
   - `location_name` — from Location.Street + ", " + Location.City + ", " + Location.State (or whatever iOS provides)
-- [ ] **3.3** Update the endpoint reference table with the new optional fields.
-- [ ] **3.4** Add a note that location is optional — the Shortcut works without it, and users can omit the "Get Current Location" action if they prefer not to share location.
+- [x] **3.3** Update the endpoint reference table with the new optional fields. — COMPLETE 2026-03-30
+- [x] **3.4** Add a note that location is optional — the Shortcut works without it, and users can omit the "Get Current Location" action if they prefer not to share location. — COMPLETE 2026-03-30
 
 ---
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -66,17 +66,17 @@ Full data flow traced: iOS → voice-capture → core-api → Postgres → pipel
 ## Phase 2: CaptureDetail Display
 
 **File:** `packages/web/src/components/CaptureDetail.tsx`
-**Status:** PENDING
+**Status:** COMPLETE 2026-03-30
 
 ### Items
 
-- [ ] **2.1** Replace raw JSON dump of `source_metadata` with structured rendering. Parse known fields:
+- [x] **2.1** Replace raw JSON dump of `source_metadata` with structured rendering. Parse known fields: — COMPLETE 2026-03-30
   - **Device:** icon + label (e.g., "Apple Watch")
   - **Duration:** formatted as "Xm Ys"
   - **Language:** language code or name
   - **Location:** pin icon + `location.name` if present, with coordinates as tooltip or secondary text
-- [ ] **2.2** For unknown source_metadata keys (future-proofing), fall back to formatted key-value display rather than raw JSON.
-- [ ] **2.3** If `location.latitude` and `location.longitude` are present, render the location name as a link to Google Maps: `https://maps.google.com/?q={lat},{lng}`
+- [x] **2.2** For unknown source_metadata keys (future-proofing), fall back to formatted key-value display rather than raw JSON. — COMPLETE 2026-03-30
+- [x] **2.3** If `location.latitude` and `location.longitude` are present, render the location name as a link to Google Maps: `https://maps.google.com/?q={lat},{lng}` — COMPLETE 2026-03-30
 
 ### Notes
 
@@ -105,15 +105,15 @@ Full data flow traced: iOS → voice-capture → core-api → Postgres → pipel
 ## Phase 4: Tests
 
 **File:** `packages/voice-capture/src/__tests__/server.test.ts`
-**Status:** PENDING
+**Status:** COMPLETE 2026-03-30
 
 ### Items
 
-- [ ] **4.1** Test: POST with valid location fields → 200, source_metadata includes `location` object with lat/lng/name/accuracy
-- [ ] **4.2** Test: POST without location fields → 200, source_metadata has no `location` key (backward compat)
-- [ ] **4.3** Test: POST with latitude but no longitude → 400 validation error
-- [ ] **4.4** Test: POST with latitude out of range (e.g., 999) → 400 validation error
-- [ ] **4.5** Test: POST with non-numeric latitude string → 400 or ignored (decide: reject vs. skip)
+- [x] **4.1** Test: POST with valid location fields → 200, source_metadata includes `location` object with lat/lng/name/accuracy — COMPLETE 2026-03-30
+- [x] **4.2** Test: POST without location fields → 200, source_metadata has no `location` key (backward compat) — COMPLETE 2026-03-30
+- [x] **4.3** Test: POST with latitude but no longitude → 400 validation error — COMPLETE 2026-03-30
+- [x] **4.4** Test: POST with latitude out of range (e.g., 999) → 400 validation error — COMPLETE 2026-03-30
+- [x] **4.5** Test: POST with non-numeric latitude string → 400 validation error — COMPLETE 2026-03-30
 
 ### Decision for 4.5
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -308,9 +308,9 @@ The CLAUDE.md contains 24 verified operational rules covering Docker healthcheck
 
 ### Entry 008 — Voice capture location feature [api] [web] [config]
 **Date:** 2026-03-30
-**Duration:** In progress
-**Environment:** Laptop (development) → Homeserver (deployment)
-**Status:** IN PROGRESS
+**Duration:** ~25 minutes
+**Environment:** Laptop (development)
+**Status:** COMPLETED
 
 **Objective:** Add optional GPS location (latitude, longitude, location_name, location_accuracy) to voice captures from iOS Shortcut. Display in CaptureDetail. No schema migration — stored in existing source_metadata JSONB.
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -306,4 +306,24 @@ The CLAUDE.md contains 24 verified operational rules covering Docker healthcheck
 
 ---
 
+### Entry 008 — Voice capture location feature [api] [web] [config]
+**Date:** 2026-03-30
+**Duration:** In progress
+**Environment:** Laptop (development) → Homeserver (deployment)
+**Status:** IN PROGRESS
+
+**Objective:** Add optional GPS location (latitude, longitude, location_name, location_accuracy) to voice captures from iOS Shortcut. Display in CaptureDetail. No schema migration — stored in existing source_metadata JSONB.
+
+**Hypothesis:** Adding 4 optional form fields to the voice-capture endpoint and nesting them under `source_metadata.location` will flow transparently through core-api, pipeline, search, and UI without any changes to those systems. The only display change needed is CaptureDetail.tsx (replace raw JSON dump with structured metadata rendering). Success criteria: voice capture with location shows pin + name in CaptureDetail, voice capture without location works identically to current behavior.
+
+**Rollback Plan:** `git revert` — all changes are additive. No migration, no data cleanup.
+
+**Plan:** IMPLEMENTATION_PLAN.md — 4 phases, 16 items. Phase 1 (endpoint) + Phase 3 (docs) run in parallel. Phase 2 (display) + Phase 4 (tests) run after Phase 1.
+
+**Actions & Results:**
+
+*Logging as implementation proceeds...*
+
+---
+
 *Entries continue below.*

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -322,7 +322,11 @@ The CLAUDE.md contains 24 verified operational rules covering Docker healthcheck
 
 **Actions & Results:**
 
-*Logging as implementation proceeds...*
+1. **Phase 1 (endpoint) + Phase 3 (docs) — parallel execution.** Both agents completed successfully.
+   - `server.ts`: parses latitude, longitude, location_name, location_accuracy from form fields; validates ranges + both-or-neither; nests under `source_metadata.location`
+   - `ios-shortcut.md`: added Get Current Location action, 3 new form fields, updated reference table, optional note
+   - Classification test updated: model name `'fast'` → `'gpt-5.4'` (pre-existing debt from OpenAI migration)
+   - All 1,407 tests pass
 
 ---
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -328,6 +328,11 @@ The CLAUDE.md contains 24 verified operational rules covering Docker healthcheck
    - Classification test updated: model name `'fast'` → `'gpt-5.4'` (pre-existing debt from OpenAI migration)
    - All 1,407 tests pass
 
+2. **Phase 2 (display) + Phase 4 (tests) — parallel execution.** Both agents completed successfully.
+   - `CaptureDetail.tsx`: new `SourceMetadataDisplay` component — structured rendering of device (icon), duration (Xm Ys), language, location (MapPin + Google Maps link). Unknown keys fall back to formatted key-value pairs. Light/dark mode compatible.
+   - `server.test.ts`: 5 new tests in "location fields" describe block — valid coords, no location (backward compat), partial coords (400), out-of-range (400), non-numeric (400). Total voice-capture tests: 82.
+   - All 1,412 tests pass (1,407 existing + 5 new)
+
 ---
 
 *Entries continue below.*

--- a/docs/ios-shortcut.md
+++ b/docs/ios-shortcut.md
@@ -20,20 +20,26 @@ Find your homeserver's Tailscale IP in the Tailscale app on any connected device
    - Duration: until stopped (or set a max, e.g. 5 minutes)
    - For Watch: the Watch records audio via the Watch app, which passes the file to the iPhone Shortcut
 
-2. **Get Contents of URL**
+2. **Get Current Location** *(optional — see note below)*
+   - Accuracy: Best
+   - This action returns a Location object with latitude, longitude, and reverse-geocoded address fields
+   - The Shortcut pauses briefly while iOS acquires a GPS fix
+
+3. **Get Contents of URL**
    - URL: `http://<tailscale-ip>:3001/api/capture`
    - Method: `POST`
    - Request Body: **Form**
-   - Add field:
-     - Key: `file`
-     - Value: the recorded audio from the previous action (file reference)
-     - Type: **File**
+   - Add fields:
+     - Key: `file` / Value: the recorded audio from step 1 / Type: **File**
+     - Key: `latitude` / Value: *Location.Latitude* (from step 2) / Type: **Text**
+     - Key: `longitude` / Value: *Location.Longitude* (from step 2) / Type: **Text**
+     - Key: `location_name` / Value: *Location.Street* + ", " + *Location.City* + ", " + *Location.State* (from step 2) / Type: **Text**
 
-3. (Optional) **Get Dictionary Value**
+4. (Optional) **Get Dictionary Value**
    - Input: result from Get Contents of URL
    - Key: `capture_id` (or `message` for status text)
 
-4. (Optional) **Show Notification** or **Show Result**
+5. (Optional) **Show Notification** or **Show Result**
    - Display the capture ID or status for confirmation
 
 ### Optional: brain_view Query Parameter
@@ -50,13 +56,18 @@ If omitted, the service auto-classifies the capture's brain view from the transc
 
 ### Endpoint Reference
 
-| Field | Value |
-|-------|-------|
-| URL | `http://<tailscale-ip>:3001/api/capture` |
-| Method | `POST` |
-| Content-Type | `multipart/form-data` |
-| Field name | `file` |
-| Supported formats | `.m4a` (default from iPhone/Watch), `.wav`, `.mp3`, `.ogg` |
+| Field | Value | Required |
+|-------|-------|----------|
+| URL | `http://<tailscale-ip>:3001/api/capture` | — |
+| Method | `POST` | — |
+| Content-Type | `multipart/form-data` | — |
+| `file` | Audio file (recorded audio) | Yes |
+| `latitude` | GPS latitude, -90 to +90 (e.g., `33.749`) | No |
+| `longitude` | GPS longitude, -180 to +180 (e.g., `-84.388`) | No |
+| `location_name` | Human-readable location (e.g., "123 Main St, Atlanta, GA") | No |
+| Supported formats | `.m4a` (default from iPhone/Watch), `.wav`, `.mp3`, `.ogg` | — |
+
+> **Location is optional.** The Shortcut works without it. If you prefer not to share location, simply omit step 2 ("Get Current Location") and the three location form fields. Captures without location are processed identically — no features are lost.
 
 **Response (success, HTTP 202)**:
 ```json
@@ -120,17 +131,23 @@ This Pushover notification is separate from the optional Shortcut "Show Result" 
 1. Record Audio
    - Audio Recording: Until Stopped
 
-2. Get Contents of URL
+2. Get Current Location          (optional — omit if you don't want location)
+   - Accuracy: Best
+
+3. Get Contents of URL
    - URL: http://100.64.x.x:3001/api/capture
    - Method: POST
    - Request Body: Form
    - [+] file = Recorded Audio (File)
+   - [+] latitude = Location.Latitude (Text)       (optional)
+   - [+] longitude = Location.Longitude (Text)      (optional)
+   - [+] location_name = Location.Street + ", " + Location.City + ", " + Location.State (Text)  (optional)
 
-3. Get Dictionary Value
+4. Get Dictionary Value
    - Key: message
    - Dictionary: Contents of URL
 
-4. Show Notification
+5. Show Notification
    - Title: Brain Capture
    - Body: Dictionary Value
 ```

--- a/packages/voice-capture/src/__tests__/classification.test.ts
+++ b/packages/voice-capture/src/__tests__/classification.test.ts
@@ -290,7 +290,7 @@ describe('ClassificationService', () => {
       expect(callArgs[0].temperature).toBe(0.1)
     })
 
-    it('sends request to the fast LiteLLM model alias', async () => {
+    it('sends request to the default classification model', async () => {
       mockCreate.mockResolvedValueOnce({
         choices: [{
           message: {
@@ -302,7 +302,7 @@ describe('ClassificationService', () => {
       await service.classify('Test.')
 
       const [callArgs] = mockCreate.mock.calls
-      expect(callArgs[0].model).toBe('fast')
+      expect(callArgs[0].model).toBe('gpt-5.4')
     })
   })
 })

--- a/packages/voice-capture/src/__tests__/server.test.ts
+++ b/packages/voice-capture/src/__tests__/server.test.ts
@@ -99,12 +99,20 @@ function buildCaptureRequest(opts: {
   content?: string
   brainView?: string
   device?: string
+  latitude?: string
+  longitude?: string
+  location_name?: string
+  location_accuracy?: string
 }): Request {
   const {
     filename = 'memo.m4a',
     content = 'fake audio bytes',
     brainView,
     device,
+    latitude,
+    longitude,
+    location_name,
+    location_accuracy,
   } = opts
 
   const formData = new FormData()
@@ -112,6 +120,10 @@ function buildCaptureRequest(opts: {
   formData.append('file', new File([blob], filename, { type: 'audio/mp4' }))
   if (brainView) formData.append('brain_view', brainView)
   if (device) formData.append('device', device)
+  if (latitude != null) formData.append('latitude', latitude)
+  if (longitude != null) formData.append('longitude', longitude)
+  if (location_name != null) formData.append('location_name', location_name)
+  if (location_accuracy != null) formData.append('location_accuracy', location_accuracy)
 
   return new Request('http://localhost/api/capture', {
     method: 'POST',
@@ -443,5 +455,90 @@ describe('POST /api/capture — ingest retry failure', () => {
     const body = await res.json() as { code: string }
     expect(body.code).toBe('INGEST_ERROR')
     expect(mockNotify).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/capture — location fields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTranscribe.mockResolvedValue(TRANSCRIPTION_RESULT)
+    mockClassify.mockResolvedValue(CLASSIFICATION_RESULT)
+    mockIngest.mockResolvedValue(INGEST_RESULT)
+    mockNotify.mockResolvedValue(undefined)
+  })
+
+  it('includes location in source_metadata when valid lat/lng/name/accuracy provided (4.1)', async () => {
+    const res = await app.request(buildCaptureRequest({
+      filename: 'memo.m4a',
+      latitude: '33.749',
+      longitude: '-84.388',
+      location_name: 'Atlanta, GA',
+      location_accuracy: '10.5',
+    }))
+
+    expect(res.status).toBe(200)
+    expect(mockIngest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          source_metadata: expect.objectContaining({
+            location: {
+              latitude: 33.749,
+              longitude: -84.388,
+              name: 'Atlanta, GA',
+              accuracy_meters: 10.5,
+            },
+          }),
+        }),
+      }),
+    )
+  })
+
+  it('omits location from source_metadata when no location fields provided (4.2)', async () => {
+    const res = await app.request(buildCaptureRequest({ filename: 'memo.m4a' }))
+
+    expect(res.status).toBe(200)
+    const ingestCall = mockIngest.mock.calls[0][0] as {
+      metadata: { source_metadata: Record<string, unknown> }
+    }
+    expect(ingestCall.metadata.source_metadata).not.toHaveProperty('location')
+  })
+
+  it('returns 400 when latitude provided without longitude (4.3)', async () => {
+    const res = await app.request(buildCaptureRequest({
+      filename: 'memo.m4a',
+      latitude: '33.749',
+    }))
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe('BAD_REQUEST')
+    expect(body.error).toContain('latitude')
+    expect(body.error).toContain('longitude')
+  })
+
+  it('returns 400 when latitude is out of range (4.4)', async () => {
+    const res = await app.request(buildCaptureRequest({
+      filename: 'memo.m4a',
+      latitude: '999',
+      longitude: '-84.388',
+    }))
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe('BAD_REQUEST')
+    expect(body.error).toContain('latitude')
+  })
+
+  it('returns 400 when latitude is a non-numeric string (4.5)', async () => {
+    const res = await app.request(buildCaptureRequest({
+      filename: 'memo.m4a',
+      latitude: 'not-a-number',
+      longitude: '-84.388',
+    }))
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe('BAD_REQUEST')
+    expect(body.error).toContain('valid numbers')
   })
 })

--- a/packages/voice-capture/src/server.ts
+++ b/packages/voice-capture/src/server.ts
@@ -43,6 +43,10 @@ app.get('/health', (c) => {
  * Optional form fields:
  *   - brain_view: target brain view (default: 'personal')
  *   - device: source device hint (default: 'apple_watch')
+ *   - latitude: GPS latitude as string (-90 to +90, requires longitude)
+ *   - longitude: GPS longitude as string (-180 to +180, requires latitude)
+ *   - location_name: reverse-geocoded place name from iOS
+ *   - location_accuracy: horizontal accuracy in meters from CLLocation
  *
  * Response: JSON with capture details forwarded from Core API, or error.
  */
@@ -71,7 +75,68 @@ app.post('/api/capture', async (c) => {
   const brainView = (formData.get('brain_view') as string | null) ?? 'personal'
   const device = (formData.get('device') as string | null) ?? 'apple_watch'
 
-  log.info({ filename, brainView, device }, 'Audio upload received')
+  // Parse optional location fields (1.1)
+  const rawLat = formData.get('latitude') as string | null
+  const rawLng = formData.get('longitude') as string | null
+  const rawLocationName = formData.get('location_name') as string | null
+  const rawLocationAccuracy = formData.get('location_accuracy') as string | null
+
+  // Build location object if any location fields are present (1.3, 1.4)
+  let location: { latitude: number; longitude: number; name?: string; accuracy_meters?: number } | undefined
+
+  if (rawLat != null || rawLng != null) {
+    // Require both lat+lng or neither (1.2)
+    if (rawLat == null || rawLng == null) {
+      return c.json(
+        { error: 'Both latitude and longitude are required when providing location', code: 'BAD_REQUEST' },
+        400,
+      )
+    }
+
+    const latitude = parseFloat(rawLat)
+    const longitude = parseFloat(rawLng)
+
+    // Reject non-numeric values (1.1)
+    if (Number.isNaN(latitude) || Number.isNaN(longitude)) {
+      return c.json(
+        { error: 'latitude and longitude must be valid numbers', code: 'BAD_REQUEST' },
+        400,
+      )
+    }
+
+    // Validate coordinate ranges (1.2)
+    if (latitude < -90 || latitude > 90) {
+      return c.json(
+        { error: 'latitude must be between -90 and 90', code: 'BAD_REQUEST' },
+        400,
+      )
+    }
+    if (longitude < -180 || longitude > 180) {
+      return c.json(
+        { error: 'longitude must be between -180 and 180', code: 'BAD_REQUEST' },
+        400,
+      )
+    }
+
+    location = { latitude, longitude }
+
+    if (rawLocationName != null && rawLocationName.trim().length > 0) {
+      location.name = rawLocationName.trim()
+    }
+
+    if (rawLocationAccuracy != null) {
+      const accuracy = parseFloat(rawLocationAccuracy)
+      if (Number.isNaN(accuracy)) {
+        return c.json(
+          { error: 'location_accuracy must be a valid number', code: 'BAD_REQUEST' },
+          400,
+        )
+      }
+      location.accuracy_meters = accuracy
+    }
+  }
+
+  log.info({ filename, brainView, device, hasLocation: !!location }, 'Audio upload received')
 
   // Step 1: Transcribe
   let transcription
@@ -111,6 +176,7 @@ app.post('/api/capture', async (c) => {
         duration_seconds: transcription.duration,
         original_filename: filename,
         language: transcription.language,
+        ...(location ? { location } : {}),
       },
       pre_extracted: {
         template: classification.template,

--- a/packages/web/src/components/CaptureDetail.tsx
+++ b/packages/web/src/components/CaptureDetail.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react';
+import { Clock, Globe, MapPin, Smartphone, Watch, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -18,6 +18,140 @@ const PIPELINE_STAGE_DOT: Record<string, string> = {
   pending: 'bg-gray-300',
   error: 'bg-red-500',
 };
+
+/** Known source_metadata keys that get structured rendering */
+const KNOWN_KEYS = new Set(['device', 'duration_seconds', 'language', 'location', 'original_filename']);
+
+const DEVICE_LABELS: Record<string, { label: string; icon: typeof Smartphone }> = {
+  iphone: { label: 'iPhone', icon: Smartphone },
+  apple_watch: { label: 'Apple Watch', icon: Watch },
+};
+
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60);
+  if (mins === 0) return `${secs}s`;
+  return `${mins}m ${secs}s`;
+}
+
+function formatMetaKey(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatMetaValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'object') return JSON.stringify(value, null, 2);
+  return String(value);
+}
+
+interface LocationData {
+  latitude?: number;
+  longitude?: number;
+  name?: string;
+  accuracy_meters?: number;
+}
+
+function SourceMetadataDisplay({ metadata }: { metadata: Record<string, unknown> }) {
+  const device = metadata.device as string | undefined;
+  const durationSeconds = metadata.duration_seconds as number | undefined;
+  const language = metadata.language as string | undefined;
+  const location = metadata.location as LocationData | undefined;
+
+  // Collect unknown keys for fallback rendering
+  const unknownEntries = Object.entries(metadata).filter(([key]) => !KNOWN_KEYS.has(key));
+
+  return (
+    <div className="space-y-1.5 text-sm">
+      {/* Device */}
+      {device != null && (() => {
+        const deviceKey = String(device).toLowerCase();
+        const info = DEVICE_LABELS[deviceKey];
+        const DeviceIcon = info?.icon ?? Smartphone;
+        const label = info?.label ?? String(device);
+        return (
+          <div className="flex items-center gap-2">
+            <DeviceIcon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span>{label}</span>
+          </div>
+        );
+      })()}
+
+      {/* Duration */}
+      {durationSeconds != null && (
+        <div className="flex items-center gap-2">
+          <Clock className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span>{formatDuration(durationSeconds)}</span>
+        </div>
+      )}
+
+      {/* Language */}
+      {language != null && (
+        <div className="flex items-center gap-2">
+          <Globe className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span>{String(language).toUpperCase()}</span>
+        </div>
+      )}
+
+      {/* Location */}
+      {location != null && (
+        <div className="flex items-start gap-2">
+          <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
+          <div>
+            {location.latitude != null && location.longitude != null ? (
+              <>
+                {location.name ? (
+                  <a
+                    href={`https://maps.google.com/?q=${location.latitude},${location.longitude}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:text-blue-400 underline underline-offset-2"
+                  >
+                    {location.name}
+                  </a>
+                ) : (
+                  <a
+                    href={`https://maps.google.com/?q=${location.latitude},${location.longitude}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:text-blue-400 underline underline-offset-2 font-mono text-xs"
+                  >
+                    {location.latitude.toFixed(4)}, {location.longitude.toFixed(4)}
+                  </a>
+                )}
+                <p className="text-[10px] text-muted-foreground font-mono">
+                  {location.latitude.toFixed(4)}, {location.longitude.toFixed(4)}
+                  {location.accuracy_meters != null && ` (±${Math.round(location.accuracy_meters)}m)`}
+                </p>
+              </>
+            ) : (
+              location.name && <span>{location.name}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Unknown keys — formatted key-value fallback */}
+      {unknownEntries.length > 0 && (
+        <div className="mt-2 space-y-1">
+          {unknownEntries.map(([key, value]) => (
+            <div key={key} className="flex items-start gap-2 text-xs">
+              <span className="text-muted-foreground shrink-0 min-w-[80px]">{formatMetaKey(key)}</span>
+              {typeof value === 'object' && value !== null ? (
+                <pre className="font-mono text-[10px] bg-secondary rounded px-1.5 py-0.5 overflow-x-auto whitespace-pre-wrap">
+                  {formatMetaValue(value)}
+                </pre>
+              ) : (
+                <span className="text-foreground">{formatMetaValue(value)}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function CaptureDetail({ capture, similarity, onClose }: CaptureDetailProps) {
   const tags = capture.tags ?? [];
@@ -154,9 +288,7 @@ export default function CaptureDetail({ capture, similarity, onClose }: CaptureD
             <Separator />
             <div>
               <p className="text-xs font-medium text-muted-foreground mb-2">Source Metadata</p>
-              <pre className="text-[10px] font-mono bg-secondary rounded p-2 overflow-x-auto whitespace-pre-wrap">
-                {JSON.stringify(sourceMetadata, null, 2)}
-              </pre>
+              <SourceMetadataDisplay metadata={sourceMetadata} />
             </div>
           </>
         )}


### PR DESCRIPTION
## Summary

Adds optional GPS location to voice captures from iOS Shortcut. Location data flows through the existing `source_metadata` JSONB column — no schema migration needed.

- **Phase 1:** Voice-capture endpoint parses `latitude`, `longitude`, `location_name`, `location_accuracy` from multipart form fields. Validates coordinate ranges, requires both-or-neither. Nests under `source_metadata.location`.
- **Phase 2:** CaptureDetail component replaces raw JSON dump with structured `SourceMetadataDisplay` — device icon, formatted duration, language, location with MapPin + Google Maps link. Unknown keys fall back to key-value display.
- **Phase 3:** iOS Shortcut docs updated with "Get Current Location" action, 3 new form fields, endpoint reference table, optional note.
- **Phase 4:** 5 new location validation tests (valid, backward compat, partial coords, out-of-range, non-numeric).

## Test plan

- [x] All 1,412 unit tests pass (1,407 existing + 5 new location tests)
- [ ] iOS Shortcut with location fields sends capture that shows pin in CaptureDetail
- [ ] iOS Shortcut without location fields still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)