### PR TITLE
fix: slack-bot crash — lightweight ai-routing.yaml load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ After any non-trivial finding during deployment, testing, or debugging:
 - **Three separate CaptureCard implementations exist** — shared component (`components/CaptureCard.tsx`), Timeline local, EntityDetail local. Unification pending.
 - **Capture source types include `email` and `mcp`** — in addition to `slack`, `voice`, `api`, `document`. The Zod schema in `shared/src/schema/` validates these.
 - **Skills must resolve model aliases from ai-routing.yaml** — workers skills pass `modelAlias` directly to OpenAI. With LiteLLM proxy gone, aliases like `synthesis` cause 404. The skill-execution worker must resolve via `configService.get('ai').models[alias]` before dispatching. Same pattern as `extract-entities.ts`.
+- **Slack-bot loads only ai-routing.yaml, not full ConfigService** — `ConfigService.load()` requires all 4 config files (pipeline, ai, brain-views, notifications). Slack-bot only needs the intent model name. Uses lightweight `js-yaml` load with fallback to `gpt-5.4`. Config dir is now mounted (`./config:/app/config:ro`) but load is graceful if missing.
 
 ---
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -27,6 +27,7 @@
 | D15 | Dashboard-managed sender allowlist (app_settings table) | 2026-03-31 | ACTIVE | Entry 009 | Config file (no UI, requires redeploy), env var (same) |
 | D16 | Web synthesis answers on search page | 2026-03-31 | ACTIVE | Entry 011 | Separate synthesis page (fragmented UX), Slack-only synthesis (no web access) |
 | D17 | Model aliases resolved at init from ai-routing.yaml, never raw to OpenAI | 2026-04-01 | ACTIVE | Entry 012 | Pass-through to proxy (LiteLLM removed), hardcode model names (fragile) |
+| D18 | Slack-bot: lightweight ai-routing.yaml load, not full ConfigService | 2026-04-01 | ACTIVE | Entry 012 | Full ConfigService requires all 4 YAML files; slack-bot only needs intent model |
 
 ## Action Items
 
@@ -158,8 +159,19 @@ The CLAUDE.md contains 24 verified operational rules covering Docker healthcheck
 - Type-checks clean across all packages
 - CI web test failure resolved
 
+#### Deployment Issue — Slack-bot ConfigService crash
+First deploy attempt crashed slack-bot: `ConfigService.load()` requires ALL config files (pipeline.yaml, ai-routing.yaml, brain-views.yaml, notifications.yaml) but slack-bot container didn't mount `./config` volume. Workers container has the mount; slack-bot didn't.
+
+**Fix:** Two changes:
+1. Replaced full `ConfigService` in slack-bot with lightweight YAML load of only `ai-routing.yaml` + safe fallback to `gpt-5.4`
+2. Added `./config:/app/config:ro` volume mount to slack-bot in docker-compose.yml
+3. Added `js-yaml` + `@types/js-yaml` as slack-bot dependencies
+
+**Root cause:** `ConfigService.load()` is all-or-nothing — no partial load. Slack-bot only needs one model name. The lightweight approach is more appropriate for a container that historically doesn't use config files.
+
 #### Decision
 - **D17:** All model alias resolution must happen at service/worker init time from `ai-routing.yaml`, never passed raw to OpenAI API. Pattern: `configService.get('ai').models[alias]`.
+- **D18:** Slack-bot loads only `ai-routing.yaml` directly (not full ConfigService) — lighter dependency, graceful fallback if config missing.
 
 ### Entry 001 — Lab notebook initialized [init] [documentation]
 **Date:** 2026-03-30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,8 @@ services:
       # SLACK_BOT_TOKEN: set in .env.secrets   (xoxb-...)
       # SLACK_APP_TOKEN: set in .env.secrets   (xapp-...)
       # LITELLM_API_KEY: set in .env.secrets
+    volumes:
+      - ./config:/app/config:ro
     depends_on:
       core-api:
         condition: service_healthy

