### PR TITLE
feat: proactive intelligence — autonomy levels, daily sweep, MCP context, heartbeat, Slack auto-response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,15 @@ After any non-trivial finding during deployment, testing, or debugging:
 - **Email worker allowlist URL derivation** — use regex `replace(/\/captures\/?$/, '')` to derive base API URL from `CAPTURES_URL`, not string replace (fragile with trailing slashes).
 - **Search API returns `results` not `captures`** — `GET /api/v1/search` returns `{ results: [{ capture, score }] }`. Frontend `searchApi.search()` maps this to the `SearchResult` type. Do not assume the API returns a flat `captures` array.
 - **Rate limiter bypass uses a Set** — `BYPASS_CALLERS` Set in `rate-limit.ts` instead of chained `||` conditions. Add new bypass callers there (e.g., `email-worker`).
-- **Three separate CaptureCard implementations exist** — shared component (`components/CaptureCard.tsx`), Timeline local, EntityDetail local. Unification pending.
+- **CaptureCard is a single shared component** — `packages/web/src/components/CaptureCard.tsx` used by Dashboard, Timeline, EntityDetail, and Search. Unified in PR #37.
 - **Capture source types include `email` and `mcp`** — in addition to `slack`, `voice`, `api`, `document`. The Zod schema in `shared/src/schema/` validates these.
 - **Skills must resolve model aliases from ai-routing.yaml** — workers skills pass `modelAlias` directly to OpenAI. With LiteLLM proxy gone, aliases like `synthesis` cause 404. The skill-execution worker must resolve via `configService.get('ai').models[alias]` before dispatching. Same pattern as `extract-entities.ts`.
 - **Slack-bot loads only ai-routing.yaml, not full ConfigService** — `ConfigService.load()` requires all 4 config files (pipeline, ai, brain-views, notifications). Slack-bot only needs the intent model name. Uses lightweight `js-yaml` load with fallback to `gpt-5.4`. Config dir is now mounted (`./config:/app/config:ro`) but load is graceful if missing.
+- **Autonomy levels gate all proactive features** — `app_settings` key `autonomy_level` with values: `observe` (default, notifications only), `assist` (draft + notify), `advise` (act + report), `partner` (autonomous). Check via `meetsAutonomyLevel()` from `@open-brain/shared`. Add new settings keys to `VALID_SETTINGS_KEYS` Set in settings.ts.
+- **Auto-response handler is async fire-and-forget** — runs after normal Slack message routing via `.then()/.catch()`. Never blocks capture/query/command handling. Autonomy level is cached for 5 minutes to avoid per-message settings API calls.
+- **`daily-sweep-skill` is distinct from `daily-sweep`** — the existing `daily-sweep` job (3 AM) silently re-queues stale captures. The new `daily-sweep-skill` (8 PM) is the LLM-powered evening summary. Different BullMQ queues and job IDs.
+- **MCP resources use `server.registerResource()`** — not `server.resource()`. The `@modelcontextprotocol/sdk` v1.27.1 resource API takes `(name, uri, metadata, handler)` and handler returns `{ contents: [{ uri, text, mimeType }] }`.
+- **Pipeline-health skill is now scheduled** — runs every 30 minutes via BullMQ repeatable job. Includes capture flow check (alerts if no captures in 6 hours during active hours 7am-midnight). Was previously manual-trigger only.
 
 ---
 
@@ -90,7 +95,7 @@ After any non-trivial finding during deployment, testing, or debugging:
 
 Self-hosted personal AI knowledge infrastructure. Ingests from voice memos, Slack, documents, email (brain@troy-davis.com via Cloudflare Email Worker); stores in Postgres+pgvector; provides semantic search, AI synthesis, weekly briefs, and governance sessions.
 
-**Status**: v1.3.0 — All 25 phases + Phase 7 architectural consolidation + email pipeline + web synthesis complete. 1,412 unit tests + 95 regression tests passing. Deployed to homeserver.
+**Status**: v1.4.0 — All 25 phases + Phase 7 consolidation + email pipeline + web synthesis + proactive intelligence. 1,504 unit tests + 95 regression tests passing. Deployed to homeserver.
 
 ## Key Architecture Decisions
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -28,6 +28,8 @@
 | D16 | Web synthesis answers on search page | 2026-03-31 | ACTIVE | Entry 011 | Separate synthesis page (fragmented UX), Slack-only synthesis (no web access) |
 | D17 | Model aliases resolved at init from ai-routing.yaml, never raw to OpenAI | 2026-04-01 | ACTIVE | Entry 012 | Pass-through to proxy (LiteLLM removed), hardcode model names (fragile) |
 | D18 | Slack-bot: lightweight ai-routing.yaml load, not full ConfigService | 2026-04-01 | ACTIVE | Entry 012 | Full ConfigService requires all 4 YAML files; slack-bot only needs intent model |
+| D19 | Autonomy levels (observe/assist/advise/partner) gate all proactive features | 2026-04-02 | ACTIVE | Entry 013 | Per-feature toggles (too granular), env var (not dashboard-configurable) |
+| D20 | Auto-response is async fire-and-forget; autonomy cached 5 min | 2026-04-02 | ACTIVE | Entry 013 | Sync (blocks message routing), no cache (hammers settings API per message) |
 
 ## Action Items
 
@@ -37,7 +39,7 @@
 | A1 | ~~Deploy Phase 7 consolidated code to homeserver~~ | 2026-03-30 | IMPL_PLAN_PHASE7 | DONE — deployed, verified via test suite |
 | A2 | Verify pg-notify reconnection works under real disconnect | 2026-03-30 | Phase 7 | MEDIUM |
 | A3 | Deferred features: F21 voice transcription history, F22 entity merge UI, F24 multi-user | 2026-03 | PRD | LOW — Could Have / Won't Have |
-| A4 | Unify three CaptureCard implementations (shared, Timeline, EntityDetail) | 2026-03-31 | Entry 009 | MEDIUM |
+| A4 | ~~Unify three CaptureCard implementations~~ | 2026-03-31 | Entry 009 | DONE — PR #37 (8c31728) |
 
 ### Completed
 | # | Action | Created | Completed | Source |
@@ -83,9 +85,9 @@ The CLAUDE.md contains 24 verified operational rules covering Docker healthcheck
 
 | Component | Status | Details |
 |-----------|--------|---------|
-| Version | v1.3.0 + email pipeline + web synthesis | ~50 commits on main |
+| Version | v1.4.0 + proactive intelligence | ~55 commits on main |
 | Containers | 9 in docker-compose.yml + Cloudflare Email Worker | core-api, workers, slack-bot, voice-capture, faster-whisper, web, postgres, redis, cloudflared; email worker on Cloudflare edge |
-| Tests | 1,412 unit + 95 regression | All passing (CI green) |
+| Tests | 1,504 unit + 95 regression | All passing (CI green) |
 | LLM backend | OpenAI API | gpt-5.4 (all aliases), text-embedding-3-large (768d) |
 | Database | Postgres 16 + pgvector | vector(768) schema, migration 0010 (app_settings) |
 | External access | brain.troy-davis.com | Cloudflare Tunnel + Email Routing (brain@troy-davis.com) |
@@ -515,5 +517,75 @@ First deploy attempt crashed slack-bot: `ConfigService.load()` requires ALL conf
 **Decision:** D16 — Web synthesis on search page (vs. separate page or Slack-only).
 
 ---
+
+--- New session: 2026-04-02 — Proactive Intelligence feature set (P1-P4, P6-P9) ---
+
+### Entry 013 — Proactive Intelligence: autonomy levels, daily sweep, MCP context, heartbeat, Slack auto-response [feature] [api] [web] [slack] [workers] [mcp]
+**Date:** 2026-04-02
+**Duration:** TBD
+**Environment:** Laptop (development)
+**Tags:** `[feature]` `[api]` `[web]` `[slack]` `[workers]` `[mcp]`
+
+**Objective:** Implement 8 features across 7 change sets to transform Open Brain from passive store to active thinking partner:
+- CS1: Configurable autonomy levels (observe/assist/advise/partner) — gates all proactive features
+- CS2: Daily sweep skill + unresolved questions tracker + dashboard widget
+- CS3: MCP context bootstrap resource (`open_brain://context`)
+- CS4: Heartbeat integration monitor (complete pipeline-health skill, schedule every 30 min)
+- CS5: Slack auto-response shadow mode (classify channel questions, log draft responses)
+- CS6: Slack DM-to-you mode (send Pushover/DM when confidence exceeds threshold)
+- CS7: Slack threaded replies (autonomous responses with attribution at `advise` level)
+
+**Hypothesis:** These features can be built incrementally following existing patterns (skill system, settings API, MCP tools, Slack handlers). CS1-CS4 are independent and can be implemented in parallel. CS5→CS6→CS7 are sequential (each extends the previous). P5 (CaptureCard unification) is already done (PR #37). Success: all unit tests pass, new features work in isolation, documentation updated.
+
+**Rollback Plan:** `git revert` — all changes are additive. Autonomy level defaults to `observe` (most restrictive). Auto-response handler is async/fire-and-forget — disabling it has zero impact on existing bot behavior.
+
+**Discovery:** P5 (Unify CaptureCard) already completed in PR #37 (`8c31728`). Only one CaptureCard implementation exists. Updated action item A4 to DONE.
+
+**Actions & Results:**
+
+**CS1 — Autonomy Levels:**
+- Created `packages/shared/src/lib/autonomy.ts` — `AutonomyLevel` type, `meetsAutonomyLevel()` ordinal comparison, `AUTONOMY_DESCRIPTIONS`
+- Added `autonomy_level`, `auto_response_threshold`, `auto_response_staleness_days` to `VALID_SETTINGS_KEYS` in settings.ts
+- Added Autonomy Level section to Settings page with radio buttons and descriptions
+- 6 unit tests pass
+
+**CS2 — Daily Intelligence (P1 + P4):**
+- Created `config/prompts/daily_sweep_v1.txt` — structured JSON output template
+- Created `packages/workers/src/skills/daily-sweep-skill.ts` — full skill: query today's captures, unresolved questions (entity overlap heuristic), new entities; LLM synthesis; Pushover + save-to-brain
+- Added `GET /api/v1/intelligence/unresolved-questions` endpoint with configurable window_days and limit
+- Added Open Questions widget to Dashboard (fetches unresolved questions, shows count + excerpts)
+- Wired into skill-execution worker and scheduler (8 PM daily)
+- 38 unit tests pass
+
+**CS3 — MCP Context Resource:**
+- Created `packages/core-api/src/mcp/resources/context.ts` — generates markdown summary: focus areas, key entities, open questions, recent decisions, capture type distribution
+- Registered as MCP resource at `open_brain://context` in server.ts
+- 7 unit tests pass
+
+**CS4 — Heartbeat Monitor:**
+- Wired existing `pipeline-health` skill into skill-execution worker (was "not yet implemented" stub)
+- Added capture flow check: alerts if no captures in 6 hours during active hours (7am-midnight)
+- Scheduled every 30 minutes
+- Updated `PipelineHealthResult` interface with `captureFlowStale` field
+- 6 new unit tests pass, 24 existing pass (30 total)
+
+**CS5-CS7 — Slack Auto-Response Pipeline:**
+- Created `packages/slack-bot/src/services/confidence-scorer.ts` — composite score (50% search, 30% coverage, 20% recency)
+- Created `packages/slack-bot/src/services/attribution-formatter.ts` — Slack mrkdwn with source citations
+- Created `packages/slack-bot/src/handlers/auto-response.ts` — three modes gated by autonomy level:
+  - observe: shadow log (always)
+  - assist: Pushover notification with draft
+  - advise: threaded reply with attribution, corroboration, staleness checks
+- Integrated into server.ts as async fire-and-forget after normal routing
+- Added `getAutonomyLevel()` with 5-minute cache
+- 26 unit tests pass across auto-response and confidence-scorer test files
+
+**Test Results:**
+- shared: 40, core-api: 423, workers: 498, slack-bot: 384, web: 77, voice-capture: 82
+- **Total: 1,504 tests, 0 failures** (up from 1,412 unit + 95 regression)
+- All packages build cleanly (tsup/vite)
+
+**Decision:** D19 — Autonomy levels gating proactive features (observe/assist/advise/partner). Default `observe`. See entry 013.
+**Decision:** D20 — Auto-response uses fire-and-forget async; never blocks normal Slack message handling. Autonomy level cached 5 minutes.
 
 *Entries continue below.*

--- a/config/prompts/daily_sweep_v1.txt
+++ b/config/prompts/daily_sweep_v1.txt
@@ -1,0 +1,31 @@
+---SYSTEM---
+You are a personal knowledge assistant analyzing today's captured information.
+Your job is to produce a concise, actionable daily summary.
+
+Respond ONLY with valid JSON matching this schema:
+{
+  "headline": "1-sentence summary of the day (max 120 chars)",
+  "key_decisions": ["decision 1 (max 100 chars)", ...],
+  "unresolved_questions": ["question still open (max 100 chars)", ...],
+  "new_entities": ["entity name — brief context (max 80 chars)", ...],
+  "tasks_without_followup": ["task description (max 100 chars)", ...],
+  "notable_captures": ["brief description of notable item (max 100 chars)", ...]
+}
+
+Rules:
+- Max 5 items per array. Prioritize by importance.
+- If a category has no items, use an empty array.
+- Be specific and actionable, not vague.
+- headline must capture the day's most significant theme.
+---USER---
+Date: {{date}}
+Total captures today: {{capture_count}}
+
+Today's captures:
+{{captures}}
+
+Unresolved questions (asked but not yet answered):
+{{unresolved_questions}}
+
+New entities first seen today:
+{{new_entities}}

--- a/packages/core-api/src/__tests__/mcp-context-resource.test.ts
+++ b/packages/core-api/src/__tests__/mcp-context-resource.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest'
+import { generateContextSummary } from '../mcp/resources/context.js'
+
+describe('generateContextSummary', () => {
+  it('returns markdown with section headers when db is empty', async () => {
+    const mockDb = {
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+    } as any
+
+    const result = await generateContextSummary(mockDb)
+    expect(result).toContain('# Open Brain Context')
+    expect(result).toContain('## Active Focus Areas')
+    expect(result).toContain('## Key Entities')
+    expect(result).toContain('## Open Questions')
+    expect(result).toContain('## Recent Decisions')
+    expect(result).toContain('## Capture Types')
+  })
+
+  it('handles database errors gracefully', async () => {
+    const mockDb = {
+      execute: vi.fn().mockRejectedValue(new Error('connection failed')),
+    } as any
+
+    const result = await generateContextSummary(mockDb)
+    expect(result).toContain('# Open Brain Context')
+    // Should contain fallback text for all sections
+    expect(result).toContain('Unable to query')
+    // Should NOT throw
+  })
+
+  it('formats entity data correctly', async () => {
+    let callCount = 0
+    const mockDb = {
+      execute: vi.fn().mockImplementation(() => {
+        callCount++
+        if (callCount === 2) {
+          // Entity query (second call)
+          return { rows: [{ name: 'TestEntity', entity_type: 'person', mention_count: '5', last_seen_at: '2026-04-01T00:00:00Z' }] }
+        }
+        return { rows: [] }
+      }),
+    } as any
+
+    const result = await generateContextSummary(mockDb)
+    expect(result).toContain('TestEntity')
+    expect(result).toContain('person')
+    expect(result).toContain('5')
+    expect(result).toContain('2026-04-01')
+  })
+
+  it('formats brain view counts correctly', async () => {
+    let callCount = 0
+    const mockDb = {
+      execute: vi.fn().mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          // View counts query (first call)
+          return { rows: [
+            { brain_view: 'technical', count: '12' },
+            { brain_view: 'personal', count: '5' },
+          ] }
+        }
+        return { rows: [] }
+      }),
+    } as any
+
+    const result = await generateContextSummary(mockDb)
+    expect(result).toContain('**technical**: 12 captures')
+    expect(result).toContain('**personal**: 5 captures')
+  })
+
+  it('truncates long content to 200 characters', async () => {
+    const longContent = 'A'.repeat(300)
+    let callCount = 0
+    const mockDb = {
+      execute: vi.fn().mockImplementation(() => {
+        callCount++
+        if (callCount === 3) {
+          // Questions query (third call)
+          return { rows: [{ content: longContent, created_at: '2026-04-01T10:00:00Z', brain_view: 'technical' }] }
+        }
+        return { rows: [] }
+      }),
+    } as any
+
+    const result = await generateContextSummary(mockDb)
+    expect(result).toContain('A'.repeat(200) + '...')
+    expect(result).not.toContain('A'.repeat(201))
+  })
+
+  it('includes date in title header', async () => {
+    const mockDb = {
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+    } as any
+
+    const result = await generateContextSummary(mockDb)
+    // Should contain a date in YYYY-MM-DD format
+    expect(result).toMatch(/# Open Brain Context — \d{4}-\d{2}-\d{2}/)
+  })
+
+  it('handles partial failures gracefully', async () => {
+    let callCount = 0
+    const mockDb = {
+      execute: vi.fn().mockImplementation(() => {
+        callCount++
+        // First and third queries succeed, rest fail
+        if (callCount === 1) {
+          return { rows: [{ brain_view: 'technical', count: '3' }] }
+        }
+        if (callCount === 3) {
+          return { rows: [{ content: 'Why does X?', created_at: '2026-04-01T10:00:00Z', brain_view: 'technical' }] }
+        }
+        throw new Error('db error')
+      }),
+    } as any
+
+    const result = await generateContextSummary(mockDb)
+    // Successful sections present
+    expect(result).toContain('**technical**: 3 captures')
+    expect(result).toContain('Why does X?')
+    // Failed sections have fallback
+    expect(result).toContain('Unable to query entities')
+  })
+})

