### PR TITLE
fix: search page crash — results mapping mismatch

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -68,11 +68,19 @@ export const statsApi = {
 // Search API
 
 export const searchApi = {
-  search: (filters: SearchFilters) => {
-    return request<SearchResult>('/search', {
+  search: async (filters: SearchFilters): Promise<SearchResult> => {
+    // API returns { results: [{ capture, score, ... }], total, query }
+    // Frontend expects { captures: Capture[], total, query, hybrid }
+    const raw = await request<{ results: Array<{ capture: Capture; score: number }>; total: number; query: string }>('/search', {
       method: 'POST',
       body: JSON.stringify(filters),
     })
+    return {
+      captures: raw.results.map(r => r.capture),
+      total: raw.total,
+      query: raw.query,
+      hybrid: filters.hybrid ?? true,
+    }
   },
 }
 


### PR DESCRIPTION
## Summary
- Search page crashes (blank white screen) when typing a query
- Root cause: API returns `{ results: [{ capture, score }] }` but frontend expected `{ captures: Capture[] }`
- Fix: `searchApi.search()` now maps the response shape correctly
- Pre-existing bug, not introduced by PR #34

## Test plan
- [x] Web builds clean
- [ ] Search page renders results after typing a query

🤖 Generated with [Claude Code](https://claude.com/claude-code)