### PR TITLE
fix: unify CaptureCard across all pages

### DIFF
--- a/packages/web/src/components/CaptureCard.tsx
+++ b/packages/web/src/components/CaptureCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, MapPin } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { cn, formatRelativeTime, truncate } from '@/lib/utils';
@@ -20,11 +20,17 @@ const SOURCE_LABELS: Record<string, string> = {
   slack: 'Slack',
   voice: 'Voice',
   api: 'API',
+  document: 'Document',
   mcp: 'MCP',
-  system: 'System',
-  bookmark: 'Bookmark',
-  calendar: 'Calendar',
+  email: 'Email',
 };
+
+interface LocationData {
+  latitude?: number;
+  longitude?: number;
+  name?: string;
+  accuracy_meters?: number;
+}
 
 const PIPELINE_STATUS_COLORS: Record<string, string> = {
   complete: 'bg-green-100 text-green-700',
@@ -51,6 +57,7 @@ export default function CaptureCard({ capture, similarity, defaultExpanded = fal
   const topics = capture.topics ?? [];
   const entities = capture.entities ?? [];
   const pipelineEvents = capture.pipeline_events ?? [];
+  const location = (capture.source_metadata?.location ?? null) as LocationData | null;
 
   return (
     <Card
@@ -89,6 +96,19 @@ export default function CaptureCard({ capture, similarity, defaultExpanded = fal
             <span className="text-xs text-muted-foreground font-mono">
               {(similarity * 100).toFixed(0)}% match
             </span>
+          )}
+          {location?.latitude != null && location?.longitude != null && (
+            <a
+              href={`https://maps.google.com/?q=${location.latitude},${location.longitude}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-0.5 text-xs text-muted-foreground hover:text-blue-500 transition-colors"
+              onClick={(e) => e.stopPropagation()}
+              title={location.name ?? `${location.latitude.toFixed(4)}, ${location.longitude.toFixed(4)}`}
+            >
+              <MapPin className="h-3 w-3" />
+              <span className="max-w-[120px] truncate">{location.name ?? `${location.latitude.toFixed(2)}, ${location.longitude.toFixed(2)}`}</span>
+            </a>
           )}
           <span className="text-xs text-muted-foreground ml-auto">
             {formatRelativeTime(capture.created_at)}

--- a/packages/web/src/pages/EntityDetail.tsx
+++ b/packages/web/src/pages/EntityDetail.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
+import CaptureCard from '@/components/CaptureCard';
 import { entitiesApi } from '@/lib/api';
 import type { Entity, Capture } from '@/lib/types';
 import { cn } from '@/lib/utils';
@@ -16,14 +17,6 @@ const TYPE_COLORS: Record<string, string> = {
   concept: 'bg-violet-100 text-violet-800 border-violet-200',
   decision: 'bg-rose-100 text-rose-800 border-rose-200',
   project: 'bg-emerald-100 text-emerald-800 border-emerald-200',
-};
-
-const VIEW_COLORS: Record<string, string> = {
-  career: 'bg-blue-100 text-blue-800 border-blue-200',
-  personal: 'bg-green-100 text-green-800 border-green-200',
-  technical: 'bg-purple-100 text-purple-800 border-purple-200',
-  'work-internal': 'bg-orange-100 text-orange-800 border-orange-200',
-  client: 'bg-red-100 text-red-800 border-red-200',
 };
 
 function formatDate(iso: string) {
@@ -84,21 +77,7 @@ function EntityCard({ entity }: { entity: Entity }) {
 
 // --- Capture row ---
 function CaptureRow({ capture }: { capture: Capture }) {
-  const viewCls = VIEW_COLORS[capture.brain_view] ?? 'bg-gray-100 text-gray-800 border-gray-200';
-  return (
-    <div className="py-3 border-b last:border-b-0">
-      <div className="flex flex-wrap items-center gap-1.5 mb-1">
-        <span className="text-xs text-muted-foreground">{formatDate(capture.created_at)}</span>
-        <Badge variant="outline" className={cn('text-xs border', viewCls)}>
-          {capture.brain_view}
-        </Badge>
-        <Badge variant="secondary" className="text-xs capitalize">
-          {capture.capture_type}
-        </Badge>
-      </div>
-      <p className="text-sm leading-relaxed line-clamp-3">{capture.content}</p>
-    </div>
-  );
+  return <CaptureCard capture={capture} />;
 }
 
 // --- Co-occurrence graph (related entities derived from shared captures) ---

--- a/packages/web/src/pages/Timeline.tsx
+++ b/packages/web/src/pages/Timeline.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Link } from 'react-router-dom';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import CaptureCard from '@/components/CaptureCard';
 import { capturesApi } from '@/lib/api';
 import type { Capture, CaptureType, BrainView } from '@/lib/types';
 import { cn } from '@/lib/utils';
@@ -38,63 +37,23 @@ function formatDate(iso: string) {
   });
 }
 
-function formatTime(iso: string) {
-  return new Date(iso).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
-}
-
 function dateGroupKey(iso: string) {
   const d = new Date(iso);
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
-function CaptureCard({ capture }: { capture: Capture }) {
+function TimelineEntry({ capture }: { capture: Capture }) {
   const dot = VIEW_DOT[capture.brain_view] ?? 'bg-gray-400';
-  const viewCls = VIEW_COLORS[capture.brain_view] ?? 'bg-gray-100 text-gray-800 border-gray-200';
   return (
-    <div className="flex gap-3 py-3 border-b last:border-b-0">
-      {/* Timeline dot */}
-      <div className="flex flex-col items-center pt-1.5 shrink-0">
+    <div className="flex gap-3 py-2">
+      {/* Timeline dot + line */}
+      <div className="flex flex-col items-center pt-3 shrink-0">
         <div className={cn('h-2.5 w-2.5 rounded-full', dot)} />
         <div className="flex-1 w-px bg-border mt-1" />
       </div>
-
-      <div className="flex-1 min-w-0 pb-2">
-        <div className="flex flex-wrap items-center gap-1.5 mb-1">
-          <span className="text-xs text-muted-foreground">{formatTime(capture.created_at)}</span>
-          <Badge variant="outline" className={cn('text-xs border', viewCls)}>
-            {capture.brain_view}
-          </Badge>
-          <Badge variant="secondary" className="text-xs capitalize">
-            {capture.capture_type}
-          </Badge>
-          <Badge variant="outline" className="text-xs">
-            {capture.source}
-          </Badge>
-        </div>
-
-        <p className="text-sm leading-relaxed line-clamp-3">{capture.content}</p>
-
-        {(capture.entities ?? []).length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-1.5">
-            {(capture.entities ?? []).slice(0, 5).map((e) => (
-              <Link
-                key={e.id}
-                to={`/entities/${e.id}`}
-                className="text-xs text-primary hover:underline"
-              >
-                @{e.name}
-              </Link>
-            ))}
-          </div>
-        )}
-
-        {(capture.tags ?? []).length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-1">
-            {(capture.tags ?? []).slice(0, 6).map((t) => (
-              <span key={t} className="text-xs text-muted-foreground">#{t}</span>
-            ))}
-          </div>
-        )}
+      {/* Shared CaptureCard */}
+      <div className="flex-1 min-w-0">
+        <CaptureCard capture={capture} />
       </div>
     </div>
   );
@@ -303,7 +262,7 @@ export default function Timeline() {
               </div>
               <div className="pl-1">
                 {group.items.map((c) => (
-                  <CaptureCard key={c.id} capture={c} />
+                  <TimelineEntry key={c.id} capture={c} />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Consolidated 3 separate capture card implementations into one shared `CaptureCard`
- Timeline: replaced local non-expandable card with shared component (+ timeline dot wrapper)
- EntityDetail: replaced local `CaptureRow` with shared `CaptureCard`
- Added MapPin location indicator to shared CaptureCard (clickable Google Maps link)
- Fixed SOURCE_LABELS (removed phantom sources, added document/email)

Net: -77 lines deleted, +35 added. Less code, consistent behavior everywhere.

## Test plan
- [ ] Dashboard: captures expand, location pins visible on voice captures
- [ ] Timeline: captures now expand (previously static), location pins visible
- [ ] Search: unchanged behavior, location pins visible
- [ ] EntityDetail: captures now expand (previously static)

🤖 Generated with [Claude Code](https://claude.com/claude-code)