--- a/packages/core-api/src/mcp/resources/context.ts
+++ b/packages/core-api/src/mcp/resources/context.ts
@@ -1,0 +1,154 @@
+import { sql } from 'drizzle-orm'
+import type { Database } from '@open-brain/shared'
+
+/**
+ * Generate a markdown summary of the current brain context.
+ * Used by the MCP resource `open_brain://context`.
+ * Pure SQL aggregation — no LLM calls, fast response (<500ms).
+ */
+export async function generateContextSummary(db: Database): Promise<string> {
+  const now = new Date()
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+  const dateStr = now.toISOString().split('T')[0]
+
+  const sections: string[] = [`# Open Brain Context — ${dateStr}\n`]
+
+  // Section 1: Capture activity summary (last 7 days)
+  try {
+    const viewCounts = await db.execute<{ brain_view: string; count: string }>(sql`
+      SELECT brain_view, COUNT(*)::text as count
+      FROM captures
+      WHERE deleted_at IS NULL
+        AND pipeline_status = 'complete'
+        AND created_at >= ${sevenDaysAgo.toISOString()}::timestamptz
+      GROUP BY brain_view
+      ORDER BY count DESC
+    `)
+
+    sections.push('## Active Focus Areas (Last 7 Days)\n')
+    if (viewCounts.rows.length === 0) {
+      sections.push('No captures in the last 7 days.\n')
+    } else {
+      for (const row of viewCounts.rows) {
+        sections.push(`- **${row.brain_view}**: ${row.count} captures`)
+      }
+      sections.push('')
+    }
+  } catch {
+    sections.push('## Active Focus Areas\n\n_Unable to query capture activity._\n')
+  }
+
+  // Section 2: Key entities (top 15 by mention count in last 7 days)
+  try {
+    const entities = await db.execute<{ name: string; entity_type: string; mention_count: string; last_seen_at: string }>(sql`
+      SELECT e.name, e.entity_type, COUNT(el.id)::text as mention_count, MAX(e.last_seen_at)::text as last_seen_at
+      FROM entities e
+      JOIN entity_links el ON el.entity_id = e.id
+      JOIN captures c ON c.id = el.capture_id
+      WHERE c.deleted_at IS NULL
+        AND c.pipeline_status = 'complete'
+        AND c.created_at >= ${sevenDaysAgo.toISOString()}::timestamptz
+      GROUP BY e.id, e.name, e.entity_type
+      ORDER BY COUNT(el.id) DESC
+      LIMIT 15
+    `)
+
+    sections.push('## Key Entities (Last 7 Days)\n')
+    if (entities.rows.length === 0) {
+      sections.push('No entities found in recent captures.\n')
+    } else {
+      sections.push('| Entity | Type | Mentions | Last Seen |')
+      sections.push('|--------|------|----------|-----------|')
+      for (const row of entities.rows) {
+        const lastSeen = row.last_seen_at ? new Date(row.last_seen_at).toISOString().split('T')[0] : '\u2014'
+        sections.push(`| ${row.name} | ${row.entity_type} | ${row.mention_count} | ${lastSeen} |`)
+      }
+      sections.push('')
+    }
+  } catch {
+    sections.push('## Key Entities\n\n_Unable to query entities._\n')
+  }
+
+  // Section 3: Open questions (capture_type='question', last 7 days)
+  try {
+    const questions = await db.execute<{ content: string; created_at: string; brain_view: string }>(sql`
+      SELECT c.content, c.created_at::text, c.brain_view
+      FROM captures c
+      WHERE c.capture_type = 'question'
+        AND c.pipeline_status = 'complete'
+        AND c.deleted_at IS NULL
+        AND c.created_at >= ${sevenDaysAgo.toISOString()}::timestamptz
+      ORDER BY c.created_at DESC
+      LIMIT 10
+    `)
+
+    sections.push('## Open Questions\n')
+    if (questions.rows.length === 0) {
+      sections.push('No recent questions.\n')
+    } else {
+      for (const row of questions.rows) {
+        const date = new Date(row.created_at).toISOString().split('T')[0]
+        const truncated = row.content.length > 200 ? row.content.slice(0, 200) + '...' : row.content
+        sections.push(`- **[${date}]** (${row.brain_view}) ${truncated}`)
+      }
+      sections.push('')
+    }
+  } catch {
+    sections.push('## Open Questions\n\n_Unable to query questions._\n')
+  }
+
+  // Section 4: Recent decisions
+  try {
+    const decisions = await db.execute<{ content: string; created_at: string; brain_view: string }>(sql`
+      SELECT c.content, c.created_at::text, c.brain_view
+      FROM captures c
+      WHERE c.capture_type = 'decision'
+        AND c.pipeline_status = 'complete'
+        AND c.deleted_at IS NULL
+        AND c.created_at >= ${sevenDaysAgo.toISOString()}::timestamptz
+      ORDER BY c.created_at DESC
+      LIMIT 5
+    `)
+
+    sections.push('## Recent Decisions\n')
+    if (decisions.rows.length === 0) {
+      sections.push('No recent decisions.\n')
+    } else {
+      for (const row of decisions.rows) {
+        const date = new Date(row.created_at).toISOString().split('T')[0]
+        const truncated = row.content.length > 200 ? row.content.slice(0, 200) + '...' : row.content
+        sections.push(`- **[${date}]** (${row.brain_view}) ${truncated}`)
+      }
+      sections.push('')
+    }
+  } catch {
+    sections.push('## Recent Decisions\n\n_Unable to query decisions._\n')
+  }
+
+  // Section 5: Capture type distribution
+  try {
+    const typeCounts = await db.execute<{ capture_type: string; count: string }>(sql`
+      SELECT capture_type, COUNT(*)::text as count
+      FROM captures
+      WHERE deleted_at IS NULL
+        AND pipeline_status = 'complete'
+        AND created_at >= ${sevenDaysAgo.toISOString()}::timestamptz
+      GROUP BY capture_type
+      ORDER BY count DESC
+    `)
+
+    sections.push('## Capture Types (Last 7 Days)\n')
+    if (typeCounts.rows.length === 0) {
+      sections.push('No captures.\n')
+    } else {
+      for (const row of typeCounts.rows) {
+        sections.push(`- ${row.capture_type}: ${row.count}`)
+      }
+      sections.push('')
+    }
+  } catch {
+    sections.push('## Capture Types\n\n_Unable to query capture types._\n')
+  }
+
+  return sections.join('\n')
+}

--- a/packages/core-api/src/mcp/server.ts
+++ b/packages/core-api/src/mcp/server.ts
@@ -7,6 +7,7 @@ import type { EntityService } from '../services/entity.js'
 import type { ConfigService, Database } from '@open-brain/shared'
 import { validateMcpAuth } from './auth.js'
 import { registerMcpTools } from './tools/index.js'
+import { generateContextSummary } from './resources/context.js'
 import { logger } from '@open-brain/shared'
 
 interface McpServerDeps {
@@ -42,6 +43,20 @@ export function mountMcpServer(app: Hono, deps: McpServerDeps): void {
     })
 
     registerMcpTools({ server, captureService, searchService, configService, db, entityService })
+
+    // Register MCP resources
+    server.registerResource(
+      'brain-context',
+      'open_brain://context',
+      { description: 'Current brain context summary — active projects, recent entities, open questions, focus areas' },
+      async () => ({
+        contents: [{
+          uri: 'open_brain://context',
+          text: await generateContextSummary(db),
+          mimeType: 'text/markdown',
+        }],
+      }),
+    )
 
     // WebStandardStreamableHTTPServerTransport works natively with Hono (web-standard Request/Response)
     const transport = new WebStandardStreamableHTTPServerTransport({

--- a/packages/core-api/src/routes/intelligence.ts
+++ b/packages/core-api/src/routes/intelligence.ts
@@ -20,7 +20,7 @@ interface IntelligenceLogRow {
 }
 
 /** Allowed intelligence skill names — prevents arbitrary skill_name injection into SQL */
-const INTELLIGENCE_SKILLS = new Set(['daily-connections', 'drift-monitor'])
+const INTELLIGENCE_SKILLS = new Set(['daily-connections', 'drift-monitor', 'daily-sweep-skill'])
 
 /** Job data shape for skill-execution queue */
 interface SkillExecutionJobData {
@@ -224,6 +224,7 @@ export function registerIntelligenceRoutes(
       'daily-connections': new Set(['windowDays', 'tokenBudget', 'modelAlias']),
       'drift-monitor': new Set(['betActivityDays', 'commitmentDays', 'entityWindowDays', 'modelAlias']),
       'weekly-brief': new Set(['windowDays', 'tokenBudget', 'modelAlias', 'emailTo']),
+      'daily-sweep-skill': new Set(['tokenBudget', 'modelAlias']),
     }
     let overrides: Record<string, unknown> = {}
     try {
@@ -265,6 +266,42 @@ export function registerIntelligenceRoutes(
       },
       202,
     )
+  })
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/intelligence/unresolved-questions
+  // Returns questions (capture_type = 'question') that have not been
+  // followed up via entity overlap within 7 days.
+  // -----------------------------------------------------------------------
+  app.get('/api/v1/intelligence/unresolved-questions', async (c) => {
+    const windowDays = Math.max(1, Math.min(Number(c.req.query('window_days') ?? '30'), 365))
+    const limit = Math.min(Math.max(1, Number(c.req.query('limit') ?? '20')), 50)
+
+    const windowDate = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000)
+
+    const rows = await db.execute(sql`
+      SELECT c.id::text, c.content, c.brain_view, c.created_at::text, c.tags
+      FROM captures c
+      WHERE c.capture_type = 'question'
+        AND c.pipeline_status = 'complete'
+        AND c.deleted_at IS NULL
+        AND c.created_at >= ${windowDate.toISOString()}::timestamptz
+        AND NOT EXISTS (
+          SELECT 1 FROM entity_links el1
+          JOIN entity_links el2 ON el1.entity_id = el2.entity_id
+          JOIN captures c2 ON el2.capture_id = c2.id
+          WHERE el1.capture_id = c.id
+            AND c2.id != c.id
+            AND c2.created_at > c.created_at
+            AND c2.created_at <= c.created_at + INTERVAL '7 days'
+            AND c2.deleted_at IS NULL
+            AND c2.pipeline_status = 'complete'
+        )
+      ORDER BY c.created_at DESC
+      LIMIT ${limit}
+    `)
+
+    return c.json({ questions: rows.rows, count: rows.rows.length })
   })
 }
 

--- a/packages/core-api/src/routes/intelligence.ts
+++ b/packages/core-api/src/routes/intelligence.ts
@@ -274,8 +274,8 @@ export function registerIntelligenceRoutes(
   // followed up via entity overlap within 7 days.
   // -----------------------------------------------------------------------
   app.get('/api/v1/intelligence/unresolved-questions', async (c) => {
-    const windowDays = Math.max(1, Math.min(Number(c.req.query('window_days') ?? '30'), 365))
-    const limit = Math.min(Math.max(1, Number(c.req.query('limit') ?? '20')), 50)
+    const windowDays = Math.max(1, Math.min(Number(c.req.query('window_days') ?? '30') || 30, 365))
+    const limit = Math.min(Math.max(1, Number(c.req.query('limit') ?? '20') || 20), 50)
 
     const windowDate = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000)
 

--- a/packages/core-api/src/routes/settings.ts
+++ b/packages/core-api/src/routes/settings.ts
@@ -4,7 +4,7 @@ import type { Database } from '@open-brain/shared'
 import { logger, app_settings } from '@open-brain/shared'
 
 /** Valid settings keys — prevents unbounded key creation */
-const VALID_SETTINGS_KEYS = new Set(['email_allowlist'])
+const VALID_SETTINGS_KEYS = new Set(['email_allowlist', 'autonomy_level', 'auto_response_threshold', 'auto_response_staleness_days'])
 
 /**
  * Register settings API routes.

--- a/packages/core-api/src/routes/settings.ts
+++ b/packages/core-api/src/routes/settings.ts
@@ -1,10 +1,26 @@
 import type { Hono } from 'hono'
 import { eq } from 'drizzle-orm'
 import type { Database } from '@open-brain/shared'
-import { logger, app_settings } from '@open-brain/shared'
+import { logger, app_settings, AUTONOMY_LEVELS } from '@open-brain/shared'
 
 /** Valid settings keys — prevents unbounded key creation */
 const VALID_SETTINGS_KEYS = new Set(['email_allowlist', 'autonomy_level', 'auto_response_threshold', 'auto_response_staleness_days'])
+
+/** Type-specific value validators for settings that need them */
+const SETTINGS_VALIDATORS: Record<string, (value: unknown) => string | null> = {
+  autonomy_level: (v) =>
+    typeof v === 'string' && AUTONOMY_LEVELS.includes(v as never)
+      ? null
+      : `autonomy_level must be one of: ${AUTONOMY_LEVELS.join(', ')}`,
+  auto_response_threshold: (v) =>
+    typeof v === 'number' && v >= 0 && v <= 1
+      ? null
+      : 'auto_response_threshold must be a number between 0 and 1',
+  auto_response_staleness_days: (v) =>
+    typeof v === 'number' && v >= 1 && v <= 365
+      ? null
+      : 'auto_response_staleness_days must be a number between 1 and 365',
+}
 
 /**
  * Register settings API routes.
@@ -35,6 +51,15 @@ export function registerSettingsRoutes(app: Hono, db: Database): void {
     }
     if (body.value === undefined) {
       return c.json({ error: 'value is required' }, 400)
+    }
+
+    // Type-specific validation for settings that need it
+    const validator = SETTINGS_VALIDATORS[key]
+    if (validator) {
+      const validationError = validator(body.value)
+      if (validationError) {
+        return c.json({ error: validationError, key }, 400)
+      }
     }
 
     const now = new Date()

--- a/packages/core-api/src/services/skill-config.ts
+++ b/packages/core-api/src/services/skill-config.ts
@@ -33,8 +33,12 @@ export const DEFAULT_SKILLS: Record<string, SkillConfig> = {
     description: 'Detect when tracked commitments, bets, or projects go silent and alert via Pushover if severity >= medium',
   },
   'pipeline-health': {
-    schedule: '0 * * * *', // Every hour
-    description: 'Check BullMQ queue stats and recent pipeline failures; alert via Pushover if thresholds exceeded',
+    schedule: '*/30 * * * *', // Every 30 minutes
+    description: 'Check BullMQ queue stats, capture flow, and recent pipeline failures; alert via Pushover if thresholds exceeded',
+  },
+  'daily-sweep-skill': {
+    schedule: '0 20 * * *', // Daily 8pm
+    description: 'Evening summary: key decisions, unresolved questions, new entities, tasks without follow-up',
   },
 }
 

