### PR TITLE
feat: email-to-capture pipeline, sender allowlist, synthesis routing

### DIFF
--- a/cloudflare/email-worker/package-lock.json
+++ b/cloudflare/email-worker/package-lock.json
@@ -1,0 +1,1569 @@
+{
+  "name": "open-brain-email-worker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "open-brain-email-worker",
+      "version": "1.0.0",
+      "dependencies": {
+        "postal-mime": "^2.4.1"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250327.0",
+        "wrangler": "^4.14.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260329.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260329.1.tgz",
+      "integrity": "sha512-oyDXYlPBuGXKkZ85+M3jFz0/qYmvA4AEURN8USIGPDCR5q+HFSRwywSd9neTx3Wi7jhey2wuYaEpD3fEFWyWUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260329.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260329.1.tgz",
+      "integrity": "sha512-++ZxVa3ovzYeDLEG6zMqql9gzZAG8vak6ZSBQgprGKZp7akr+GKTpw9f3RrMP552NSi3gTisroLobrrkPBtYLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260329.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260329.1.tgz",
+      "integrity": "sha512-kkeywAgIHwbqHkVILqbj/YkfbrA6ARbmutjiYzZA2MwMSfNXlw6/kedAKOY8YwcymZIgepx3YTIPnBP50pOotw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260329.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260329.1.tgz",
+      "integrity": "sha512-eYBN20+B7XOUSWEe0mlqkMUbfLoIKjKZnpqQiSxnLbL72JKY0D/KlfN/b7RVGLpewB7i8rTrwTNr0szCKnZzSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260329.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260329.1.tgz",
+      "integrity": "sha512-5R+/oxrDhS9nL3oA3ZWtD6ndMOqm7RfKknDNxLcmYW5DkUu7UH3J/s1t/Dz66iFePzr5BJmE7/8gbmve6TjtZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260331.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260331.1.tgz",
+      "integrity": "sha512-fsf+MWPQdQ8XPV0y3tQvqf035ETgEXfJgNTYqmiLcOHB32eH/5Kb75fyZIXS9nnBMq3x6c4+HJRTRxbovNLWiA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260329.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260329.0.tgz",
+      "integrity": "sha512-+G+1YFVeuEpw/gZZmUHQR7IfzJV+DDGvnSl0yXzhgvHh8Nbr8Go5uiWIwl17EyZ1Uors3FKUMDUyU6+ejeKZOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.4",
+        "workerd": "1.20260329.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260329.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260329.1.tgz",
+      "integrity": "sha512-+ifMv3uBuD33ee7pan5n8+sgVxm2u5HnbgfXzHKwMNTKw86znqBJSnJoBqtP88+2T5U2Lu11xXUt+khPYioXwQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260329.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260329.1",
+        "@cloudflare/workerd-linux-64": "1.20260329.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260329.1",
+        "@cloudflare/workerd-windows-64": "1.20260329.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.79.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.79.0.tgz",
+      "integrity": "sha512-NMinIdB1pXIqdk+NLw4+RjzB7K5z4+lWMxhTxFTfZomwJu3Pm6N+kZ+a66D3nI7w0oCjsdv/umrZVmSHCBp2cg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260329.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260329.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260329.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/cloudflare/email-worker/package.json
+++ b/cloudflare/email-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "open-brain-email-worker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250327.0",
+    "wrangler": "^4.14.0"
+  },
+  "dependencies": {
+    "postal-mime": "^2.4.1"
+  }
+}

--- a/cloudflare/email-worker/src/index.ts
+++ b/cloudflare/email-worker/src/index.ts
@@ -13,7 +13,6 @@ interface Env {
   CAPTURES_URL: string
   DEFAULT_BRAIN_VIEW: string
   DEFAULT_CAPTURE_TYPE: string
-  INGEST_SECRET?: string
 }
 
 /** Common email signature delimiters — strip everything after the first match */