--- a/packages/slack-bot/package.json
+++ b/packages/slack-bot/package.json
@@ -21,10 +21,12 @@
   "dependencies": {
     "@open-brain/shared": "workspace:*",
     "@slack/bolt": "^4.6.0",
-    "ioredis": "^5.10.0"
+    "ioredis": "^5.10.0",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@slack/types": "^2.20.0",
+    "@types/js-yaml": "^4.0.9",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0",

--- a/packages/slack-bot/src/server.ts
+++ b/packages/slack-bot/src/server.ts
@@ -7,7 +7,10 @@ import type { App } from '@slack/bolt'
 import type { GenericMessageEvent } from '@slack/types'
 import { Redis } from 'ioredis'
 import type { CoreApiClient } from './lib/core-api-client.js'
-import { logger, ConfigService } from '@open-brain/shared'
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import yaml from 'js-yaml'
+import { logger } from '@open-brain/shared'
 import { IntentRouter } from './intent/router.js'
 import { handleCapture } from './handlers/capture.js'
 import { handleQuery } from './handlers/query.js'
@@ -20,12 +23,22 @@ import { safeHandle } from './lib/safe-handle.js'
  * Register all message/event handlers on the Bolt app.
  */
 function registerHandlers(app: App, coreApiClient: CoreApiClient, redis: Redis): void {
-  // Resolve model alias from ai-routing.yaml — OpenAI API rejects alias strings
+  // Resolve intent model alias from ai-routing.yaml — OpenAI API rejects alias strings.
+  // Load only ai-routing.yaml (not full ConfigService) since slack-bot doesn't mount all config files.
+  let intentModel = 'gpt-5.4' // safe fallback
   const configDir = process.env.CONFIG_DIR ?? '/app/config'
-  const configService = new ConfigService(configDir)
-  configService.load()
-  const aiConfig = configService.get('ai')
-  const intentModel: string = aiConfig.models['intent'] as string
+  const aiConfigPath = join(configDir, 'ai-routing.yaml')
+  if (existsSync(aiConfigPath)) {
+    try {
+      const raw = yaml.load(readFileSync(aiConfigPath, 'utf8')) as Record<string, unknown>
+      const models = raw?.models as Record<string, string> | undefined
+      if (models?.intent) intentModel = models.intent
+    } catch (err) {
+      logger.warn({ err }, 'Failed to load ai-routing.yaml — using default intent model')
+    }
+  } else {
+    logger.info({ path: aiConfigPath }, 'ai-routing.yaml not found — using default intent model')
+  }
 
   // Build IntentRouter from environment — falls back to CAPTURE if LiteLLM unavailable
   const litellmUrl = process.env.LITELLM_URL ?? 'https://llm.k4jda.net'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,10 +141,16 @@ importers:
       ioredis:
         specifier: ^5.10.0
         version: 5.10.0
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
     devDependencies:
       '@slack/types':
         specifier: ^2.20.0
         version: 2.20.0
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
## Summary

Follow-up to PR #38 — deploying the model alias fix crashed the slack-bot because `ConfigService.load()` requires all 4 config files but the slack-bot container didn't mount the config directory.

### Changes

- **Slack-bot server.ts**: Replace `ConfigService` with lightweight `js-yaml` load of only `ai-routing.yaml`, with safe fallback to `gpt-5.4` if file missing
- **docker-compose.yml**: Add `./config:/app/config:ro` volume mount to slack-bot (matches workers/core-api pattern)
- **package.json**: Add `js-yaml` + `@types/js-yaml` as slack-bot dependencies

### Why not just add the volume mount?

`ConfigService.load()` is all-or-nothing — it needs `pipeline.yaml`, `ai-routing.yaml`, `brain-views.yaml`, and `notifications.yaml`. The slack-bot only needs one model name from one file. The lightweight approach is more appropriate and has a graceful fallback.

## Test plan

- [x] All 1,426 tests pass (68 test files, 6 packages)
- [ ] Deploy to homeserver — slack-bot should start cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)