--- a/packages/shared/src/lib/__tests__/autonomy.test.ts
+++ b/packages/shared/src/lib/__tests__/autonomy.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { meetsAutonomyLevel } from '../autonomy.js'
+
+describe('meetsAutonomyLevel', () => {
+  it('observe meets observe', () => {
+    expect(meetsAutonomyLevel('observe', 'observe')).toBe(true)
+  })
+
+  it('observe does not meet assist', () => {
+    expect(meetsAutonomyLevel('observe', 'assist')).toBe(false)
+  })
+
+  it('assist meets observe', () => {
+    expect(meetsAutonomyLevel('assist', 'observe')).toBe(true)
+  })
+
+  it('advise meets assist', () => {
+    expect(meetsAutonomyLevel('advise', 'assist')).toBe(true)
+  })
+
+  it('partner meets everything', () => {
+    expect(meetsAutonomyLevel('partner', 'observe')).toBe(true)
+    expect(meetsAutonomyLevel('partner', 'assist')).toBe(true)
+    expect(meetsAutonomyLevel('partner', 'advise')).toBe(true)
+    expect(meetsAutonomyLevel('partner', 'partner')).toBe(true)
+  })
+
+  it('observe does not meet partner', () => {
+    expect(meetsAutonomyLevel('observe', 'partner')).toBe(false)
+  })
+})

--- a/packages/shared/src/lib/autonomy.ts
+++ b/packages/shared/src/lib/autonomy.ts
@@ -1,0 +1,25 @@
+/**
+ * Autonomy level types and helpers.
+ * All proactive features check autonomy level before taking action.
+ */
+
+export type AutonomyLevel = 'observe' | 'assist' | 'advise' | 'partner'
+
+export const AUTONOMY_LEVELS: AutonomyLevel[] = ['observe', 'assist', 'advise', 'partner']
+
+export const AUTONOMY_DESCRIPTIONS: Record<AutonomyLevel, string> = {
+  observe: 'Notifications only — no autonomous actions',
+  assist: 'Draft + notify — human relays responses',
+  advise: 'Act + report — posts with clear bot attribution',
+  partner: 'Autonomous within guardrails',
+}
+
+export const DEFAULT_AUTONOMY: AutonomyLevel = 'observe'
+
+/**
+ * Check if the current autonomy level meets or exceeds the required level.
+ * Uses ordinal comparison based on AUTONOMY_LEVELS array order.
+ */
+export function meetsAutonomyLevel(current: AutonomyLevel, required: AutonomyLevel): boolean {
+  return AUTONOMY_LEVELS.indexOf(current) >= AUTONOMY_LEVELS.indexOf(required)
+}

--- a/packages/shared/src/lib/index.ts
+++ b/packages/shared/src/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './prompt-template.js'
 export * from './logger.js'
+export * from './autonomy.js'

--- a/packages/slack-bot/src/__tests__/auto-response.test.ts
+++ b/packages/slack-bot/src/__tests__/auto-response.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { isAutoResponseCandidate, type AutoResponseConfig } from '../handlers/auto-response.js'
+import { scoreConfidence } from '../services/confidence-scorer.js'
+import { formatAttributedResponse } from '../services/attribution-formatter.js'
+import type { SearchResult } from '../lib/core-api-types.js'
+
+const baseConfig: AutoResponseConfig = {
+  coreApiUrl: 'http://localhost:3000',
+  confidenceThreshold: 0.6,
+  stalenessDays: 90,
+  minCorroboratingResults: 2,
+  botUserId: 'B123',
+  ownerUserId: 'U_OWNER',
+}
+
+describe('isAutoResponseCandidate', () => {
+  const makeMessage = (text: string, user = 'U_OTHER') =>
+    ({
+      text,
+      user,
+      channel: 'C123',
+      ts: '1234.5678',
+      type: 'message' as const,
+    }) as any
+
+  it('returns true for questions from other users', () => {
+    expect(isAutoResponseCandidate(makeMessage('What is the status of project X?'), baseConfig)).toBe(true)
+    expect(isAutoResponseCandidate(makeMessage('How do we handle auth in the new system?'), baseConfig)).toBe(true)
+    expect(isAutoResponseCandidate(makeMessage('Does anyone know the deploy process?'), baseConfig)).toBe(true)
+  })
+
+  it('returns true for messages ending with question mark', () => {
+    expect(isAutoResponseCandidate(makeMessage('The deploy is broken again?'), baseConfig)).toBe(true)
+  })
+
+  it('returns false for owner messages', () => {
+    expect(isAutoResponseCandidate(makeMessage('What is the plan?', 'U_OWNER'), baseConfig)).toBe(false)
+  })
+
+  it('returns false for bot messages', () => {
+    expect(isAutoResponseCandidate(makeMessage('What is happening?', 'B123'), baseConfig)).toBe(false)
+  })
+
+  it('returns false for short messages', () => {
+    expect(isAutoResponseCandidate(makeMessage('hi?'), baseConfig)).toBe(false)
+  })
+
+  it('returns false for command/query prefixes', () => {
+    expect(isAutoResponseCandidate(makeMessage('!stats something long enough'), baseConfig)).toBe(false)
+    expect(isAutoResponseCandidate(makeMessage('?search something long enough'), baseConfig)).toBe(false)
+  })
+
+  it('returns false for non-question messages', () => {
+    expect(isAutoResponseCandidate(makeMessage('I just pushed the new build'), baseConfig)).toBe(false)
+    expect(isAutoResponseCandidate(makeMessage('Lunch at noon sounds good'), baseConfig)).toBe(false)
+  })
+})
+
+describe('scoreConfidence', () => {
+  it('returns zero for empty results', () => {
+    const result = scoreConfidence([])
+    expect(result.composite).toBe(0)
+  })
+
+  it('returns high confidence for strong results', () => {
+    const results: SearchResult[] = [
+      { id: '1', content: 'test', score: 0.9, created_at: new Date().toISOString(), capture_type: 'observation', brain_view: 'technical', source: 'slack' },
+      { id: '2', content: 'test2', score: 0.8, created_at: new Date().toISOString(), capture_type: 'observation', brain_view: 'technical', source: 'slack' },
+      { id: '3', content: 'test3', score: 0.7, created_at: new Date().toISOString(), capture_type: 'observation', brain_view: 'technical', source: 'slack' },
+    ]
+    const result = scoreConfidence(results)
+    expect(result.composite).toBeGreaterThan(0.6)
+    expect(result.relevantResultCount).toBe(3)
+  })
+
+  it('returns low confidence for weak results', () => {
+    const results: SearchResult[] = [
+      { id: '1', content: 'test', score: 0.2, created_at: '2025-01-01T00:00:00Z', capture_type: 'observation', brain_view: 'technical', source: 'api' },
+    ]
+    const result = scoreConfidence(results)
+    expect(result.composite).toBeLessThan(0.3)
+  })
+})
+
+describe('formatAttributedResponse', () => {
+  it('formats synthesis with sources', () => {
+    const results: SearchResult[] = [
+      {
+        id: '1',
+        content: 'The deploy process uses Docker Compose',
+        score: 0.9,
+        created_at: '2026-04-01T00:00:00Z',
+        source: 'slack',
+        capture_type: 'decision',
+        brain_view: 'technical',
+      },
+    ]
+    const response = formatAttributedResponse('We use Docker Compose for deploys.', results)
+    expect(response.text).toContain('Based on captured context')
+    expect(response.text).toContain('Docker Compose for deploys')
+    expect(response.text).toContain('AI-generated')
+    expect(response.sources).toHaveLength(1)
+    expect(response.sources[0].source).toBe('slack')
+  })
+
+  it('limits sources to maxSources', () => {
+    const results: SearchResult[] = Array.from({ length: 10 }, (_, i) => ({
+      id: String(i),
+      content: `capture ${i}`,
+      score: 0.5,
+      created_at: '2026-04-01T00:00:00Z',
+      source: 'api',
+      capture_type: 'observation',
+      brain_view: 'technical',
+    }))
+    const response = formatAttributedResponse('test', results, { maxSources: 2 })
+    expect(response.sources).toHaveLength(2)
+  })
+
+  it('truncates long synthesis in summary', () => {
+    const longText = 'A'.repeat(300)
+    const results: SearchResult[] = [
+      { id: '1', content: 'test', score: 0.9, created_at: '2026-04-01T00:00:00Z', source: 'api', capture_type: 'observation', brain_view: 'technical' },
+    ]
+    const response = formatAttributedResponse(longText, results)
+    expect(response.summary.length).toBeLessThanOrEqual(203) // 200 + '...'
+    expect(response.summary).toContain('...')
+  })
+
+  it('truncates long content excerpts', () => {
+    const longContent = 'B'.repeat(100)
+    const results: SearchResult[] = [
+      { id: '1', content: longContent, score: 0.9, created_at: '2026-04-01T00:00:00Z', source: 'slack', capture_type: 'observation', brain_view: 'technical' },
+    ]
+    const response = formatAttributedResponse('test', results)
+    expect(response.sources[0].excerpt.length).toBeLessThanOrEqual(83) // 80 + '...'
+  })
+})

--- a/packages/slack-bot/src/__tests__/confidence-scorer.test.ts
+++ b/packages/slack-bot/src/__tests__/confidence-scorer.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { scoreConfidence } from '../services/confidence-scorer.js'
+import type { SearchResult } from '../lib/core-api-types.js'
+
+function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    id: '1',
+    content: 'test content',
+    score: 0.5,
+    created_at: new Date().toISOString(),
+    capture_type: 'observation',
+    brain_view: 'technical',
+    source: 'api',
+    ...overrides,
+  }
+}
+
+describe('scoreConfidence', () => {
+  it('caps search score at 1.0', () => {
+    const results = [makeResult({ score: 1.5 })]
+    const { searchScore } = scoreConfidence(results)
+    expect(searchScore).toBeLessThanOrEqual(1)
+  })
+
+  it('recency favors recent results', () => {
+    const recent = [makeResult({ score: 0.5, created_at: new Date().toISOString() })]
+    const old = [makeResult({ score: 0.5, created_at: '2025-01-01T00:00:00Z' })]
+    const recentConf = scoreConfidence(recent)
+    const oldConf = scoreConfidence(old)
+    expect(recentConf.composite).toBeGreaterThan(oldConf.composite)
+  })
+
+  it('coverage score caps at 5 relevant results', () => {
+    const fiveResults = Array.from({ length: 5 }, (_, i) =>
+      makeResult({ id: String(i), score: 0.5 }),
+    )
+    const tenResults = Array.from({ length: 10 }, (_, i) =>
+      makeResult({ id: String(i), score: 0.5 }),
+    )
+    const conf5 = scoreConfidence(fiveResults)
+    const conf10 = scoreConfidence(tenResults)
+    // Coverage should be the same (capped at 5)
+    expect(conf5.composite).toBe(conf10.composite)
+  })
+
+  it('returns zero composite for empty results', () => {
+    expect(scoreConfidence([]).composite).toBe(0)
+  })
+
+  it('returns 999 avgAgeDays for empty results', () => {
+    expect(scoreConfidence([]).avgAgeDays).toBe(999)
+  })
+
+  it('composite is weighted sum: 0.5 * search + 0.3 * coverage + 0.2 * recency', () => {
+    // Single result with score 1.0 and very recent date
+    const results = [makeResult({ score: 1.0, created_at: new Date().toISOString() })]
+    const conf = scoreConfidence(results)
+    // search = 1.0, coverage = 1/5 = 0.2, recency ~ 1.0
+    // composite ~ 0.5 * 1.0 + 0.3 * 0.2 + 0.2 * 1.0 = 0.76
+    expect(conf.composite).toBeGreaterThan(0.7)
+    expect(conf.composite).toBeLessThan(0.8)
+  })
+
+  it('counts only results with score > 0.3 as relevant', () => {
+    const results = [
+      makeResult({ id: '1', score: 0.8 }),
+      makeResult({ id: '2', score: 0.4 }),
+      makeResult({ id: '3', score: 0.2 }), // below threshold
+      makeResult({ id: '4', score: 0.1 }), // below threshold
+    ]
+    const conf = scoreConfidence(results)
+    expect(conf.relevantResultCount).toBe(2)
+  })
+})

--- a/packages/slack-bot/src/handlers/auto-response.ts
+++ b/packages/slack-bot/src/handlers/auto-response.ts
@@ -19,6 +19,13 @@ import { scoreConfidence } from '../services/confidence-scorer.js'
 import { formatAttributedResponse } from '../services/attribution-formatter.js'
 import { logger, PushoverService, type AutonomyLevel, meetsAutonomyLevel } from '@open-brain/shared'
 
+/** Lazy-initialized PushoverService singleton for auto-response notifications */
+let _pushover: PushoverService | null = null
+function getPushover(): PushoverService {
+  if (!_pushover) _pushover = new PushoverService({ onError: 'swallow' })
+  return _pushover
+}
+
 /** Minimum message length to consider for auto-response */
 const MIN_MESSAGE_LENGTH = 15
 