@@ -82,7 +81,7 @@ export default {
     console.log(`Email received: from=${from} to=${to} subject="${subject}"`)
 
     // ── Allowlist check (fail fast) ──────────────────────────────────────────
-    const allowlistUrl = env.CAPTURES_URL.replace('/captures', '/settings/email_allowlist')
+    const allowlistUrl = env.CAPTURES_URL.replace(/\/captures\/?$/, '') + '/settings/email_allowlist'
     try {
       const alRes = await fetch(allowlistUrl, {
         headers: { 'X-Open-Brain-Caller': 'email-worker' },
@@ -170,9 +169,6 @@ export default {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'X-Open-Brain-Caller': 'email-worker',
-    }
-    if (env.INGEST_SECRET) {
-      headers['X-Open-Brain-Ingest-Secret'] = env.INGEST_SECRET
     }
 
     console.log(`POSTing capture: ${trimmedContent.length} chars, ${attachments.length} attachments`)

--- a/cloudflare/email-worker/src/index.ts
+++ b/cloudflare/email-worker/src/index.ts
@@ -1,0 +1,196 @@
+/**
+ * Open Brain Email Worker — Cloudflare Email Routing handler.
+ *
+ * Receives emails routed via Cloudflare Email Routing (e.g., brain@troy-davis.com),
+ * checks the sender against an allowlist fetched from Core API, parses the email
+ * with postal-mime, and POSTs the content as a capture. The existing pipeline
+ * handles classification, embedding, and entity extraction.
+ */
+
+import PostalMime from 'postal-mime'
+
+interface Env {
+  CAPTURES_URL: string
+  DEFAULT_BRAIN_VIEW: string
+  DEFAULT_CAPTURE_TYPE: string
+  INGEST_SECRET?: string
+}
+
+/** Common email signature delimiters — strip everything after the first match */
+const SIGNATURE_PATTERNS = [
+  /^--\s*$/m,                          // standard "-- " delimiter
+  /^_{3,}$/m,                          // ___ underscores
+  /^-{3,}$/m,                          // --- dashes
+  /^Sent from my (iPhone|iPad|Galaxy|Pixel|Android)/mi,
+  /^Get Outlook for/mi,
+  /^Sent from Mail for/mi,
+  /^On .+ wrote:$/m,                   // quoted reply header
+  /^From: .+$/m,                       // forwarded email header block
+]
+
+function stripSignature(text: string): string {
+  let earliest = text.length
+  for (const pattern of SIGNATURE_PATTERNS) {
+    const match = pattern.exec(text)
+    if (match && match.index < earliest) {
+      earliest = match.index
+    }
+  }
+  return text.slice(0, earliest).trim()
+}
+
+/** Collapse excessive whitespace/newlines but preserve paragraph breaks */
+function normalizeWhitespace(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]+/g, ' ')
+    .trim()
+}
+
+/** Build capture content from email fields */
+function buildCaptureContent(subject: string, body: string): string {
+  const parts: string[] = []
+  if (subject) {
+    parts.push(`Subject: ${subject}`)
+    parts.push('')  // blank line separator
+  }
+  parts.push(body)
+  return parts.join('\n')
+}
+
+/**
+ * Check sender against allowlist. Supports exact email match and @domain match.
+ */
+function isSenderAllowed(sender: string, allowlist: string[]): boolean {
+  const senderLower = sender.toLowerCase()
+  const atIdx = senderLower.indexOf('@')
+  const senderDomain = atIdx >= 0 ? senderLower.slice(atIdx) : ''
+
+  return allowlist.some(entry => {
+    const e = entry.toLowerCase()
+    return e === senderLower || (e.startsWith('@') && e === senderDomain)
+  })
+}
+
+export default {
+  async email(message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext): Promise<void> {
+    const from = message.from
+    const to = message.to
+    const subject = message.headers.get('subject') ?? '(no subject)'
+
+    console.log(`Email received: from=${from} to=${to} subject="${subject}"`)
+
+    // ── Allowlist check (fail fast) ──────────────────────────────────────────
+    const allowlistUrl = env.CAPTURES_URL.replace('/captures', '/settings/email_allowlist')
+    try {
+      const alRes = await fetch(allowlistUrl, {
+        headers: { 'X-Open-Brain-Caller': 'email-worker' },
+      })
+      if (alRes.ok) {
+        const alData = await alRes.json() as { value: string[] }
+        const entries: string[] = alData.value ?? []
+        if (!isSenderAllowed(from, entries)) {
+          console.log(`Sender ${from} not in allowlist — rejecting`)
+          message.setReject(`Sender ${from} not authorized`)
+          return
+        }
+      } else {
+        console.error(`Allowlist fetch failed: ${alRes.status}`)
+        message.setReject('Allowlist check failed — will retry')
+        return
+      }
+    } catch (err) {
+      console.error('Allowlist fetch error:', err)
+      message.setReject('Allowlist check failed — will retry')
+      return
+    }
+
+    // ── Parse email ──────────────────────────────────────────────────────────
+    const rawEmail = await new Response(message.raw).arrayBuffer()
+    const parser = new PostalMime()
+    const parsed = await parser.parse(rawEmail)
+
+    // Prefer plain text body; fall back to stripping HTML tags
+    let body = parsed.text ?? ''
+    if (!body && parsed.html) {
+      body = parsed.html
+        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<\/p>/gi, '\n\n')
+        .replace(/<\/div>/gi, '\n')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+    }
+
+    body = stripSignature(body)
+    body = normalizeWhitespace(body)
+
+    if (!body) {
+      console.log('Empty email body after parsing — skipping capture creation')
+      return
+    }
+
+    const content = buildCaptureContent(subject, body)
+
+    // Enforce 50K content limit (matches Zod schema)
+    const trimmedContent = content.length > 49_000 ? content.slice(0, 49_000) + '\n\n[truncated]' : content
+
+    // Collect attachment info as metadata (don't upload the binary data)
+    const attachments = (parsed.attachments ?? []).map(att => ({
+      filename: att.filename ?? 'unnamed',
+      mimeType: att.mimeType,
+      size: att.content.byteLength,
+    }))
+
+    // ── Create capture ───────────────────────────────────────────────────────
+    const capturePayload = {
+      content: trimmedContent,
+      capture_type: env.DEFAULT_CAPTURE_TYPE,
+      brain_view: env.DEFAULT_BRAIN_VIEW,
+      source: 'email',
+      metadata: {
+        source_metadata: {
+          from,
+          to,
+          subject,
+          message_id: message.headers.get('message-id') ?? undefined,
+          date: message.headers.get('date') ?? undefined,
+          ...(attachments.length > 0 ? { attachments } : {}),
+        },
+      },
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Open-Brain-Caller': 'email-worker',
+    }
+    if (env.INGEST_SECRET) {
+      headers['X-Open-Brain-Ingest-Secret'] = env.INGEST_SECRET
+    }
+
+    console.log(`POSTing capture: ${trimmedContent.length} chars, ${attachments.length} attachments`)
+
+    const response = await fetch(env.CAPTURES_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(capturePayload),
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.text()
+      console.error(`Capture creation failed: ${response.status} ${response.statusText} — ${errorBody}`)
+      message.setReject(`Capture API returned ${response.status}`)
+      return
+    }
+
+    const result = await response.json() as { id: string; pipeline_status: string }
+    console.log(`Capture created: id=${result.id} status=${result.pipeline_status}`)
+  },
+}

--- a/cloudflare/email-worker/tsconfig.json
+++ b/cloudflare/email-worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/cloudflare/email-worker/wrangler.toml
+++ b/cloudflare/email-worker/wrangler.toml
@@ -13,6 +13,3 @@ CAPTURES_URL = "https://brain.troy-davis.com/api/v1/captures"
 DEFAULT_BRAIN_VIEW = "personal"
 # Default capture_type — pipeline reclassifies via LLM
 DEFAULT_CAPTURE_TYPE = "observation"
-
-# INGEST_SECRET is stored as a Cloudflare Worker secret (wrangler secret put INGEST_SECRET)
-# Must match the X-Open-Brain-Ingest-Secret header expected by core-api (if you add that check)

--- a/cloudflare/email-worker/wrangler.toml
+++ b/cloudflare/email-worker/wrangler.toml
@@ -1,0 +1,18 @@
+name = "open-brain-email-worker"
+main = "src/index.ts"
+compatibility_date = "2025-03-30"
+workers_dev = false
+
+# Email routing trigger — Cloudflare routes matching emails to this worker
+# After deploying, configure Email Routing in the dashboard:
+#   brain@troy-davis.com → this worker
+
+[vars]
+CAPTURES_URL = "https://brain.troy-davis.com/api/v1/captures"
+# Default brain_view for email captures — pipeline reclassifies via LLM
+DEFAULT_BRAIN_VIEW = "personal"
+# Default capture_type — pipeline reclassifies via LLM
+DEFAULT_CAPTURE_TYPE = "observation"
+
+# INGEST_SECRET is stored as a Cloudflare Worker secret (wrangler secret put INGEST_SECRET)
+# Must match the X-Open-Brain-Ingest-Secret header expected by core-api (if you add that check)

--- a/packages/core-api/src/app.ts
+++ b/packages/core-api/src/app.ts
@@ -14,6 +14,7 @@ import { registerSkillRoutes } from './routes/skills.js'
 import { registerTriggerRoutes } from './routes/triggers.js'
 import { registerEntityRoutes } from './routes/entities.js'
 import { registerBetRoutes } from './routes/bets.js'
+import { registerSettingsRoutes } from './routes/settings.js'
 import { registerSessionRoutes } from './routes/sessions.js'
 import { registerEventsRoutes } from './routes/events.js'
 import { registerDocumentRoutes } from './routes/documents.js'
@@ -129,6 +130,11 @@ export function createApp(deps: AppDependencies = {}): Hono {
   // Sessions API — GovernanceEngine is passed via SessionService constructor in index.ts
   if (sessionService) {
     registerSessionRoutes(app, sessionService)
+  }
+
+  // Settings API (generic key-value store — used by email allowlist, etc.)
+  if (db) {
+    registerSettingsRoutes(app, db)
   }
 
   // MCP endpoint — requires all services to be available

--- a/packages/core-api/src/middleware/rate-limit.ts
+++ b/packages/core-api/src/middleware/rate-limit.ts
@@ -155,11 +155,9 @@ export function rateLimit(limiter: RateLimiter): MiddlewareHandler {
   return async (c, next) => {
     const key = getClientKey(c.req.raw.headers)
 
-    // Bypass rate limiting for trusted internal callers:
-    // - integration-test: automated test suites
-    // - web-ui: nginx proxy adds this header for all /api/ requests from the dashboard
-    // - email-worker: Cloudflare Email Worker — guaranteed delivery
-    if (key === 'internal:integration-test' || key === 'internal:web-ui' || key === 'internal:email-worker') {
+    // Bypass rate limiting for trusted internal callers
+    const BYPASS_CALLERS = new Set(['internal:integration-test', 'internal:web-ui', 'internal:email-worker'])
+    if (BYPASS_CALLERS.has(key)) {
       await next()
       return
     }

--- a/packages/core-api/src/middleware/rate-limit.ts
+++ b/packages/core-api/src/middleware/rate-limit.ts
@@ -158,7 +158,8 @@ export function rateLimit(limiter: RateLimiter): MiddlewareHandler {
     // Bypass rate limiting for trusted internal callers:
     // - integration-test: automated test suites
     // - web-ui: nginx proxy adds this header for all /api/ requests from the dashboard
-    if (key === 'internal:integration-test' || key === 'internal:web-ui') {
+    // - email-worker: Cloudflare Email Worker — guaranteed delivery
+    if (key === 'internal:integration-test' || key === 'internal:web-ui' || key === 'internal:email-worker') {
       await next()
       return
     }

--- a/packages/core-api/src/routes/settings.ts
+++ b/packages/core-api/src/routes/settings.ts
@@ -3,11 +3,14 @@ import { eq } from 'drizzle-orm'
 import type { Database } from '@open-brain/shared'
 import { logger, app_settings } from '@open-brain/shared'
 
+/** Valid settings keys — prevents unbounded key creation */
+const VALID_SETTINGS_KEYS = new Set(['email_allowlist'])
+
 /**
  * Register settings API routes.
  *
  * GET  /api/v1/settings/:key — retrieve a setting by key
- * PUT  /api/v1/settings/:key — upsert a setting
+ * PUT  /api/v1/settings/:key — upsert a setting (key must be in whitelist)
  */
 export function registerSettingsRoutes(app: Hono, db: Database): void {
   app.get('/api/v1/settings/:key', async (c) => {
@@ -21,6 +24,9 @@ export function registerSettingsRoutes(app: Hono, db: Database): void {
 
   app.put('/api/v1/settings/:key', async (c) => {
     const key = c.req.param('key')
+    if (!VALID_SETTINGS_KEYS.has(key)) {
+      return c.json({ error: 'Unknown settings key', key }, 400)
+    }
     let body: { value: unknown }
     try {
       body = await c.req.json()

--- a/packages/core-api/src/routes/settings.ts
+++ b/packages/core-api/src/routes/settings.ts
@@ -1,0 +1,41 @@
+import type { Hono } from 'hono'
+import { eq } from 'drizzle-orm'
+import type { Database } from '@open-brain/shared'
+import { logger, app_settings } from '@open-brain/shared'
+
+/**
+ * Register settings API routes.
+ *
+ * GET  /api/v1/settings/:key — retrieve a setting by key
+ * PUT  /api/v1/settings/:key — upsert a setting
+ */
+export function registerSettingsRoutes(app: Hono, db: Database): void {
+  app.get('/api/v1/settings/:key', async (c) => {
+    const key = c.req.param('key')
+    const rows = await db.select().from(app_settings).where(eq(app_settings.key, key))
+    if (rows.length === 0) {
+      return c.json({ error: 'Not found', key }, 404)
+    }
+    return c.json({ key: rows[0].key, value: rows[0].value, updated_at: rows[0].updated_at })
+  })
+
+  app.put('/api/v1/settings/:key', async (c) => {
+    const key = c.req.param('key')
+    let body: { value: unknown }
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400)
+    }
+    if (body.value === undefined) {
+      return c.json({ error: 'value is required' }, 400)
+    }
+
+    const now = new Date()
+    await db.insert(app_settings).values({ key, value: body.value, updated_at: now })
+      .onConflictDoUpdate({ target: app_settings.key, set: { value: body.value, updated_at: now } })
+
+    logger.info({ key }, '[settings] Setting updated')
+    return c.json({ key, value: body.value, updated_at: now.toISOString() })
+  })
+}

--- a/packages/core-api/src/schemas/capture.ts
+++ b/packages/core-api/src/schemas/capture.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 const CAPTURE_TYPES = ['decision', 'idea', 'observation', 'task', 'win', 'blocker', 'question', 'reflection'] as const
-const CAPTURE_SOURCES = ['slack', 'voice', 'api', 'document'] as const
+const CAPTURE_SOURCES = ['slack', 'voice', 'api', 'document', 'mcp', 'email'] as const
 
 export const createCaptureSchema = z.object({
   content: z.string().min(1).max(50000),

--- a/packages/shared/drizzle/0010_app_settings.sql
+++ b/packages/shared/drizzle/0010_app_settings.sql
@@ -1,0 +1,15 @@
+-- Migration: 0010
+-- Generic app settings table (key-value, JSONB values).
+-- Seeded with the email sender allowlist for the Cloudflare Email Worker.
+
+CREATE TABLE IF NOT EXISTS app_settings (
+  key        TEXT PRIMARY KEY,
+  value      JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the email allowlist with Troy's known addresses
+INSERT INTO app_settings (key, value) VALUES (
+  'email_allowlist',
+  '["troy.davis@hotmail.com","troy.e.davis@gmail.com","tdavis@stratfieldconsulting.com","troy.davis@accesscfa.com","troy@k4jda.net"]'::jsonb
+) ON CONFLICT (key) DO NOTHING;

--- a/packages/shared/src/schema/supporting.ts
+++ b/packages/shared/src/schema/supporting.ts
@@ -194,3 +194,12 @@ export const triggers = pgTable(
     enabled_idx: index('triggers_enabled_idx').on(table.enabled),
   }),
 )
+
+// ============================================================
+// app_settings table — generic key-value settings store
+// ============================================================
+export const app_settings = pgTable('app_settings', {
+  key: text('key').primaryKey(),
+  value: jsonb('value').notNull(),
+  updated_at: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+})

--- a/packages/shared/src/types/capture.ts
+++ b/packages/shared/src/types/capture.ts
@@ -8,7 +8,7 @@ export type CaptureType =
   | 'question'
   | 'reflection'
 
-export type CaptureSource = 'slack' | 'voice' | 'api' | 'document' | 'mcp'
+export type CaptureSource = 'slack' | 'voice' | 'api' | 'document' | 'mcp' | 'email'
 
 // BrainView is a string — validated against config at runtime, not a hardcoded enum
 export type BrainView = string

--- a/packages/slack-bot/src/__tests__/query-handler.test.ts
+++ b/packages/slack-bot/src/__tests__/query-handler.test.ts
@@ -117,6 +117,42 @@ describe('handleQuery()', () => {
   // New query — no thread context
   // -------------------------------------------------------------------------
 
+  // -------------------------------------------------------------------------
+  // Synthesis routing — questions and requests delegate to synthesize_query
+  // -------------------------------------------------------------------------
+
+  describe('synthesis routing', () => {
+    it('calls synthesize_query for question-like queries', async () => {
+      const msg = makeMessage({ text: '? what did I decide about pricing?' })
+      await handleQuery(msg, say, client, redis)
+      expect(client.synthesize_query).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'what did I decide about pricing?' }),
+      )
+      expect(client.search_query).not.toHaveBeenCalled()
+    })
+
+    it('calls synthesize_query for "give me a summary" requests', async () => {
+      const msg = makeMessage({ text: 'give me a summary of what I did yesterday' })
+      await handleQuery(msg, say, client, redis)
+      expect(client.synthesize_query).toHaveBeenCalled()
+      expect(client.search_query).not.toHaveBeenCalled()
+    })
+
+    it('sends acknowledgment before synthesis', async () => {
+      const msg = makeMessage({ text: '? how should I approach QSR pricing?' })
+      await handleQuery(msg, say, client, redis)
+      const calls = (say as ReturnType<typeof vi.fn>).mock.calls
+      expect(calls[0][0].text).toContain('Synthesizing')
+    })
+
+    it('falls through to search for keyword-only queries', async () => {
+      const msg = makeMessage({ text: '? QSR pricing strategy' })
+      await handleQuery(msg, say, client, redis)
+      expect(client.search_query).toHaveBeenCalled()
+      expect(client.synthesize_query).not.toHaveBeenCalled()
+    })
+  })
+
   describe('new query (no thread context)', () => {
     it('calls search_query with extracted text (strips ? prefix)', async () => {
       const msg = makeMessage({ text: '? QSR pricing strategy' })
@@ -135,9 +171,18 @@ describe('handleQuery()', () => {
     })
 
     it('strips @mention from query text', async () => {
-      const msg = makeMessage({ text: '<@UBOTID> what are my recent decisions?' })
+      // Use keyword-only query to test prefix stripping without triggering synthesis
+      const msg = makeMessage({ text: '<@UBOTID> QSR pricing strategy' })
       await handleQuery(msg, say, client, redis)
       expect(client.search_query).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'QSR pricing strategy' }),
+      )
+    })
+
+    it('routes @mention questions to synthesis', async () => {
+      const msg = makeMessage({ text: '<@UBOTID> what are my recent decisions?' })
+      await handleQuery(msg, say, client, redis)
+      expect(client.synthesize_query).toHaveBeenCalledWith(
         expect.objectContaining({ query: 'what are my recent decisions?' }),
       )
     })
@@ -371,11 +416,18 @@ describe('handleQuery()', () => {
       })
     })
 
-    it('treats unrecognized follow-up as a new search', async () => {
+    it('routes question follow-ups to synthesis', async () => {
       const msg = makeMessage({ text: 'tell me about contract pricing', thread_ts: 'ts-original' })
       await handleQuery(msg, say, client, redis)
+      expect(client.synthesize_query).toHaveBeenCalled()
+      expect(client.search_query).not.toHaveBeenCalled()
+    })
+
+    it('treats keyword follow-ups as new search', async () => {
+      const msg = makeMessage({ text: 'contract pricing terms', thread_ts: 'ts-original' })
+      await handleQuery(msg, say, client, redis)
       expect(client.search_query).toHaveBeenCalledWith(
-        expect.objectContaining({ query: 'tell me about contract pricing' }),
+        expect.objectContaining({ query: 'contract pricing terms' }),
       )
     })
 
@@ -414,6 +466,7 @@ describe('handleQuery()', () => {
 // ---------------------------------------------------------------------------
 
 describe('isSynthesisRequest()', () => {
+  // --- Existing synthesis keywords ---
   it('returns true for "summarize my work"', () => {
     expect(isSynthesisRequest('summarize my work')).toBe(true)
   })
@@ -438,23 +491,70 @@ describe('isSynthesisRequest()', () => {
     expect(isSynthesisRequest('what have I learned')).toBe(true)
   })
 
-  it('returns false for a plain search query', () => {
-    expect(isSynthesisRequest('QSR pricing strategy')).toBe(false)
-  })
-
-  it('returns false for a question without synthesis keywords', () => {
-    expect(isSynthesisRequest('what did I decide about pricing?')).toBe(false)
-  })
-
-  it('returns false for empty string', () => {
-    expect(isSynthesisRequest('')).toBe(false)
-  })
-
   it('is case-insensitive', () => {
     expect(isSynthesisRequest('SUMMARIZE my notes')).toBe(true)
   })
 
   it('returns true for "overall summary"', () => {
     expect(isSynthesisRequest('give me an overall summary of my work')).toBe(true)
+  })
+
+  // --- Broadened patterns: questions ---
+  it('returns true for questions starting with interrogative words', () => {
+    expect(isSynthesisRequest('what did I decide about pricing')).toBe(true)
+    expect(isSynthesisRequest('how should I approach the QSR deal')).toBe(true)
+    expect(isSynthesisRequest('why did we choose that vendor')).toBe(true)
+    expect(isSynthesisRequest('when did I last discuss pricing')).toBe(true)
+    expect(isSynthesisRequest('who was involved in the QSR decision')).toBe(true)
+    expect(isSynthesisRequest('where did I capture that idea')).toBe(true)
+  })
+
+  it('returns true for questions ending with ?', () => {
+    expect(isSynthesisRequest('did I ever discuss pricing?')).toBe(true)
+    expect(isSynthesisRequest('anything about QSR contracts?')).toBe(true)
+  })
+
+  it('returns true for the user example: "give me a summary of what I did yesterday"', () => {
+    expect(isSynthesisRequest('give me a summary of what I did yesterday')).toBe(true)
+  })
+
+  // --- Broadened patterns: request verbs ---
+  it('returns true for "tell me about ..."', () => {
+    expect(isSynthesisRequest('tell me about my recent decisions')).toBe(true)
+  })
+
+  it('returns true for "explain ..."', () => {
+    expect(isSynthesisRequest('explain my QSR pricing strategy')).toBe(true)
+  })
+
+  it('returns true for "describe ..."', () => {
+    expect(isSynthesisRequest('describe my work this week')).toBe(true)
+  })
+
+  // --- Broadened patterns: noun forms ---
+  it('returns true for "recap", "rundown", "breakdown"', () => {
+    expect(isSynthesisRequest('give me a recap of this week')).toBe(true)
+    expect(isSynthesisRequest('rundown of my recent captures')).toBe(true)
+    expect(isSynthesisRequest('breakdown of decisions by topic')).toBe(true)
+  })
+
+  // --- Reflective ---
+  it('returns true for "what did I ..."', () => {
+    expect(isSynthesisRequest('what did I work on last week')).toBe(true)
+  })
+
+  it('returns true for "what do I ..."', () => {
+    expect(isSynthesisRequest('what do I know about vendor selection')).toBe(true)
+  })
+
+  // --- Should still be raw search (keyword-only, no question structure) ---
+  it('returns false for keyword-only queries', () => {
+    expect(isSynthesisRequest('QSR pricing strategy')).toBe(false)
+    expect(isSynthesisRequest('meeting notes march')).toBe(false)
+    expect(isSynthesisRequest('decisions')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isSynthesisRequest('')).toBe(false)
   })
 })

--- a/packages/slack-bot/src/handlers/query.ts
+++ b/packages/slack-bot/src/handlers/query.ts
@@ -21,6 +21,7 @@ import type { Redis } from 'ioredis'
 import type { CoreApiClient } from '../lib/core-api-client.js'
 import { formatSearchResults, formatCapture, formatError } from '../lib/formatters.js'
 import { getThreadContext, setThreadContext } from '../lib/thread-context.js'
+import { isSynthesisRequest, handleSynthesis } from './synthesis.js'
 import { logger } from '@open-brain/shared'
 
 const SEARCH_LIMIT = 20   // Fetch up to 20 results; paginate 5 per page
@@ -180,8 +181,12 @@ export async function handleQuery(
       return
     }
 
-    // followUp.type === 'new_query' — run a fresh search scoped to this thread
+    // followUp.type === 'new_query' — question → synthesis, keywords → search
     const queryText = extractQueryText(followUp.text)
+    if (isSynthesisRequest(queryText)) {
+      await handleSynthesis(message, say, coreApiClient, queryText)
+      return
+    }
     await runSearch(queryText, ts, say, coreApiClient, redis)
     return
   }
@@ -190,5 +195,12 @@ export async function handleQuery(
   // Fresh query (not a thread reply)
   // -------------------------------------------------------------------------
   const queryText = extractQueryText(rawText)
+
+  // Questions and requests get LLM-synthesized answers; keyword-only queries get raw search
+  if (isSynthesisRequest(queryText)) {
+    await handleSynthesis(message, say, coreApiClient, queryText)
+    return
+  }
+
   await runSearch(queryText, ts, say, coreApiClient, redis)
 }

--- a/packages/slack-bot/src/handlers/synthesis.ts
+++ b/packages/slack-bot/src/handlers/synthesis.ts
@@ -11,15 +11,42 @@ import type { CoreApiClient } from '../lib/core-api-client.js'
 import { formatError } from '../lib/formatters.js'
 import { logger } from '@open-brain/shared'
 
-/** Patterns that indicate synthesis intent rather than a plain search */
+/**
+ * Patterns that indicate synthesis intent rather than a plain search.
+ *
+ * By the time this check runs, the message is already classified as QUERY intent,
+ * so we can be aggressive — captures and casual messages never reach here.
+ *
+ * Design: questions and requests get LLM-synthesized answers.
+ * Keyword-only queries (no question structure) fall through to raw search.
+ */
 const SYNTHESIS_PATTERNS = [
-  /\bsummariz(e|ing)\b/i,
-  /\bsynthesiz(e|ing)\b/i,
-  /\bwhat('s| is) the pattern\b/i,
-  /\bwhat('s| are) (my|the) (themes?|trends?|patterns?)\b/i,
-  /\bwhat have I (learned|decided|said|captured)\b/i,
-  /\boverall (summary|view|picture)\b/i,
-  /\bgive me an overview\b/i,
+  // Summary / synthesis keywords (verb and noun forms)
+  /\bsummar(y|iz(e|ing))\b/i,
+  /\bsynthesi(s|z(e|ing))\b/i,
+  /\brecap\b/i,
+  /\brundown\b/i,
+  /\bbreakdown\b/i,
+  /\boverview\b/i,
+
+  // Pattern / theme / trend analysis
+  /\bwhat('s| is| are) (the |my )?(patterns?|themes?|trends?)\b/i,
+
+  // Reflective queries — "what have/did/do I ..."
+  /\bwhat (have|did|do) I\b/i,
+  /\bwhat('s| is) my\b/i,
+
+  // Interrogative words at start of query — questions want answers, not result lists
+  /^(what|how|why|when|who|where|which)\b/i,
+
+  // Trailing question mark
+  /\?\s*$/,
+
+  // Request verbs — "give me ...", "tell me ...", "explain ...", "describe ..."
+  /\bgive me\b/i,
+  /\btell me\b/i,
+  /\bexplain\b/i,
+  /\bdescribe\b/i,
 ]
 
 /**

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -8,7 +8,6 @@ import {
   Gavel,
   Lightbulb,
   Mic,
-  Hash,
   Settings,
   HelpCircle,
   Brain,
@@ -35,7 +34,6 @@ const navItems: NavItem[] = [
 ];
 
 const bottomNavItems: NavItem[] = [
-  { to: '/slack-cleanup', label: 'Slack Cleanup', icon: Hash },
   { to: '/help', label: 'Help', icon: HelpCircle },
   { to: '/settings', label: 'Settings', icon: Settings },
 ];

--- a/packages/web/src/components/SearchFilters.tsx
+++ b/packages/web/src/components/SearchFilters.tsx
@@ -7,7 +7,7 @@ const BRAIN_VIEWS: BrainView[] = ['career', 'personal', 'technical', 'work-inter
 const CAPTURE_TYPES: CaptureType[] = [
   'decision', 'idea', 'observation', 'task', 'win', 'blocker', 'question', 'reflection',
 ];
-const CAPTURE_SOURCES: CaptureSource[] = ['slack', 'voice', 'api', 'mcp', 'system', 'bookmark', 'calendar'];
+const CAPTURE_SOURCES: CaptureSource[] = ['slack', 'voice', 'api', 'document', 'mcp', 'email'];
 
 interface SearchFiltersProps {
   filters: SearchFilters;

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import { cn } from '@/lib/utils'
+
+const TooltipProvider = TooltipPrimitive.Provider
+const Tooltip = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95',
+      className,
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -309,6 +309,21 @@ export const adminApi = {
   },
 }
 
+// Settings API
+
+export const settingsApi = {
+  get: <T = unknown>(key: string) => {
+    return request<{ key: string; value: T; updated_at: string }>(`/settings/${encodeURIComponent(key)}`)
+  },
+
+  put: <T = unknown>(key: string, value: T) => {
+    return request<{ key: string; value: T; updated_at: string }>(`/settings/${encodeURIComponent(key)}`, {
+      method: 'PUT',
+      body: JSON.stringify({ value }),
+    })
+  },
+}
+
 // Pipeline API
 
 export const pipelineApi = {

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -4,7 +4,7 @@
 
 export type CaptureType = 'decision' | 'idea' | 'observation' | 'task' | 'win' | 'blocker' | 'question' | 'reflection'
 export type BrainView = 'career' | 'personal' | 'technical' | 'work-internal' | 'client'
-export type CaptureSource = 'api' | 'slack' | 'voice' | 'document' | 'bookmark' | 'calendar' | 'mcp' | 'system'
+export type CaptureSource = 'api' | 'slack' | 'voice' | 'document' | 'mcp' | 'email'
 export type PipelineStatus = 'pending' | 'processing' | 'complete' | 'partial' | 'failed'
 
 export interface PreExtracted {

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -674,6 +674,8 @@ function EmailAllowlistSection({ entries, loading, error, onAdd, onRemove }: {
     setRemoving(entry);
     try {
       await onRemove(entry);
+    } catch {
+      setAddError('Failed to remove entry — please try again');
     } finally {
       setRemoving(null);
     }

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, Plus, Trash2, AlertCircle, CheckCircle, XCircle, Activity, Pencil, Check, X, Loader2 } from 'lucide-react';
+import { RefreshCw, Plus, Trash2, AlertCircle, CheckCircle, XCircle, Activity, Pencil, Check, X, Loader2, Mail, Info } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import { skillsApi, triggersApi, pipelineApi, adminApi } from '@/lib/api';
+import { skillsApi, triggersApi, pipelineApi, adminApi, settingsApi } from '@/lib/api';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { Skill, Trigger } from '@/lib/types';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -616,6 +617,156 @@ function TriggersSection({ triggers, loading, error, onAdd, onDelete }: {
   );
 }
 
+// ─── Email Allowlist section ─────────────────────────────────────────────────
+
+function EmailAllowlistSection({ entries, loading, error, onAdd, onRemove }: {
+  entries: string[];
+  loading: boolean;
+  error: string | null;
+  onAdd: (entry: string) => Promise<void>;
+  onRemove: (entry: string) => Promise<void>;
+}) {
+  const [adding, setAdding] = useState(false);
+  const [newEntry, setNewEntry] = useState('');
+  const [addSubmitting, setAddSubmitting] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  function validateEntry(value: string): string | null {
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed) return 'Entry cannot be empty';
+    if (trimmed.startsWith('@')) {
+      // Domain pattern: @example.com
+      if (!/^@[a-z0-9.-]+\.[a-z]{2,}$/.test(trimmed)) return 'Invalid domain format. Use @example.com';
+      return null;
+    }
+    // Email address
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) return 'Invalid email address';
+    return null;
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = newEntry.trim().toLowerCase();
+    const validationError = validateEntry(trimmed);
+    if (validationError) {
+      setAddError(validationError);
+      return;
+    }
+    if (entries.includes(trimmed)) {
+      setAddError('Already in the allowlist');
+      return;
+    }
+    setAddSubmitting(true);
+    setAddError(null);
+    try {
+      await onAdd(trimmed);
+      setNewEntry('');
+      setAdding(false);
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : 'Failed to add entry');
+    } finally {
+      setAddSubmitting(false);
+    }
+  }
+
+  async function handleRemove(entry: string) {
+    setRemoving(entry);
+    try {
+      await onRemove(entry);
+    } finally {
+      setRemoving(null);
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-semibold">Email Allowlist</h2>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+              </TooltipTrigger>
+              <TooltipContent side="right" className="max-w-xs">
+                <p>Controls which senders can create captures via <strong>brain@troy-davis.com</strong>.</p>
+                <p className="mt-1">Enter a full email address (e.g. <code className="text-xs bg-muted px-1 rounded">user@example.com</code>) for exact matching, or a domain starting with <code className="text-xs bg-muted px-1 rounded">@</code> (e.g. <code className="text-xs bg-muted px-1 rounded">@example.com</code>) to allow all addresses from that domain.</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <Button size="sm" variant="outline" onClick={() => setAdding((v) => !v)} className="gap-1.5">
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </Button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {adding && (
+        <form onSubmit={handleAdd} className="rounded-lg border bg-card p-4 space-y-3">
+          <h3 className="text-sm font-medium">Add Allowed Sender</h3>
+          <Input
+            value={newEntry}
+            onChange={(e) => { setNewEntry(e.target.value); setAddError(null); }}
+            placeholder="user@example.com or @example.com"
+            required
+            autoFocus
+          />
+          {addError && <p className="text-xs text-destructive">{addError}</p>}
+          <div className="flex gap-2">
+            <Button type="submit" size="sm" disabled={addSubmitting || !newEntry.trim()}>
+              {addSubmitting ? 'Adding...' : 'Add'}
+            </Button>
+            <Button type="button" size="sm" variant="ghost" onClick={() => { setAdding(false); setAddError(null); }}>Cancel</Button>
+          </div>
+        </form>
+      )}
+
+      {loading && entries.length === 0 ? (
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => <div key={i} className="h-10 animate-pulse rounded bg-secondary" />)}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+          <p className="text-sm">No allowed senders configured.</p>
+          <p className="text-xs mt-1">All emails to brain@troy-davis.com will be rejected until you add at least one entry.</p>
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card divide-y">
+          {entries.map((entry) => (
+            <div key={entry} className="px-4 py-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 min-w-0">
+                <Mail className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                <span className="text-sm font-mono truncate">{entry}</span>
+                <Badge variant={entry.startsWith('@') ? 'secondary' : 'outline'} className="text-xs shrink-0">
+                  {entry.startsWith('@') ? 'domain' : 'exact'}
+                </Badge>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-muted-foreground hover:text-destructive shrink-0"
+                disabled={removing === entry}
+                onClick={() => handleRemove(entry)}
+                aria-label={`Remove ${entry}`}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 // ─── Danger Zone section ──────────────────────────────────────────────────────
 
 const CONFIRM_PHRASE = 'WIPE ALL DATA';
@@ -775,6 +926,10 @@ export default function Settings() {
   const [triggersLoading, setTriggersLoading] = useState(true);
   const [triggersError, setTriggersError] = useState<string | null>(null);
 
+  const [allowlist, setAllowlist] = useState<string[]>([]);
+  const [allowlistLoading, setAllowlistLoading] = useState(true);
+  const [allowlistError, setAllowlistError] = useState<string | null>(null);
+
   const [refreshing, setRefreshing] = useState(false);
 
   const loadHealth = useCallback(async () => {
@@ -830,9 +985,26 @@ export default function Settings() {
     }
   }, []);
 
+  const loadAllowlist = useCallback(async () => {
+    setAllowlistError(null);
+    try {
+      const res = await settingsApi.get<string[]>('email_allowlist');
+      setAllowlist(res.value);
+    } catch (err) {
+      // 404 means no allowlist yet — treat as empty
+      if (err instanceof Error && err.message.includes('404')) {
+        setAllowlist([]);
+      } else {
+        setAllowlistError(err instanceof Error ? err.message : 'Failed to load allowlist');
+      }
+    } finally {
+      setAllowlistLoading(false);
+    }
+  }, []);
+
   const loadAll = useCallback(async () => {
-    await Promise.allSettled([loadHealth(), loadSkills(), loadTriggers()]);
-  }, [loadHealth, loadSkills, loadTriggers]);
+    await Promise.allSettled([loadHealth(), loadSkills(), loadTriggers(), loadAllowlist()]);
+  }, [loadHealth, loadSkills, loadTriggers, loadAllowlist]);
 
   useEffect(() => {
     loadAll();
@@ -861,6 +1033,18 @@ export default function Settings() {
   async function handleDeleteTrigger(id: string) {
     await triggersApi.delete(id);
     await loadTriggers();
+  }
+
+  async function handleAddAllowlistEntry(entry: string) {
+    const updated = [...allowlist, entry];
+    await settingsApi.put('email_allowlist', updated);
+    setAllowlist(updated);
+  }
+
+  async function handleRemoveAllowlistEntry(entry: string) {
+    const updated = allowlist.filter((e) => e !== entry);
+    await settingsApi.put('email_allowlist', updated);
+    setAllowlist(updated);
   }
 
   async function handleClearQueue(queueName: string) {
@@ -919,6 +1103,16 @@ export default function Settings() {
         error={triggersError}
         onAdd={handleAddTrigger}
         onDelete={handleDeleteTrigger}
+      />
+
+      <Separator />
+
+      <EmailAllowlistSection
+        entries={allowlist}
+        loading={allowlistLoading}
+        error={allowlistError}
+        onAdd={handleAddAllowlistEntry}
+        onRemove={handleRemoveAllowlistEntry}
       />
 
       <Separator />


### PR DESCRIPTION
## Summary

- **Email ingestion**: Cloudflare Email Worker at `brain@troy-davis.com` parses emails with postal-mime, strips signatures, POSTs captures to Core API. Zero new infrastructure — Cloudflare free tier.
- **Sender allowlist**: Dashboard-managed allowlist (exact address + `@domain` matching) in new `app_settings` table. Worker rejects unauthorized senders. Reusable settings API.
- **Synthesis routing**: Slack bot routes questions to `/api/v1/synthesize` instead of raw search results. Broadened detection patterns — interrogatives, `?`, request verbs, summary nouns.
- **Fixes**: `email`/`mcp` source types, frontend source filter mismatch, rate limiter bypass for email-worker, Slack Cleanup removed from nav.

## Files Changed (21)

| Area | Files | What |
|------|-------|------|
| Email Worker | `cloudflare/email-worker/*` (5 new) | Cloudflare Worker project |
| Settings API | `core-api/routes/settings.ts` (new), `app.ts` | GET/PUT `/api/v1/settings/:key` |
| Migration | `shared/drizzle/0010_app_settings.sql` (new) | `app_settings` table + seed |
| Schema | `shared/schema/supporting.ts`, `shared/types/capture.ts`, `core-api/schemas/capture.ts` | Add `email`/`mcp` source, Drizzle table |
| Rate limiter | `core-api/middleware/rate-limit.ts` | Bypass for `email-worker` |
| Synthesis | `slack-bot/handlers/synthesis.ts`, `query.ts`, tests | Broadened patterns, wired into query handler |
| Web UI | `Settings.tsx`, `api.ts`, `tooltip.tsx` (new), `types.ts`, `SearchFilters.tsx`, `Layout.tsx` | Allowlist section, fixed sources, removed Slack nav |

## Test plan

- [x] 416 core-api unit tests passing
- [x] 363 slack-bot unit tests passing
- [x] Web builds with no type errors
- [x] Worker dry-run deploys successfully
- [x] Email sent to brain@troy-davis.com creates capture (tested live)
- [ ] Deploy migration 0010 to homeserver
- [ ] docker-compose up --build -d
- [ ] Verify settings API returns seeded allowlist
- [ ] Verify email from allowed sender creates capture with `source: 'email'`
- [ ] Verify email from disallowed sender is rejected
- [ ] Dashboard settings page shows allowlist section
- [ ] Search filters dropdown shows correct sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)