@@ -138,7 +145,7 @@ export async function handleAutoResponse(
       synthesis
     ) {
       try {
-        const pushover = new PushoverService({ onError: 'swallow' })
+        const pushover = getPushover()
         if (pushover.isConfigured) {
           const pushoverMessage = [
             `Channel question from <@${message.user}>:`,

--- a/packages/slack-bot/src/handlers/auto-response.ts
+++ b/packages/slack-bot/src/handlers/auto-response.ts
@@ -1,0 +1,207 @@
+/**
+ * Auto-response handler -- processes channel messages that look like questions
+ * Open Brain could answer.
+ *
+ * Three modes based on autonomy level:
+ * - observe: Shadow mode -- classify, search, synthesize, LOG but never post
+ * - assist: DM mode -- send Pushover/DM with draft when confidence > threshold
+ * - advise: Threaded reply -- post attributed response in channel thread
+ *
+ * This handler runs ASYNCHRONOUSLY after normal message routing.
+ * It must NEVER block or interfere with existing capture/query/command handling.
+ */
+
+import type { GenericMessageEvent } from '@slack/types'
+import type { App } from '@slack/bolt'
+import type { CoreApiClient } from '../lib/core-api-client.js'
+import type { SearchResult } from '../lib/core-api-types.js'
+import { scoreConfidence } from '../services/confidence-scorer.js'
+import { formatAttributedResponse } from '../services/attribution-formatter.js'
+import { logger, PushoverService, type AutonomyLevel, meetsAutonomyLevel } from '@open-brain/shared'
+
+/** Minimum message length to consider for auto-response */
+const MIN_MESSAGE_LENGTH = 15
+
+/** Question patterns -- more conservative than IntentRouter's patterns */
+const AUTO_RESPONSE_QUESTION_PATTERNS = [
+  /^(what|who|when|where|why|how|which)\s/i,
+  /\?\s*$/,
+  /^(does anyone know|can someone|has anyone|do we|did we|is there|are there)\s/i,
+]
+
+export interface AutoResponseConfig {
+  /** Core API base URL */
+  coreApiUrl: string
+  /** Confidence threshold for delivery (DM/threaded). Default: 0.6 */
+  confidenceThreshold: number
+  /** Staleness window in days for threaded replies. Default: 90 */
+  stalenessDays: number
+  /** Minimum corroborating results for threaded reply. Default: 2 */
+  minCorroboratingResults: number
+  /** Bot user ID (to filter out own messages) */
+  botUserId?: string
+  /** Owner user ID (skip auto-response for owner messages) */
+  ownerUserId?: string
+}
+
+/**
+ * Check if a message is a candidate for auto-response.
+ * Only classifies questions from OTHER users (not the bot owner).
+ */
+export function isAutoResponseCandidate(
+  message: GenericMessageEvent,
+  config: AutoResponseConfig,
+): boolean {
+  const text = message.text ?? ''
+
+  // Skip short messages
+  if (text.length < MIN_MESSAGE_LENGTH) return false
+
+  // Skip own messages and owner messages
+  if (config.botUserId && message.user === config.botUserId) return false
+  if (config.ownerUserId && message.user === config.ownerUserId) return false
+
+  // Skip messages with command/capture prefixes
+  if (text.startsWith('!') || text.startsWith('?')) return false
+
+  // Check question patterns
+  return AUTO_RESPONSE_QUESTION_PATTERNS.some(p => p.test(text))
+}
+
+/**
+ * Handle a potential auto-response. This runs asynchronously and never throws.
+ */
+export async function handleAutoResponse(
+  message: GenericMessageEvent,
+  app: App,
+  coreApiClient: CoreApiClient,
+  autonomyLevel: AutonomyLevel,
+  config: AutoResponseConfig,
+): Promise<void> {
+  const text = message.text ?? ''
+  const channel = message.channel
+  const ts = message.ts
+
+  try {
+    // Step 1: Search for relevant captures
+    const searchResponse = await coreApiClient.search_query({
+      query: text,
+      limit: 10,
+      search_mode: 'hybrid',
+      temporal_weight: 0.1,
+    })
+
+    const results: SearchResult[] = searchResponse.results
+
+    // Step 2: Score confidence
+    const confidence = scoreConfidence(results)
+
+    // Step 3: Synthesize a response (only if we have decent results)
+    let synthesis = ''
+    if (confidence.composite > 0.2 && results.length > 0) {
+      try {
+        const synthResponse = await coreApiClient.synthesize_query({
+          query: text,
+          limit: 10,
+        })
+        synthesis = synthResponse.response
+      } catch (err) {
+        logger.warn({ err }, '[auto-response] synthesis failed -- logging without synthesis')
+      }
+    }
+
+    // Step 4: Format attributed response
+    const attributed = synthesis
+      ? formatAttributedResponse(synthesis, results)
+      : { text: '', summary: 'No synthesis available', sources: [] }
+
+    // Step 5: Log everything (shadow mode -- always happens)
+    logger.info(
+      {
+        channel,
+        ts,
+        user: message.user,
+        queryLength: text.length,
+        confidence: confidence.composite,
+        factors: confidence,
+        resultCount: results.length,
+        hasSynthesis: !!synthesis,
+        autonomyLevel,
+      },
+      '[auto-response] shadow log',
+    )
+
+    // Step 6: DM/Pushover delivery (assist mode)
+    if (
+      meetsAutonomyLevel(autonomyLevel, 'assist') &&
+      confidence.composite >= config.confidenceThreshold &&
+      synthesis
+    ) {
+      try {
+        const pushover = new PushoverService({ onError: 'swallow' })
+        if (pushover.isConfigured) {
+          const pushoverMessage = [
+            `Channel question from <@${message.user}>:`,
+            `"${text.length > 150 ? text.slice(0, 150) + '...' : text}"`,
+            '',
+            `Draft response (confidence: ${(confidence.composite * 100).toFixed(0)}%):`,
+            attributed.summary,
+            '',
+            `Sources: ${confidence.relevantResultCount} relevant captures`,
+          ].join('\n')
+
+          await pushover.send({
+            title: 'Open Brain: Auto-Response Draft',
+            message: pushoverMessage,
+            priority: 0,
+          })
+
+          logger.info({ channel, ts, confidence: confidence.composite }, '[auto-response] Pushover sent')
+        }
+      } catch (err) {
+        logger.warn({ err }, '[auto-response] Pushover delivery failed')
+      }
+    }
+
+    // Step 7: Threaded reply (advise mode)
+    if (
+      meetsAutonomyLevel(autonomyLevel, 'advise') &&
+      confidence.composite >= config.confidenceThreshold &&
+      synthesis &&
+      confidence.relevantResultCount >= config.minCorroboratingResults
+    ) {
+      // Check staleness
+      const now = Date.now()
+      const oldestRelevant = results
+        .filter(r => r.score > 0.3)
+        .reduce((oldest, r) => {
+          const age = (now - new Date(r.created_at).getTime()) / (1000 * 60 * 60 * 24)
+          return Math.max(oldest, age)
+        }, 0)
+
+      if (oldestRelevant <= config.stalenessDays) {
+        try {
+          await app.client.chat.postMessage({
+            channel,
+            thread_ts: ts,
+            text: attributed.text,
+          })
+          logger.info(
+            { channel, ts, confidence: confidence.composite, resultCount: confidence.relevantResultCount },
+            '[auto-response] threaded reply posted',
+          )
+        } catch (err) {
+          logger.warn({ err }, '[auto-response] failed to post threaded reply')
+        }
+      } else {
+        logger.debug(
+          { oldestRelevant, stalenessDays: config.stalenessDays },
+          '[auto-response] skipped -- results too stale',
+        )
+      }
+    }
+  } catch (err) {
+    // Never throw from auto-response -- it's fire-and-forget
+    logger.error({ err, channel, ts }, '[auto-response] unhandled error')
+  }
+}

--- a/packages/slack-bot/src/server.ts
+++ b/packages/slack-bot/src/server.ts
@@ -10,7 +10,7 @@ import type { CoreApiClient } from './lib/core-api-client.js'
 import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import yaml from 'js-yaml'
-import { logger } from '@open-brain/shared'
+import { logger, type AutonomyLevel } from '@open-brain/shared'
 import { IntentRouter } from './intent/router.js'
 import { handleCapture } from './handlers/capture.js'
 import { handleQuery } from './handlers/query.js'
@@ -18,6 +18,37 @@ import { handleCommand } from './handlers/command.js'
 import { handleSessionThreadReply, getSessionThread } from './handlers/session.js'
 import { getThreadContext } from './lib/thread-context.js'
 import { safeHandle } from './lib/safe-handle.js'
+import { isAutoResponseCandidate, handleAutoResponse, type AutoResponseConfig } from './handlers/auto-response.js'
+
+/** Cache for autonomy level -- refreshed every 5 minutes */
+let cachedAutonomyLevel: { level: AutonomyLevel; fetchedAt: number } | null = null
+const AUTONOMY_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+async function getAutonomyLevel(coreApiClient: CoreApiClient): Promise<AutonomyLevel> {
+  const now = Date.now()
+  if (cachedAutonomyLevel && now - cachedAutonomyLevel.fetchedAt < AUTONOMY_CACHE_TTL) {
+    return cachedAutonomyLevel.level
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.CORE_API_URL ?? 'http://core-api:3000'}/api/v1/settings/autonomy_level`,
+    )
+    if (response.ok) {
+      const data = (await response.json()) as { value: string }
+      const level = (['observe', 'assist', 'advise', 'partner'].includes(data.value)
+        ? data.value
+        : 'observe') as AutonomyLevel
+      cachedAutonomyLevel = { level, fetchedAt: now }
+      return level
+    }
+  } catch {
+    // Settings not available -- default to observe
+  }
+
+  cachedAutonomyLevel = { level: 'observe', fetchedAt: now }
+  return 'observe'
+}
 
 /**
  * Register all message/event handlers on the Bolt app.
@@ -49,6 +80,16 @@ function registerHandlers(app: App, coreApiClient: CoreApiClient, redis: Redis):
     intent_model: intentModel,
     llm_timeout_ms: 5_000,
   })
+
+  // Auto-response configuration
+  const autoResponseConfig: AutoResponseConfig = {
+    coreApiUrl: process.env.CORE_API_URL ?? 'http://core-api:3000',
+    confidenceThreshold: 0.6,
+    stalenessDays: 90,
+    minCorroboratingResults: 2,
+    botUserId: undefined, // Set after app.start() if available
+    ownerUserId: process.env.SLACK_OWNER_USER_ID,
+  }
 
   // Ignore bot messages globally — prevents feedback loops
   app.message(async ({ message, next }) => {
@@ -129,6 +170,22 @@ function registerHandlers(app: App, coreApiClient: CoreApiClient, redis: Redis):
           // Safety net — treat unknown intents as capture
           await handleCapture(genericMessage, say, coreApiClient)
           break
+      }
+
+      // --- Auto-response (async, fire-and-forget) ---
+      // For messages that aren't directed at the bot, check if they're
+      // questions Open Brain could answer. Runs in background.
+      if (
+        intentResult.intent === 'conversation' ||
+        intentResult.intent === 'capture'
+      ) {
+        if (isAutoResponseCandidate(genericMessage, autoResponseConfig)) {
+          getAutonomyLevel(coreApiClient).then(level => {
+            handleAutoResponse(genericMessage, app, coreApiClient, level, autoResponseConfig)
+          }).catch(err => {
+            logger.debug({ err }, '[auto-response] skipped — failed to get autonomy level')
+          })
+        }
       }
     }, say, ts)
   })

--- a/packages/slack-bot/src/services/attribution-formatter.ts
+++ b/packages/slack-bot/src/services/attribution-formatter.ts
@@ -1,0 +1,52 @@
+/**
+ * Format attributed responses for auto-response feature.
+ * Produces Slack mrkdwn with source citations.
+ */
+
+import type { SearchResult } from '../lib/core-api-types.js'
+
+export interface AttributedResponse {
+  /** Full Slack mrkdwn message text */
+  text: string
+  /** Short summary for Pushover notifications */
+  summary: string
+  /** Source citations */
+  sources: Array<{ id: string; date: string; source: string; excerpt: string }>
+}
+
+/**
+ * Format a synthesis response with attribution for Slack posting.
+ */
+export function formatAttributedResponse(
+  synthesis: string,
+  results: SearchResult[],
+  opts?: { maxSources?: number },
+): AttributedResponse {
+  const maxSources = opts?.maxSources ?? 3
+
+  // Build source citations
+  const sources = results.slice(0, maxSources).map(r => {
+    const date = new Date(r.created_at).toISOString().split('T')[0]
+    const source = r.source ?? 'unknown'
+    const excerpt = r.content.length > 80 ? r.content.slice(0, 80) + '...' : r.content
+    return { id: r.id, date, source, excerpt }
+  })
+
+  // Build Slack mrkdwn
+  const citationLines = sources
+    .map((s, i) => `> _[${i + 1}] ${s.date} (${s.source}): ${s.excerpt}_`)
+    .join('\n')
+
+  const text = [
+    'Based on captured context:\n',
+    synthesis,
+    '\n---\n_Sources:_',
+    citationLines,
+    '\n_This is an AI-generated response based on captured context._',
+  ].join('\n')
+
+  // Short summary for Pushover
+  const summary = synthesis.length > 200 ? synthesis.slice(0, 200) + '...' : synthesis
+
+  return { text, summary, sources }
+}

--- a/packages/slack-bot/src/services/confidence-scorer.ts
+++ b/packages/slack-bot/src/services/confidence-scorer.ts
@@ -1,0 +1,62 @@
+/**
+ * Confidence scoring for auto-response candidates.
+ * Produces a composite score (0.0-1.0) from search quality metrics.
+ */
+
+import { logger } from '@open-brain/shared'
+import type { SearchResult } from '../lib/core-api-types.js'
+
+export interface ConfidenceFactors {
+  /** Normalized top search score (0-1) */
+  searchScore: number
+  /** How many results are above a relevance threshold */
+  relevantResultCount: number
+  /** Average age of results in days (lower = more recent = better) */
+  avgAgeDays: number
+  /** Final composite confidence */
+  composite: number
+}
+
+/**
+ * Compute a composite confidence score from search results.
+ *
+ * Weights:
+ * - 0.5: Top search score (most important -- is the best match good?)
+ * - 0.3: Result coverage (more relevant results = more corroboration)
+ * - 0.2: Recency (recent captures are more likely to be accurate)
+ */
+export function scoreConfidence(results: SearchResult[]): ConfidenceFactors {
+  if (results.length === 0) {
+    return { searchScore: 0, relevantResultCount: 0, avgAgeDays: 999, composite: 0 }
+  }
+
+  // Top search score (already 0-1 from the API)
+  const topScore = Math.min(results[0].score, 1)
+
+  // Count results with score > 0.3 (relevance threshold)
+  const relevant = results.filter(r => r.score > 0.3)
+  const coverageScore = Math.min(relevant.length / 5, 1) // cap at 5 results
+
+  // Recency: average age in days, mapped to 0-1 (0 days = 1.0, 90+ days = 0.0)
+  const now = Date.now()
+  const ages = results.slice(0, 5).map(r => {
+    const created = new Date(r.created_at).getTime()
+    return (now - created) / (1000 * 60 * 60 * 24) // days
+  })
+  const avgAge = ages.reduce((a, b) => a + b, 0) / ages.length
+  const recencyScore = Math.max(0, 1 - avgAge / 90)
+
+  const composite = 0.5 * topScore + 0.3 * coverageScore + 0.2 * recencyScore
+
+  logger.debug(
+    { topScore, coverageScore, recencyScore, composite, resultCount: results.length },
+    '[confidence] score computed',
+  )
+
+  return {
+    searchScore: topScore,
+    relevantResultCount: relevant.length,
+    avgAgeDays: Math.round(avgAge * 10) / 10,
+    composite: Math.round(composite * 1000) / 1000,
+  }
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -405,7 +405,7 @@ export const intelligenceApi = {
   },
 
   /** Manually trigger an intelligence skill */
-  trigger: (skill: 'daily-connections' | 'drift-monitor', overrides?: Record<string, unknown>) => {
+  trigger: (skill: 'daily-connections' | 'drift-monitor' | 'daily-sweep-skill', overrides?: Record<string, unknown>) => {
     return request<{ skill: string; job_id: string; status: string; message: string }>(
       `/intelligence/${skill}/trigger`,
       {
@@ -414,6 +414,12 @@ export const intelligenceApi = {
       },
     )
   },
+
+  /** Fetch unresolved questions — questions with no entity-overlap follow-up in 7 days */
+  unresolvedQuestions: (limit = 5) =>
+    request<{ questions: Array<{ id: string; content: string; brain_view: string; created_at: string }>; count: number }>(
+      `/intelligence/unresolved-questions?limit=${limit}`,
+    ),
 }
 
 // Bets API — API uses statement/confidence/resolution; web uses description/status/due_date

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -2,6 +2,8 @@
  * Types for the Open Brain web dashboard
  */
 
+export type AutonomyLevel = 'observe' | 'assist' | 'advise' | 'partner'
+
 export type CaptureType = 'decision' | 'idea' | 'observation' | 'task' | 'win' | 'blocker' | 'question' | 'reflection'
 export type BrainView = 'career' | 'personal' | 'technical' | 'work-internal' | 'client'
 export type CaptureSource = 'api' | 'slack' | 'voice' | 'document' | 'mcp' | 'email'

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { RefreshCw, Plus, AlertCircle } from 'lucide-react';
+import { RefreshCw, Plus, AlertCircle, HelpCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import StatsCards from '@/components/StatsCards';
 import CaptureCard from '@/components/CaptureCard';
-import { capturesApi, statsApi, pipelineApi, adminApi } from '@/lib/api';
+import { capturesApi, statsApi, pipelineApi, adminApi, intelligenceApi } from '@/lib/api';
 import type { AdminBanner } from '@/lib/api';
 import type { BrainStats, Capture } from '@/lib/types';
 
@@ -46,6 +46,7 @@ export default function Dashboard() {
   const [recentCaptures, setRecentCaptures] = useState<Capture[]>([]);
   const [pipelineHealth, setPipelineHealth] = useState<PipelineHealth | null>(null);
   const [adminBanner, setAdminBanner] = useState<AdminBanner | null>(null);
+  const [unresolvedQuestions, setUnresolvedQuestions] = useState<Array<{ id: string; content: string; brain_view: string; created_at: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -60,17 +61,19 @@ export default function Dashboard() {
     if (!silent) setLoading(true);
     setError(null);
     try {
-      const [statsData, capturesData, healthData, bannerData] = await Promise.allSettled([
+      const [statsData, capturesData, healthData, bannerData, questionsData] = await Promise.allSettled([
         statsApi.get(),
         capturesApi.list({ limit: RECENT_LIMIT }),
         pipelineApi.health(),
         adminApi.getBanner(),
+        intelligenceApi.unresolvedQuestions(5),
       ]);
 
       if (statsData.status === 'fulfilled') setStats(statsData.value);
       if (capturesData.status === 'fulfilled') setRecentCaptures(capturesData.value.data);
       if (healthData.status === 'fulfilled') setPipelineHealth(healthData.value);
       if (bannerData.status === 'fulfilled') setAdminBanner(bannerData.value.banner);
+      if (questionsData.status === 'fulfilled') setUnresolvedQuestions(questionsData.value.questions);
 
       // Surface error only if all three failed
       if (
@@ -184,6 +187,32 @@ export default function Dashboard() {
 
       {/* Stats cards */}
       {stats && <StatsCards stats={stats} />}
+
+      {/* Open Questions widget */}
+      {unresolvedQuestions.length > 0 && (
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-base font-semibold flex items-center gap-2">
+              <HelpCircle className="h-4 w-4 text-amber-500" />
+              Open Questions
+              <span className="text-xs font-normal text-muted-foreground">({unresolvedQuestions.length})</span>
+            </h2>
+            <Button variant="ghost" size="sm" onClick={() => navigate('/search?q=type:question')} className="text-xs">
+              View all
+            </Button>
+          </div>
+          <ul className="space-y-2">
+            {unresolvedQuestions.slice(0, 5).map((q) => (
+              <li key={q.id} className="text-sm text-muted-foreground flex items-start gap-2">
+                <span className="shrink-0 mt-0.5 text-amber-400">?</span>
+                <span className="line-clamp-2">
+                  {q.content.length > 100 ? `${q.content.slice(0, 100)}...` : q.content}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <Separator />
 

--- a/packages/web/src/pages/Settings.tsx
+++ b/packages/web/src/pages/Settings.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, Plus, Trash2, AlertCircle, CheckCircle, XCircle, Activity, Pencil, Check, X, Loader2, Mail, Info } from 'lucide-react';
+import { RefreshCw, Plus, Trash2, AlertCircle, CheckCircle, XCircle, Activity, Pencil, Check, X, Loader2, Mail, Info, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { skillsApi, triggersApi, pipelineApi, adminApi, settingsApi } from '@/lib/api';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import type { Skill, Trigger } from '@/lib/types';
+import type { Skill, Trigger, AutonomyLevel } from '@/lib/types';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -617,6 +617,98 @@ function TriggersSection({ triggers, loading, error, onAdd, onDelete }: {
   );
 }
 
+// ─── Autonomy Level section ─────────────────────────────────────────────────
+
+const AUTONOMY_LEVELS: { value: AutonomyLevel; label: string; description: string }[] = [
+  { value: 'observe', label: 'Observe', description: 'Notifications only \u2014 no autonomous actions' },
+  { value: 'assist', label: 'Assist', description: 'Draft + notify \u2014 human relays responses' },
+  { value: 'advise', label: 'Advise', description: 'Act + report \u2014 posts with clear bot attribution' },
+  { value: 'partner', label: 'Partner', description: 'Autonomous within guardrails' },
+];
+
+function AutonomyLevelSection({ level, loading, error, onChange }: {
+  level: AutonomyLevel;
+  loading: boolean;
+  error: string | null;
+  onChange: (level: AutonomyLevel) => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  async function handleChange(newLevel: AutonomyLevel) {
+    if (newLevel === level) return;
+    setSaving(true);
+    setSaveResult(null);
+    try {
+      await onChange(newLevel);
+      setSaveResult({ success: true, message: 'Saved' });
+      setTimeout(() => setSaveResult(null), 3000);
+    } catch (err) {
+      setSaveResult({ success: false, message: err instanceof Error ? err.message : 'Failed to save' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Shield className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-base font-semibold">Autonomy Level</h2>
+        {saveResult && (
+          <Badge variant={saveResult.success ? 'default' : 'destructive'} className="text-xs">
+            {saveResult.success ? <CheckCircle className="h-3 w-3 mr-1" /> : <AlertCircle className="h-3 w-3 mr-1" />}
+            {saveResult.message}
+          </Badge>
+        )}
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-2">
+          {[...Array(4)].map((_, i) => <div key={i} className="h-12 animate-pulse rounded bg-secondary" />)}
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card divide-y">
+          {AUTONOMY_LEVELS.map((opt) => (
+            <label
+              key={opt.value}
+              className={`px-4 py-3 flex items-start gap-3 cursor-pointer transition-colors hover:bg-accent/50 ${
+                saving ? 'opacity-60 pointer-events-none' : ''
+              }`}
+            >
+              <input
+                type="radio"
+                name="autonomy_level"
+                value={opt.value}
+                checked={level === opt.value}
+                onChange={() => handleChange(opt.value)}
+                disabled={saving}
+                className="mt-0.5 accent-primary"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{opt.label}</span>
+                  {level === opt.value && (
+                    <Badge variant="default" className="text-xs">Active</Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-0.5">{opt.description}</p>
+              </div>
+            </label>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 // ─── Email Allowlist section ─────────────────────────────────────────────────
 
 function EmailAllowlistSection({ entries, loading, error, onAdd, onRemove }: {
@@ -928,6 +1020,10 @@ export default function Settings() {
   const [triggersLoading, setTriggersLoading] = useState(true);
   const [triggersError, setTriggersError] = useState<string | null>(null);
 
+  const [autonomyLevel, setAutonomyLevel] = useState<AutonomyLevel>('observe');
+  const [autonomyLoading, setAutonomyLoading] = useState(true);
+  const [autonomyError, setAutonomyError] = useState<string | null>(null);
+
   const [allowlist, setAllowlist] = useState<string[]>([]);
   const [allowlistLoading, setAllowlistLoading] = useState(true);
   const [allowlistError, setAllowlistError] = useState<string | null>(null);
@@ -987,6 +1083,23 @@ export default function Settings() {
     }
   }, []);
 
+  const loadAutonomy = useCallback(async () => {
+    setAutonomyError(null);
+    try {
+      const res = await settingsApi.get<string>('autonomy_level');
+      setAutonomyLevel(res.value as AutonomyLevel);
+    } catch (err) {
+      // 404 means no level set yet — default to observe
+      if (err instanceof Error && err.message.includes('404')) {
+        setAutonomyLevel('observe');
+      } else {
+        setAutonomyError(err instanceof Error ? err.message : 'Failed to load autonomy level');
+      }
+    } finally {
+      setAutonomyLoading(false);
+    }
+  }, []);
+
   const loadAllowlist = useCallback(async () => {
     setAllowlistError(null);
     try {
@@ -1005,8 +1118,8 @@ export default function Settings() {
   }, []);
 
   const loadAll = useCallback(async () => {
-    await Promise.allSettled([loadHealth(), loadSkills(), loadTriggers(), loadAllowlist()]);
-  }, [loadHealth, loadSkills, loadTriggers, loadAllowlist]);
+    await Promise.allSettled([loadHealth(), loadSkills(), loadTriggers(), loadAutonomy(), loadAllowlist()]);
+  }, [loadHealth, loadSkills, loadTriggers, loadAutonomy, loadAllowlist]);
 
   useEffect(() => {
     loadAll();
@@ -1035,6 +1148,11 @@ export default function Settings() {
   async function handleDeleteTrigger(id: string) {
     await triggersApi.delete(id);
     await loadTriggers();
+  }
+
+  async function handleAutonomyChange(level: AutonomyLevel) {
+    await settingsApi.put('autonomy_level', level);
+    setAutonomyLevel(level);
   }
 
   async function handleAddAllowlistEntry(entry: string) {
@@ -1105,6 +1223,15 @@ export default function Settings() {
         error={triggersError}
         onAdd={handleAddTrigger}
         onDelete={handleDeleteTrigger}
+      />
+
+      <Separator />
+
+      <AutonomyLevelSection
+        level={autonomyLevel}
+        loading={autonomyLoading}
+        error={autonomyError}
+        onChange={handleAutonomyChange}
       />
 
       <Separator />

--- a/packages/workers/src/__tests__/daily-sweep-skill.test.ts
+++ b/packages/workers/src/__tests__/daily-sweep-skill.test.ts
@@ -1,0 +1,592 @@
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest'
+import { join } from 'node:path'
+import {
+  DailySweepSkill,
+  parseOutput,
+  assembleContext,
+  fmtDate,
+  queryTodayCaptures,
+  queryUnresolvedQuestions,
+  queryNewEntities,
+} from '../skills/daily-sweep-skill.js'
+import type { DailySweepOutput } from '../skills/daily-sweep-skill.js'
+import { PushoverService } from '../services/pushover.js'
+
+// Prompt templates live at <repo-root>/config/prompts/
+const REPO_PROMPTS_DIR = join(import.meta.dirname, '..', '..', '..', '..', 'config', 'prompts')
+
+// ============================================================
+// Fixtures
+// ============================================================
+
+const SAMPLE_CAPTURES = [
+  {
+    id: 'cap-1',
+    content: 'Decided to switch to OpenAI embeddings for better quality.',
+    capture_type: 'decision',
+    brain_view: 'technical',
+    source: 'api',
+    tags: ['open-brain', 'embeddings'],
+    created_at: '2026-04-02',
+  },
+  {
+    id: 'cap-2',
+    content: 'Why is the voice pipeline latency so high on the watch?',
+    capture_type: 'question',
+    brain_view: 'technical',
+    source: 'voice',
+    tags: ['voice'],
+    created_at: '2026-04-02',
+  },
+  {
+    id: 'cap-3',
+    content: 'Closed the NovaBurger retainer — $8K/month starting April.',
+    capture_type: 'win',
+    brain_view: 'client',
+    source: 'slack',
+    tags: ['stratfield', 'revenue'],
+    created_at: '2026-04-02',
+  },
+]
+
+const SAMPLE_QUESTIONS = [
+  {
+    id: 'q-1',
+    content: 'Should we move to a dedicated embedding service?',
+    brain_view: 'technical',
+    created_at: '2026-03-28',
+    tags: ['architecture'],
+  },
+  {
+    id: 'q-2',
+    content: 'What is the ideal ACT-R temporal weight for warm start?',
+    brain_view: 'technical',
+    created_at: '2026-03-25',
+    tags: null,
+  },
+]
+
+const SAMPLE_ENTITIES = [
+  { name: 'NovaBurger', entity_type: 'organization' },
+  { name: 'OpenAI Embeddings', entity_type: 'technology' },
+]
+
+const SAMPLE_OUTPUT: DailySweepOutput = {
+  headline: 'Embedding migration decided + NovaBurger retainer closed',
+  key_decisions: ['Switch to OpenAI text-embedding-3-large for all vectors'],
+  unresolved_questions: ['Voice pipeline watch latency root cause unknown', 'Dedicated embedding service decision pending'],
+  new_entities: ['NovaBurger — new QSR client retainer', 'OpenAI Embeddings — vector provider'],
+  tasks_without_followup: [],
+  notable_captures: ['NovaBurger retainer closes $8K/month recurring revenue'],
+}
+
+// ============================================================
+// Mock helpers
+// ============================================================
+
+function makeMockDb(
+  captures = SAMPLE_CAPTURES,
+  questions = SAMPLE_QUESTIONS,
+  entities = SAMPLE_ENTITIES,
+) {
+  let callCount = 0
+  return {
+    execute: vi.fn().mockImplementation(() => {
+      callCount++
+      // Call order: 1=todayCaptures, 2=unresolvedQuestions, 3=newEntities
+      if (callCount === 1) return Promise.resolve({ rows: captures })
+      if (callCount === 2) return Promise.resolve({ rows: questions })
+      return Promise.resolve({ rows: entities })
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+  }
+}
+
+function makeMockOpenAI(jsonOutput: DailySweepOutput = SAMPLE_OUTPUT) {
+  return {
+    chat: {
+      completions: {
+        create: vi.fn().mockResolvedValue({
+          choices: [{ message: { content: JSON.stringify(jsonOutput) } }],
+          usage: { prompt_tokens: 500, completion_tokens: 200, total_tokens: 700 },
+        }),
+      },
+    },
+  }
+}
+
+function makePushoverService(configured = true) {
+  const svc = new PushoverService('fake-token', 'fake-user')
+  if (!configured) {
+    Object.defineProperty(svc, 'isConfigured', { get: () => false })
+  }
+  vi.spyOn(svc, 'send').mockResolvedValue(undefined)
+  return svc
+}
+
+function makeSkill(opts: {
+  captures?: typeof SAMPLE_CAPTURES
+  questions?: typeof SAMPLE_QUESTIONS
+  entities?: typeof SAMPLE_ENTITIES
+  sweepOutput?: DailySweepOutput
+  pushoverConfigured?: boolean
+  promptsDir?: string
+  coreApiResponse?: { ok: boolean; json?: object; status?: number }
+} = {}) {
+  const db = makeMockDb(
+    opts.captures ?? SAMPLE_CAPTURES,
+    opts.questions ?? SAMPLE_QUESTIONS,
+    opts.entities ?? SAMPLE_ENTITIES,
+  )
+  const mockLitellm = makeMockOpenAI(opts.sweepOutput ?? SAMPLE_OUTPUT)
+  const pushover = makePushoverService(opts.pushoverConfigured ?? true)
+
+  const fetchResponse = opts.coreApiResponse ?? { ok: true, json: { id: 'saved-cap-id' } }
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: fetchResponse.ok,
+    status: fetchResponse.status ?? (fetchResponse.ok ? 200 : 500),
+    json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
+    text: vi.fn().mockResolvedValue(''),
+  })
+
+  const skill = new DailySweepSkill({
+    db: db as unknown as import('@open-brain/shared').Database,
+    promptsDir: opts.promptsDir ?? REPO_PROMPTS_DIR,
+    coreApiUrl: 'http://localhost:3000',
+    pushover,
+  })
+
+  // Replace internal litellmClient
+  // @ts-ignore — accessing private field for testing
+  skill.litellmClient = mockLitellm
+
+  // Replace global fetch
+  vi.stubGlobal('fetch', mockFetch)
+
+  return { skill, db, mockLitellm, pushover, mockFetch }
+}
+
+// ============================================================
+// Tests: parseOutput
+// ============================================================
+
+describe('parseOutput', () => {
+  it('parses valid JSON into DailySweepOutput', () => {
+    const raw = JSON.stringify(SAMPLE_OUTPUT)
+    const result = parseOutput(raw)
+    expect(result.headline).toBe(SAMPLE_OUTPUT.headline)
+    expect(result.key_decisions).toHaveLength(1)
+    expect(result.unresolved_questions).toHaveLength(2)
+    expect(result.new_entities).toHaveLength(2)
+    expect(result.tasks_without_followup).toEqual([])
+    expect(result.notable_captures).toHaveLength(1)
+  })
+
+  it('strips markdown code fences before parsing', () => {
+    const raw = '```json\n' + JSON.stringify(SAMPLE_OUTPUT) + '\n```'
+    const result = parseOutput(raw)
+    expect(result.headline).toBe(SAMPLE_OUTPUT.headline)
+    expect(result.key_decisions).toHaveLength(1)
+  })
+
+  it('strips code fences without language specifier', () => {
+    const raw = '```\n' + JSON.stringify(SAMPLE_OUTPUT) + '\n```'
+    const result = parseOutput(raw)
+    expect(result.headline).toBe(SAMPLE_OUTPUT.headline)
+  })
+
+  it('returns fallback for completely invalid JSON', () => {
+    const raw = 'This is not JSON at all, sorry.'
+    const result = parseOutput(raw)
+    expect(result.headline).toBe('This is not JSON at all, sorry.')
+    expect(result.key_decisions).toEqual([])
+    expect(result.unresolved_questions).toEqual([])
+    expect(result.new_entities).toEqual([])
+    expect(result.tasks_without_followup).toEqual([])
+    expect(result.notable_captures).toEqual([])
+  })
+
+  it('truncates raw text to 120 chars for fallback headline', () => {
+    const raw = 'A'.repeat(300)
+    const result = parseOutput(raw)
+    expect(result.headline).toHaveLength(120)
+  })
+
+  it('handles missing headline field gracefully', () => {
+    const raw = JSON.stringify({ key_decisions: [], unresolved_questions: [] })
+    const result = parseOutput(raw)
+    expect(result.headline).toBe('(no headline)')
+  })
+
+  it('handles missing array fields gracefully', () => {
+    const raw = JSON.stringify({ headline: 'Test' })
+    const result = parseOutput(raw)
+    expect(result.key_decisions).toEqual([])
+    expect(result.unresolved_questions).toEqual([])
+    expect(result.new_entities).toEqual([])
+    expect(result.tasks_without_followup).toEqual([])
+    expect(result.notable_captures).toEqual([])
+  })
+
+  it('filters non-string items from arrays', () => {
+    const raw = JSON.stringify({
+      headline: 'Test',
+      key_decisions: ['valid', 42, null, 'also valid'],
+      unresolved_questions: [true, 'question'],
+      new_entities: [],
+      tasks_without_followup: [],
+      notable_captures: [],
+    })
+    const result = parseOutput(raw)
+    expect(result.key_decisions).toEqual(['valid', 'also valid'])
+    expect(result.unresolved_questions).toEqual(['question'])
+  })
+
+  it('limits arrays to 5 items', () => {
+    const raw = JSON.stringify({
+      headline: 'Test',
+      key_decisions: Array.from({ length: 10 }, (_, i) => `Decision ${i}`),
+    })
+    const result = parseOutput(raw)
+    expect(result.key_decisions).toHaveLength(5)
+  })
+
+  it('handles empty string input', () => {
+    const result = parseOutput('')
+    expect(result.key_decisions).toEqual([])
+  })
+})
+
+// ============================================================
+// Tests: fmtDate
+// ============================================================
+
+describe('fmtDate', () => {
+  it('formats a Date as YYYY-MM-DD', () => {
+    expect(fmtDate(new Date('2026-04-02T14:30:00Z'))).toBe('2026-04-02')
+  })
+
+  it('handles year boundaries', () => {
+    expect(fmtDate(new Date('2025-12-31T23:59:59Z'))).toBe('2025-12-31')
+  })
+})
+
+// ============================================================
+// Tests: assembleContext
+// ============================================================
+
+describe('assembleContext', () => {
+  it('formats captures, questions, and entities within budget', () => {
+    const { capturesText, questionsText, entitiesText } = assembleContext(
+      SAMPLE_CAPTURES,
+      SAMPLE_QUESTIONS,
+      SAMPLE_ENTITIES,
+      100_000,
+    )
+    expect(capturesText).toContain('decision')
+    expect(capturesText).toContain('Decided to switch')
+    expect(questionsText).toContain('dedicated embedding service')
+    expect(entitiesText).toContain('NovaBurger')
+    expect(entitiesText).toContain('organization')
+  })
+
+  it('returns placeholder text when captures are empty', () => {
+    const { capturesText } = assembleContext([], SAMPLE_QUESTIONS, SAMPLE_ENTITIES, 100_000)
+    expect(capturesText).toBe('(no captures today)\n')
+  })
+
+  it('returns placeholder text when questions are empty', () => {
+    const { questionsText } = assembleContext(SAMPLE_CAPTURES, [], SAMPLE_ENTITIES, 100_000)
+    expect(questionsText).toBe('(no unresolved questions)\n')
+  })
+
+  it('returns placeholder text when entities are empty', () => {
+    const { entitiesText } = assembleContext(SAMPLE_CAPTURES, SAMPLE_QUESTIONS, [], 100_000)
+    expect(entitiesText).toBe('(no new entities today)\n')
+  })
+
+  it('truncates captures when budget is exceeded', () => {
+    const largeCaptures = Array.from({ length: 50 }, (_, i) => ({
+      id: `c-${i}`,
+      content: 'x'.repeat(200),
+      capture_type: 'observation',
+      brain_view: 'technical',
+      source: 'api',
+      tags: [],
+      created_at: '2026-04-02',
+    }))
+    const { capturesText } = assembleContext(largeCaptures, [], [], 500)
+    const lineCount = capturesText.split('\n').filter(l => l.trim()).length
+    expect(lineCount).toBeLessThan(50)
+  })
+})
+
+// ============================================================
+// Tests: query functions
+// ============================================================
+
+describe('queryTodayCaptures', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls db.execute and returns rows', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: SAMPLE_CAPTURES }) }
+    const result = await queryTodayCaptures(mockDb as any)
+    expect(mockDb.execute).toHaveBeenCalledOnce()
+    expect(result).toEqual(SAMPLE_CAPTURES)
+  })
+
+  it('returns empty array when no captures found', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: [] }) }
+    const result = await queryTodayCaptures(mockDb as any)
+    expect(result).toEqual([])
+  })
+})
+
+describe('queryUnresolvedQuestions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls db.execute and returns rows', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: SAMPLE_QUESTIONS }) }
+    const result = await queryUnresolvedQuestions(mockDb as any)
+    expect(mockDb.execute).toHaveBeenCalledOnce()
+    expect(result).toEqual(SAMPLE_QUESTIONS)
+  })
+})
+
+describe('queryNewEntities', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls db.execute and returns rows', async () => {
+    const mockDb = { execute: vi.fn().mockResolvedValue({ rows: SAMPLE_ENTITIES }) }
+    const result = await queryNewEntities(mockDb as any)
+    expect(mockDb.execute).toHaveBeenCalledOnce()
+    expect(result).toEqual(SAMPLE_ENTITIES)
+  })
+})
+
+// ============================================================
+// Tests: DailySweepSkill — execute happy path
+// ============================================================
+
+describe('DailySweepSkill', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('execute — happy path', () => {
+    it('returns a DailySweepResult with correct captureCount', async () => {
+      const { skill } = makeSkill()
+      const result = await skill.execute()
+
+      expect(result.captureCount).toBe(SAMPLE_CAPTURES.length)
+      expect(result.output.headline).toBe(SAMPLE_OUTPUT.headline)
+      expect(result.output.key_decisions).toHaveLength(1)
+      expect(result.durationMs).toBeGreaterThanOrEqual(0)
+    })
+
+    it('returns savedCaptureId from Core API response', async () => {
+      const { skill } = makeSkill()
+      const result = await skill.execute()
+      expect(result.savedCaptureId).toBe('saved-cap-id')
+    })
+
+    it('sends Pushover notification with headline and key items', async () => {
+      const { skill, pushover } = makeSkill()
+      await skill.execute()
+
+      expect(pushover.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Daily Sweep',
+          priority: 0,
+        }),
+      )
+      const sendCall = (pushover.send as unknown as MockInstance).mock.calls[0][0]
+      expect(sendCall.message).toContain(SAMPLE_OUTPUT.headline)
+    })
+
+    it('saves sweep back to brain via Core API POST', async () => {
+      const { skill, mockFetch } = makeSkill()
+      await skill.execute()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/api/v1/captures',
+        expect.objectContaining({ method: 'POST' }),
+      )
+
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(fetchBody.capture_type).toBe('reflection')
+      expect(fetchBody.brain_view).toBe('personal')
+      expect(fetchBody.tags).toEqual(['daily-sweep', 'skill-output'])
+      expect(fetchBody.metadata.source_metadata.generator).toBe('daily-sweep-skill')
+    })
+
+    it('writes a skills_log entry', async () => {
+      const { skill, db } = makeSkill()
+      await skill.execute()
+
+      const insertSpy = db.insert as MockInstance
+      expect(insertSpy).toHaveBeenCalled()
+      const valuesSpy = insertSpy.mock.results[0].value.values as MockInstance
+      const logEntry = valuesSpy.mock.calls[0][0]
+      expect(logEntry.skill_name).toBe('daily-sweep-skill')
+      expect(logEntry.input_summary).toContain('3 captures')
+      expect(logEntry.output_summary).toContain('headline:')
+      expect(logEntry.result).toBeDefined()
+    })
+
+    it('calls LLM with daily_sweep_v1 template variables substituted', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      await skill.execute()
+
+      const createSpy = mockLitellm.chat.completions.create as MockInstance
+      const callArgs = createSpy.mock.calls[0][0]
+      const prompt: string = callArgs.messages[0].content
+
+      // Template vars should be substituted
+      expect(prompt).not.toContain('{{date}}')
+      expect(prompt).not.toContain('{{capture_count}}')
+      expect(prompt).not.toContain('{{captures}}')
+      expect(prompt).not.toContain('{{unresolved_questions}}')
+      expect(prompt).not.toContain('{{new_entities}}')
+
+      // Should contain actual content
+      expect(prompt).toContain('3')
+      expect(prompt).toContain('NovaBurger')
+    })
+
+    it('uses the provided modelAlias in LLM call', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      await skill.execute({ modelAlias: 'gpt-5.4' })
+
+      const createSpy = mockLitellm.chat.completions.create as MockInstance
+      const callArgs = createSpy.mock.calls[0][0]
+      expect(callArgs.model).toBe('gpt-5.4')
+    })
+
+    it('uses max_completion_tokens not max_tokens', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      await skill.execute()
+
+      const createSpy = mockLitellm.chat.completions.create as MockInstance
+      const callArgs = createSpy.mock.calls[0][0]
+      expect(callArgs.max_completion_tokens).toBe(2048)
+      expect(callArgs.max_tokens).toBeUndefined()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Empty captures (quiet day)
+  // ----------------------------------------------------------
+
+  describe('execute — no captures today', () => {
+    it('returns quiet-day output and skips LLM call', async () => {
+      const { skill, mockLitellm } = makeSkill({ captures: [] })
+      const result = await skill.execute()
+
+      expect(result.captureCount).toBe(0)
+      expect(result.output.headline).toBe('Quiet day — no captures')
+      expect(result.output.key_decisions).toEqual([])
+      expect(result.savedCaptureId).toBeNull()
+      expect(mockLitellm.chat.completions.create).not.toHaveBeenCalled()
+    })
+
+    it('still writes a skills_log entry when no captures found', async () => {
+      const { skill, db } = makeSkill({ captures: [] })
+      await skill.execute()
+
+      expect(db.insert).toHaveBeenCalled()
+      const valuesSpy = (db.insert as MockInstance).mock.results[0].value.values as MockInstance
+      const logEntry = valuesSpy.mock.calls[0][0]
+      expect(logEntry.output_summary).toContain('Quiet day')
+    })
+
+    it('still sends Pushover notification on quiet day', async () => {
+      const { skill, pushover } = makeSkill({ captures: [] })
+      await skill.execute()
+
+      expect(pushover.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Daily Sweep',
+          message: expect.stringContaining('Quiet day'),
+        }),
+      )
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Delivery failures (non-fatal)
+  // ----------------------------------------------------------
+
+  describe('delivery — non-fatal failures', () => {
+    it('continues if Pushover delivery fails', async () => {
+      const { skill, pushover } = makeSkill()
+      vi.spyOn(pushover, 'send').mockRejectedValue(new Error('Pushover API down'))
+
+      const result = await skill.execute()
+      expect(result.output.headline).toBe(SAMPLE_OUTPUT.headline)
+      expect(result.notificationSent).toBe(false)
+    })
+
+    it('continues if Core API save-back fails', async () => {
+      const { skill } = makeSkill({ coreApiResponse: { ok: false, status: 500 } })
+
+      const result = await skill.execute()
+      expect(result.output.headline).toBe(SAMPLE_OUTPUT.headline)
+      expect(result.savedCaptureId).toBeNull()
+    })
+
+    it('continues if skills_log insert fails', async () => {
+      const { skill, db } = makeSkill()
+      ;(db.insert as MockInstance).mockReturnValue({
+        values: vi.fn().mockRejectedValue(new Error('DB write failed')),
+      })
+
+      const result = await skill.execute()
+      expect(result.captureCount).toBe(SAMPLE_CAPTURES.length)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Notification configuration
+  // ----------------------------------------------------------
+
+  describe('notification configuration', () => {
+    it('skips Pushover if not configured', async () => {
+      const { skill, pushover } = makeSkill({ pushoverConfigured: false })
+      await skill.execute()
+      expect(pushover.send).not.toHaveBeenCalled()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // LLM timeout
+  // ----------------------------------------------------------
+
+  describe('execute — LLM timeout', () => {
+    it('propagates LLM timeout error', async () => {
+      const { skill, mockLitellm } = makeSkill()
+      ;(mockLitellm.chat.completions.create as MockInstance).mockRejectedValue(new Error('Request timed out'))
+
+      await expect(skill.execute()).rejects.toThrow('Request timed out')
+    })
+  })
+})
+
+// ============================================================
+// Tests: executeDailySweep top-level function
+// ============================================================
+
+describe('executeDailySweep', () => {
+  it('is exported and callable (delegates to DailySweepSkill)', async () => {
+    const { executeDailySweep } = await import('../skills/daily-sweep-skill.js')
+    expect(typeof executeDailySweep).toBe('function')
+  })
+})

--- a/packages/workers/src/__tests__/pipeline-health-heartbeat.test.ts
+++ b/packages/workers/src/__tests__/pipeline-health-heartbeat.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PipelineHealthSkill } from '../skills/pipeline-health.js'
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function makeMockQueueFactory() {
+  return (name: string) => ({
+    getJobCounts: vi.fn().mockResolvedValue({ waiting: 0, active: 0, failed: 0, delayed: 0, paused: 0 }),
+    getJobCountByTypes: vi.fn().mockResolvedValue(0),
+    close: vi.fn().mockResolvedValue(undefined),
+  })
+}
+
+function makeMockDb(captureCount: string = '5') {
+  // The db.execute mock needs to handle two different queries:
+  // 1. pipeline_events failure query (returns rows array)
+  // 2. capture flow COUNT query (returns { count: string })
+  // We differentiate by call order: first call = pipeline_events, second = capture flow
+  const executeMock = vi.fn()
+    .mockResolvedValueOnce({ rows: [] })  // pipeline_events query
+    .mockResolvedValueOnce({ rows: [{ count: captureCount }] })  // capture flow query
+
+  return {
+    execute: executeMock,
+    insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+  }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('PipelineHealthSkill — heartbeat (capture flow)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('executes without errors with mock queues', async () => {
+    const mockDb = makeMockDb('5')
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: false, send: vi.fn() } as any,
+    })
+
+    const result = await skill.execute()
+    expect(result.healthy).toBe(true)
+    expect(result.alertSent).toBe(false)
+    expect(typeof result.durationMs).toBe('number')
+  })
+
+  it('includes captureFlowStale field in result', async () => {
+    const mockDb = makeMockDb('10')
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: false, send: vi.fn() } as any,
+    })
+
+    const result = await skill.execute()
+    expect(typeof result.captureFlowStale).toBe('boolean')
+  })
+
+  it('detects when no captures have flowed recently (during active hours)', async () => {
+    // Mock Date to return 10am (active hours)
+    const mockDate = new Date('2026-04-02T10:00:00')
+    vi.setSystemTime(mockDate)
+
+    const mockDb = makeMockDb('0')
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: true, send: vi.fn().mockResolvedValue(undefined) } as any,
+    })
+
+    const result = await skill.execute()
+    expect(result.captureFlowStale).toBe(true)
+
+    vi.useRealTimers()
+  })
+
+  it('skips capture flow check during quiet hours (midnight-7am)', async () => {
+    // Mock Date to return 3am (quiet hours)
+    const mockDate = new Date('2026-04-02T03:00:00')
+    vi.setSystemTime(mockDate)
+
+    // Return 0 captures — but it should not matter during quiet hours
+    const mockDb = makeMockDb('0')
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: false, send: vi.fn() } as any,
+    })
+
+    const result = await skill.execute()
+    // captureFlowStale should be false because the check is skipped
+    expect(result.captureFlowStale).toBe(false)
+
+    vi.useRealTimers()
+  })
+
+  it('includes capture flow stale message in Pushover alert', async () => {
+    // Mock Date to return 10am (active hours)
+    const mockDate = new Date('2026-04-02T10:00:00')
+    vi.setSystemTime(mockDate)
+
+    const sendMock = vi.fn().mockResolvedValue(undefined)
+    const mockDb = makeMockDb('0')
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: true, send: sendMock } as any,
+    })
+
+    await skill.execute()
+
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('No captures received in the last 6 hours'),
+      }),
+    )
+
+    vi.useRealTimers()
+  })
+
+  it('treats capture flow check DB errors as non-fatal (assumes OK)', async () => {
+    // Mock Date to return 10am (active hours)
+    const mockDate = new Date('2026-04-02T10:00:00')
+    vi.setSystemTime(mockDate)
+
+    const executeMock = vi.fn()
+      .mockResolvedValueOnce({ rows: [] })  // pipeline_events query
+      .mockRejectedValueOnce(new Error('DB connection lost'))  // capture flow query fails
+
+    const mockDb = {
+      execute: executeMock,
+      insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+    }
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: false, send: vi.fn() } as any,
+    })
+
+    const result = await skill.execute()
+    // Should not crash, and should assume OK (not stale)
+    expect(result.captureFlowStale).toBe(false)
+    expect(result.healthy).toBe(true)
+
+    vi.useRealTimers()
+  })
+})

--- a/packages/workers/src/__tests__/pipeline-health.test.ts
+++ b/packages/workers/src/__tests__/pipeline-health.test.ts
@@ -96,8 +96,14 @@ const SAMPLE_FAILURES = [
 // ============================================================
 
 function makeMockDb(failures = SAMPLE_FAILURES) {
+  // db.execute is called twice:
+  //   1. pipeline_events failure query → returns failures rows
+  //   2. capture flow COUNT query → returns count > 0 (healthy by default)
+  const executeMock = vi.fn()
+    .mockResolvedValueOnce({ rows: failures })
+    .mockResolvedValueOnce({ rows: [{ count: '10' }] })
   return {
-    execute: vi.fn().mockResolvedValue({ rows: failures }),
+    execute: executeMock,
     insert: vi.fn().mockReturnValue({
       values: vi.fn().mockResolvedValue(undefined),
     }),

--- a/packages/workers/src/jobs/skill-execution.ts
+++ b/packages/workers/src/jobs/skill-execution.ts
@@ -5,6 +5,7 @@ import { logger } from '@open-brain/shared'
 import { executeWeeklyBrief } from '../skills/weekly-brief.js'
 import { executeDailyConnections } from '../skills/daily-connections.js'
 import { executeDriftMonitor } from '../skills/drift-monitor.js'
+import { executeDailySweep } from '../skills/daily-sweep-skill.js'
 import type { SkillExecutionJobData } from '../queues/skill-execution.js'
 
 /**
@@ -89,9 +90,28 @@ export function createSkillExecutionWorker(
         }
 
         case 'pipeline-health': {
-          // Defined in KNOWN_SKILLS for scheduling visibility but not yet implemented.
-          // Log and skip gracefully.
-          logger.warn({ skillName }, '[skill-execution] skill not yet implemented — skipping')
+          const { executePipelineHealth } = await import('../skills/pipeline-health.js')
+          const result = await executePipelineHealth(db, {
+            failureLookbackMinutes: typeof input?.failureLookbackMinutes === 'number' ? input.failureLookbackMinutes : undefined,
+            failedThreshold: typeof input?.failedThreshold === 'number' ? input.failedThreshold : undefined,
+            waitingThreshold: typeof input?.waitingThreshold === 'number' ? input.waitingThreshold : undefined,
+          })
+          logger.info(
+            { skillName, healthy: result.healthy, alertSent: result.alertSent, durationMs: result.durationMs },
+            '[skill-execution] pipeline-health complete',
+          )
+          break
+        }
+
+        case 'daily-sweep-skill': {
+          const result = await executeDailySweep(db, {
+            tokenBudget: typeof input?.tokenBudget === 'number' ? input.tokenBudget : undefined,
+            modelAlias: synthesisModel,
+          })
+          logger.info(
+            { skillName, captureCount: result.captureCount, headline: result.output.headline, durationMs: result.durationMs },
+            '[skill-execution] daily-sweep-skill complete',
+          )
           break
         }
 

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -116,5 +116,43 @@ export async function registerScheduledJobs(
 
   logger.info({ cron: driftCron }, '[scheduler] drift-monitor repeatable job registered')
 
+  // --------------------------------------------------------
+  // Pipeline health (every 30 minutes)
+  // --------------------------------------------------------
+  const pipelineHealthCron = '*/30 * * * *'
+
+  await skillExecutionQueue.add(
+    'pipeline-health',
+    {
+      skillName: 'pipeline-health',
+      input: {},
+    },
+    {
+      repeat: { pattern: pipelineHealthCron },
+      jobId: 'scheduled_pipeline-health',
+    },
+  )
+
+  logger.info({ cron: pipelineHealthCron }, '[scheduler] pipeline-health repeatable job registered')
+
+  // --------------------------------------------------------
+  // Daily sweep skill (8:00 PM)
+  // --------------------------------------------------------
+  const dailySweepSkillCron = '0 20 * * *'
+
+  await skillExecutionQueue.add(
+    'daily-sweep-skill',
+    {
+      skillName: 'daily-sweep-skill',
+      input: {},
+    },
+    {
+      repeat: { pattern: dailySweepSkillCron },
+      jobId: 'scheduled_daily-sweep-skill',
+    },
+  )
+
+  logger.info({ cron: dailySweepSkillCron }, '[scheduler] daily-sweep-skill repeatable job registered')
+
   return { dailySweep: dailySweepQueue, budgetCheck: budgetCheckQueue, skillExecution: skillExecutionQueue }
 }

--- a/packages/workers/src/skills/daily-sweep-skill.ts
+++ b/packages/workers/src/skills/daily-sweep-skill.ts
@@ -1,0 +1,554 @@
+import { join } from 'node:path'
+import type OpenAI from 'openai'
+import { sql } from 'drizzle-orm'
+import type { Database } from '@open-brain/shared'
+import { skills_log, logger, PushoverService, createLiteLLMClient, TemplateCache } from '@open-brain/shared'
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface DailySweepOutput {
+  headline: string
+  key_decisions: string[]
+  unresolved_questions: string[]
+  new_entities: string[]
+  tasks_without_followup: string[]
+  notable_captures: string[]
+}
+
+export interface DailySweepResult {
+  output: DailySweepOutput
+  captureCount: number
+  durationMs: number
+  savedCaptureId: string | null
+  notificationSent: boolean
+}
+
+export interface DailySweepOptions {
+  /** Max chars of context to include. Default: 30000 */
+  tokenBudget?: number
+  /** Actual model name (not alias). Required. */
+  modelAlias?: string
+}
+
+// ============================================================
+// Constants
+// ============================================================
+
+const DEFAULT_TOKEN_BUDGET = 30_000
+const CHARS_PER_TOKEN = 4
+
+// ============================================================
+// Query helpers
+// ============================================================
+
+interface CaptureRow {
+  [key: string]: unknown
+  id: string
+  content: string
+  capture_type: string
+  brain_view: string
+  source: string
+  tags: string[] | null
+  created_at: string
+}
+
+interface QuestionRow {
+  [key: string]: unknown
+  id: string
+  content: string
+  brain_view: string
+  created_at: string
+  tags: string[] | null
+}
+
+interface EntityRow {
+  [key: string]: unknown
+  name: string
+  entity_type: string
+}
+
+/** Query today's completed captures. */
+export async function queryTodayCaptures(db: Database): Promise<CaptureRow[]> {
+  const todayMidnight = new Date()
+  todayMidnight.setHours(0, 0, 0, 0)
+
+  const result = await db.execute<CaptureRow>(sql`
+    SELECT id::text, content, capture_type, brain_view, source, tags, created_at::text
+    FROM captures
+    WHERE deleted_at IS NULL
+      AND pipeline_status = 'complete'
+      AND created_at >= ${todayMidnight.toISOString()}::timestamptz
+    ORDER BY created_at DESC
+  `)
+  return result.rows
+}
+
+/** Query unresolved questions — questions with no follow-up via entity overlap in 7 days. */
+export async function queryUnresolvedQuestions(db: Database): Promise<QuestionRow[]> {
+  const result = await db.execute<QuestionRow>(sql`
+    SELECT c.id::text, c.content, c.brain_view, c.created_at::text, c.tags
+    FROM captures c
+    WHERE c.capture_type = 'question'
+      AND c.pipeline_status = 'complete'
+      AND c.deleted_at IS NULL
+      AND c.created_at >= (NOW() - INTERVAL '30 days')
+      AND NOT EXISTS (
+        SELECT 1 FROM entity_links el1
+        JOIN entity_links el2 ON el1.entity_id = el2.entity_id
+        JOIN captures c2 ON el2.capture_id = c2.id
+        WHERE el1.capture_id = c.id
+          AND c2.id != c.id
+          AND c2.created_at > c.created_at
+          AND c2.created_at <= c.created_at + INTERVAL '7 days'
+          AND c2.deleted_at IS NULL
+          AND c2.pipeline_status = 'complete'
+      )
+    ORDER BY c.created_at DESC
+    LIMIT 10
+  `)
+  return result.rows
+}
+
+/** Query new entities first seen today. */
+export async function queryNewEntities(db: Database): Promise<EntityRow[]> {
+  const todayMidnight = new Date()
+  todayMidnight.setHours(0, 0, 0, 0)
+
+  const result = await db.execute<EntityRow>(sql`
+    SELECT name, entity_type
+    FROM entities
+    WHERE first_seen_at >= ${todayMidnight.toISOString()}::timestamptz
+    ORDER BY first_seen_at DESC
+    LIMIT 20
+  `)
+  return result.rows
+}
+
+// ============================================================
+// Context assembly
+// ============================================================
+
+function formatCapture(c: CaptureRow): string {
+  const tags = c.tags?.length ? ` [${c.tags.join(', ')}]` : ''
+  const date = typeof c.created_at === 'string' ? c.created_at.split('T')[0] : ''
+  return `[${date}] [${c.capture_type}] [${c.brain_view}]${tags} ${c.content}\n`
+}
+
+function formatQuestion(q: QuestionRow): string {
+  const date = typeof q.created_at === 'string' ? q.created_at.split('T')[0] : ''
+  return `[${date}] [${q.brain_view}] ${q.content}\n`
+}
+
+function formatEntity(e: EntityRow): string {
+  return `${e.name} (${e.entity_type})\n`
+}
+
+export function assembleContext(
+  captures: CaptureRow[],
+  questions: QuestionRow[],
+  entities: EntityRow[],
+  maxChars: number,
+): { capturesText: string; questionsText: string; entitiesText: string } {
+  // Allocate budget: 70% captures, 20% questions, 10% entities
+  const captureBudget = Math.floor(maxChars * 0.7)
+  const questionBudget = Math.floor(maxChars * 0.2)
+  const entityBudget = Math.floor(maxChars * 0.1)
+
+  let capturesText = ''
+  let usedChars = 0
+  for (const c of captures) {
+    const line = formatCapture(c)
+    if (usedChars + line.length > captureBudget) break
+    capturesText += line
+    usedChars += line.length
+  }
+  if (captures.length === 0) capturesText = '(no captures today)\n'
+
+  let questionsText = ''
+  usedChars = 0
+  for (const q of questions) {
+    const line = formatQuestion(q)
+    if (usedChars + line.length > questionBudget) break
+    questionsText += line
+    usedChars += line.length
+  }
+  if (questions.length === 0) questionsText = '(no unresolved questions)\n'
+
+  let entitiesText = ''
+  usedChars = 0
+  for (const e of entities) {
+    const line = formatEntity(e)
+    if (usedChars + line.length > entityBudget) break
+    entitiesText += line
+    usedChars += line.length
+  }
+  if (entities.length === 0) entitiesText = '(no new entities today)\n'
+
+  return { capturesText, questionsText, entitiesText }
+}
+
+// ============================================================
+// Date formatting
+// ============================================================
+
+export function fmtDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+// ============================================================
+// DailySweepSkill class
+// ============================================================
+
+/**
+ * DailySweepSkill — produces an evening summary of the day's captures.
+ *
+ * Follows the DailyConnectionsSkill/DriftMonitorSkill pattern:
+ * query data, assemble context, call LLM, parse output, deliver via Pushover,
+ * save as capture, log to skills_log.
+ */
+export class DailySweepSkill {
+  private db: Database
+  private litellmClient: OpenAI | null
+  private pushover: PushoverService
+  private templates: TemplateCache
+  private coreApiUrl: string
+
+  constructor(opts: {
+    db: Database
+    litellmBaseUrl?: string
+    litellmApiKey?: string
+    pushover?: PushoverService
+    promptsDir?: string
+    coreApiUrl?: string
+    templates?: TemplateCache
+  }) {
+    this.db = opts.db
+    this.litellmClient = createLiteLLMClient({
+      baseUrl: opts.litellmBaseUrl,
+      apiKey: opts.litellmApiKey,
+      timeout: 'extended',
+      maxRetries: 0,
+    })
+    this.pushover = opts.pushover ?? new PushoverService({ onError: 'throw' })
+    this.templates = opts.templates ?? new TemplateCache(opts.promptsDir ?? join(process.cwd(), 'config', 'prompts'))
+    this.coreApiUrl = opts.coreApiUrl ?? process.env.OPEN_BRAIN_API_URL ?? 'http://localhost:3000'
+  }
+
+  async execute(options: DailySweepOptions = {}): Promise<DailySweepResult> {
+    const {
+      tokenBudget: rawBudget = DEFAULT_TOKEN_BUDGET,
+      modelAlias = 'synthesis',
+    } = options
+    const tokenBudget = Math.max(1_000, Math.min(rawBudget, 100_000))
+
+    const startMs = Date.now()
+    const today = new Date()
+    logger.info({ tokenBudget }, '[daily-sweep-skill] starting execution')
+
+    // Step 1: Query today's captures
+    const captures = await queryTodayCaptures(this.db)
+    const captureCount = captures.length
+    logger.info({ captureCount }, '[daily-sweep-skill] captures fetched')
+
+    if (captureCount === 0) {
+      logger.info('[daily-sweep-skill] no captures today — producing quiet-day summary')
+      const quietOutput = emptyOutput()
+      const notificationSent = await this.deliverPushover(quietOutput)
+      await this.logToSkillsLog({
+        inputSummary: '0 captures today',
+        outputSummary: 'Quiet day — no captures',
+        durationMs: Date.now() - startMs,
+      })
+      return {
+        output: quietOutput,
+        captureCount: 0,
+        durationMs: Date.now() - startMs,
+        savedCaptureId: null,
+        notificationSent,
+      }
+    }
+
+    // Step 2: Query unresolved questions and new entities
+    const questions = await queryUnresolvedQuestions(this.db)
+    const newEntities = await queryNewEntities(this.db)
+    logger.info(
+      { unresolvedQuestions: questions.length, newEntities: newEntities.length },
+      '[daily-sweep-skill] supplementary data fetched',
+    )
+
+    // Step 3: Assemble context within token budget
+    const maxChars = tokenBudget * CHARS_PER_TOKEN
+    const { capturesText, questionsText, entitiesText } = assembleContext(captures, questions, newEntities, maxChars)
+
+    // Step 4: Call LLM
+    const rawOutput = await this.callLLM(capturesText, questionsText, entitiesText, captureCount, fmtDate(today), modelAlias)
+    const output = parseOutput(rawOutput)
+    const durationMs = Date.now() - startMs
+
+    // Step 5: Deliver Pushover notification
+    const notificationSent = await this.deliverPushover(output)
+
+    // Step 6: Save as capture back into the brain
+    const savedCaptureId = await this.saveSweepCapture(output, fmtDate(today))
+
+    // Step 7: Log to skills_log
+    await this.logToSkillsLog({
+      inputSummary: `${captureCount} captures, ${questions.length} unresolved questions, ${newEntities.length} new entities`,
+      outputSummary: `headline: "${output.headline}" | decisions:${output.key_decisions.length} questions:${output.unresolved_questions.length} entities:${output.new_entities.length} tasks:${output.tasks_without_followup.length} | notified:${notificationSent}`,
+      durationMs,
+      captureId: savedCaptureId ?? undefined,
+      result: output,
+    })
+
+    logger.info(
+      { captureCount, durationMs, notificationSent, savedCaptureId, headline: output.headline },
+      '[daily-sweep-skill] execution complete',
+    )
+
+    return { output, captureCount, durationMs, savedCaptureId, notificationSent }
+  }
+
+  // ----------------------------------------------------------
+  // Private: LLM call
+  // ----------------------------------------------------------
+
+  private async callLLM(
+    capturesText: string,
+    questionsText: string,
+    entitiesText: string,
+    captureCount: number,
+    date: string,
+    modelAlias: string,
+  ): Promise<string> {
+    if (!this.litellmClient) throw new Error('[daily-sweep-skill] LiteLLM client not configured — LITELLM_API_KEY missing')
+    const prompt = this.templates.render('daily_sweep_v1.txt', {
+      date,
+      capture_count: String(captureCount),
+      captures: capturesText,
+      unresolved_questions: questionsText,
+      new_entities: entitiesText,
+    })
+    logger.debug({ modelAlias, promptLength: prompt.length }, '[daily-sweep-skill] calling LLM')
+
+    const response = await this.litellmClient.chat.completions.create({
+      model: modelAlias,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.3,
+      max_completion_tokens: 2048,
+    })
+
+    const text = response.choices[0]?.message?.content ?? ''
+    logger.info(
+      { promptTokens: response.usage?.prompt_tokens, completionTokens: response.usage?.completion_tokens },
+      '[daily-sweep-skill] LLM call complete',
+    )
+    return text
+  }
+
+  // ----------------------------------------------------------
+  // Private: Pushover delivery
+  // ----------------------------------------------------------
+
+  private async deliverPushover(output: DailySweepOutput): Promise<boolean> {
+    if (!this.pushover.isConfigured) return false
+
+    const lines: string[] = [output.headline]
+
+    if (output.key_decisions.length > 0) {
+      lines.push('', 'Decisions:')
+      for (const d of output.key_decisions.slice(0, 3)) {
+        lines.push(`  - ${d}`)
+      }
+    }
+
+    if (output.unresolved_questions.length > 0) {
+      lines.push('', 'Open questions:')
+      for (const q of output.unresolved_questions.slice(0, 3)) {
+        lines.push(`  - ${q}`)
+      }
+    }
+
+    try {
+      await this.pushover.send({
+        title: 'Daily Sweep',
+        message: lines.join('\n'),
+        priority: 0,
+      })
+      return true
+    } catch {
+      // Pushover delivery is non-fatal
+      return false
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Private: Save as capture
+  // ----------------------------------------------------------
+
+  private async saveSweepCapture(
+    output: DailySweepOutput,
+    date: string,
+  ): Promise<string | null> {
+    try {
+      const content = buildSweepText(output, date)
+      const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          content,
+          capture_type: 'reflection',
+          brain_view: 'personal',
+          source: 'api',
+          tags: ['daily-sweep', 'skill-output'],
+          metadata: {
+            source_metadata: {
+              generator: 'daily-sweep-skill',
+              date,
+            },
+          },
+        }),
+        signal: AbortSignal.timeout(15_000),
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as { id?: string; data?: { id?: string } }
+      return data.id ?? data.data?.id ?? null
+    } catch {
+      return null
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Private: skills_log
+  // ----------------------------------------------------------
+
+  private async logToSkillsLog(params: {
+    inputSummary: string
+    outputSummary: string
+    durationMs: number
+    captureId?: string
+    result?: DailySweepOutput
+  }): Promise<void> {
+    try {
+      await this.db.insert(skills_log).values({
+        skill_name: 'daily-sweep-skill',
+        capture_id: params.captureId ?? null,
+        input_summary: params.inputSummary,
+        output_summary: params.outputSummary,
+        result: params.result ?? null,
+        duration_ms: params.durationMs,
+      })
+    } catch {
+      // skills_log failure is non-fatal
+    }
+  }
+}
+
+// ============================================================
+// Top-level entry point — called by BullMQ worker dispatcher
+// ============================================================
+
+/** Top-level entry point called by BullMQ worker. */
+export async function executeDailySweep(
+  db: Database,
+  options: DailySweepOptions = {},
+): Promise<DailySweepResult> {
+  return new DailySweepSkill({ db }).execute(options)
+}
+
+// ============================================================
+// Output parsing
+// ============================================================
+
+function emptyOutput(): DailySweepOutput {
+  return {
+    headline: 'Quiet day — no captures',
+    key_decisions: [],
+    unresolved_questions: [],
+    new_entities: [],
+    tasks_without_followup: [],
+    notable_captures: [],
+  }
+}
+
+/**
+ * Parses LLM JSON output into a DailySweepOutput.
+ * Handles markdown code fences and malformed output gracefully.
+ * Exported for testing.
+ */
+export function parseOutput(raw: string): DailySweepOutput {
+  let cleaned = raw.trim()
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
+  }
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(cleaned)
+  } catch (err) {
+    logger.warn({ raw: raw.slice(0, 500), err }, '[daily-sweep-skill] failed to parse LLM output as JSON — saving raw text')
+    return {
+      headline: raw.slice(0, 120),
+      key_decisions: [],
+      unresolved_questions: [],
+      new_entities: [],
+      tasks_without_followup: [],
+      notable_captures: [],
+    }
+  }
+
+  const headline = typeof parsed.headline === 'string' ? parsed.headline : '(no headline)'
+
+  const arrayFields = ['key_decisions', 'unresolved_questions', 'new_entities', 'tasks_without_followup', 'notable_captures'] as const
+  const output: DailySweepOutput = {
+    headline,
+    key_decisions: [],
+    unresolved_questions: [],
+    new_entities: [],
+    tasks_without_followup: [],
+    notable_captures: [],
+  }
+
+  for (const field of arrayFields) {
+    const val = parsed[field]
+    if (Array.isArray(val)) {
+      output[field] = val.filter((item): item is string => typeof item === 'string').slice(0, 5)
+    }
+  }
+
+  return output
+}
+
+// ============================================================
+// Text rendering (for capture-back-to-brain)
+// ============================================================
+
+function buildSweepText(output: DailySweepOutput, date: string): string {
+  const lines: string[] = [
+    `Daily Sweep — ${date}`,
+    '',
+    output.headline,
+    '',
+  ]
+
+  const sections: Array<{ label: string; items: string[] }> = [
+    { label: 'Key Decisions', items: output.key_decisions },
+    { label: 'Unresolved Questions', items: output.unresolved_questions },
+    { label: 'New Entities', items: output.new_entities },
+    { label: 'Tasks Without Follow-up', items: output.tasks_without_followup },
+    { label: 'Notable Captures', items: output.notable_captures },
+  ]
+
+  for (const section of sections) {
+    if (section.items.length > 0) {
+      lines.push(`${section.label}:`)
+      for (const item of section.items) {
+        lines.push(`- ${item}`)
+      }
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n').trim()
+}

--- a/packages/workers/src/skills/pipeline-health.ts
+++ b/packages/workers/src/skills/pipeline-health.ts
@@ -35,6 +35,7 @@ export interface PipelineHealthResult {
   queues: QueueStats[]
   recentFailures: RecentFailure[]
   stalledByQueue: StalledStats[]
+  captureFlowStale: boolean
   alertSent: boolean
   durationMs: number
 }
@@ -195,12 +196,20 @@ export class PipelineHealthSkill {
     // Step 3: Check for stalled jobs
     const stalledByQueue = await this.queryStalledJobs()
 
+    // Step 3.5: Check capture flow (skip during quiet hours)
+    let captureFlowStale = false
+    const hour = new Date().getHours()
+    const isQuietHours = hour >= 0 && hour < 7  // midnight-7am
+    if (!isQuietHours) {
+      captureFlowStale = await this.checkCaptureFlow(6)  // 6 hours threshold
+    }
+
     // Step 4: Evaluate thresholds
     const failedQueues = queues.filter(q => q.failed >= failedThreshold)
     const backloggedQueues = queues.filter(q => q.waiting >= waitingThreshold)
     const stalledQueues = alertOnStalled ? stalledByQueue.filter(s => s.stalledCount > 0) : []
 
-    const shouldAlert = failedQueues.length > 0 || backloggedQueues.length > 0 || stalledQueues.length > 0
+    const shouldAlert = failedQueues.length > 0 || backloggedQueues.length > 0 || stalledQueues.length > 0 || captureFlowStale
 
     const healthy = !shouldAlert && recentFailures.length === 0
 
@@ -211,6 +220,7 @@ export class PipelineHealthSkill {
         backloggedQueues,
         stalledQueues,
         recentFailures,
+        captureFlowStale,
         failedThreshold,
         waitingThreshold,
       })
@@ -223,6 +233,7 @@ export class PipelineHealthSkill {
       queues,
       recentFailures,
       stalledByQueue,
+      captureFlowStale,
       healthy,
       alertSent,
       durationMs,
@@ -238,6 +249,7 @@ export class PipelineHealthSkill {
       queues,
       recentFailures,
       stalledByQueue,
+      captureFlowStale,
       alertSent,
       durationMs,
     }
@@ -358,6 +370,36 @@ export class PipelineHealthSkill {
   }
 
   // ----------------------------------------------------------
+  // Private: capture flow check
+  // ----------------------------------------------------------
+
+  /**
+   * Check if captures are flowing. Returns true if no capture has been
+   * created in the last `hoursThreshold` hours.
+   * This detects silent failures where the system is "running" but not processing.
+   */
+  private async checkCaptureFlow(hoursThreshold: number): Promise<boolean> {
+    try {
+      const since = new Date(Date.now() - hoursThreshold * 60 * 60 * 1000)
+      const rows = await this.db.execute<{ count: string }>(sql`
+        SELECT COUNT(*)::text as count
+        FROM captures
+        WHERE created_at >= ${since.toISOString()}::timestamptz
+          AND deleted_at IS NULL
+      `)
+      const count = Number(rows.rows[0]?.count ?? 0)
+      if (count === 0) {
+        logger.warn({ hoursThreshold }, '[pipeline-health] no captures in recent window')
+        return true
+      }
+      return false
+    } catch (err) {
+      logger.warn({ err }, '[pipeline-health] failed to check capture flow — assuming OK')
+      return false
+    }
+  }
+
+  // ----------------------------------------------------------
   // Private: Pushover alert
   // ----------------------------------------------------------
 
@@ -372,6 +414,7 @@ export class PipelineHealthSkill {
     backloggedQueues: QueueStats[]
     stalledQueues: StalledStats[]
     recentFailures: RecentFailure[]
+    captureFlowStale: boolean
     failedThreshold: number
     waitingThreshold: number
   }): Promise<boolean> {
@@ -415,6 +458,10 @@ export class PipelineHealthSkill {
       lines.push(`Recent failures: ${params.recentFailures.length} (${stageSummary})`)
     }
 
+    if (params.captureFlowStale) {
+      lines.push('No captures received in the last 6 hours (during active hours)')
+    }
+
     const message = lines.join('\n')
 
     try {
@@ -439,6 +486,7 @@ export class PipelineHealthSkill {
     queues: QueueStats[]
     recentFailures: RecentFailure[]
     stalledByQueue: StalledStats[]
+    captureFlowStale: boolean
     healthy: boolean
     alertSent: boolean
     durationMs: number
@@ -456,6 +504,7 @@ export class PipelineHealthSkill {
       `active:${totalActive}`,
       `stalled:${totalStalled}`,
       `recentFailures:${params.recentFailures.length}`,
+      `captureFlowStale:${params.captureFlowStale}`,
       `alert:${params.alertSent}`,
     ].join(' | ')
 


### PR DESCRIPTION
## Summary

Transforms Open Brain from a passive knowledge store into an active thinking partner with 8 features across 7 change sets:

- **Autonomy Levels (P3)**: Configurable observe/assist/advise/partner gating in `app_settings`, shared `meetsAutonomyLevel()` utility, Settings page radio buttons
- **Daily Sweep Skill (P1)**: Evening LLM summary at 8 PM — key decisions, unresolved questions, new entities, tasks without follow-up. Pushover notification + save as capture.
- **Unresolved Questions Tracker (P4)**: Entity-overlap heuristic identifies questions with no follow-up within 7 days. API endpoint + Dashboard widget.
- **MCP Context Bootstrap (P2)**: `open_brain://context` resource returns markdown summary of active focus areas, key entities, open questions, recent decisions.
- **Heartbeat Monitor (P8)**: Completes pipeline-health skill with capture flow check. Scheduled every 30 min. Alerts via Pushover during active hours only.
- **Slack Shadow Mode (P6)**: Classifies channel questions from others, runs search+synthesis silently, logs draft responses with confidence scores.
- **Slack DM-to-You (P7)**: Sends Pushover notification with draft when confidence > threshold and autonomy >= assist.
- **Slack Threaded Replies (P9)**: Posts attributed responses in channel threads when autonomy >= advise, with corroboration and staleness gates.

Also fixes stale CLAUDE.md entry — CaptureCard was already unified in PR #37.

### Stats
- 29 files changed, +2,695 lines
- 13 new files (skills, handlers, services, resources, tests, prompts)
- **1,504 unit tests passing** (92 new, 0 regressions)
- All 6 packages build cleanly

### Dependency Graph
```
P3 (Autonomy) ─── P6 (Shadow) ─── P7 (DM) ─── P9 (Threaded)
P1 (Sweep) ← P4 (Questions)
P2 (MCP) — independent
P8 (Heartbeat) — independent
```

## Test plan
- [ ] Verify Settings page shows Autonomy Level section with 4 radio buttons
- [ ] Set autonomy to `assist`, trigger daily-sweep-skill manually, verify Pushover received
- [ ] Verify MCP context resource returns markdown via MCP client
- [ ] Verify pipeline-health runs on schedule (check skills_log after 30 min)
- [ ] Send question from another Slack user, verify auto-response shadow log
- [ ] Run full test suite: `pnpm -r test` (1,504 tests expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)