### PR TITLE
fix: reduce pipeline-health alert frequency and add capture-flow suppression

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -668,4 +668,26 @@ First deploy attempt crashed slack-bot: `ConfigService.load()` requires ALL conf
 - New bundle `Briefs-dVn2Pd3L.js` confirmed in container
 - **Reminder:** Users may need Ctrl+Shift+R to clear PWA cache and pick up new bundles (known issue)
 
+### Entry 015 — Reduce pipeline-health alert frequency and add capture-flow suppression [config] [workers]
+
+**Date:** 2026-04-05
+**Environment:** Laptop (development)
+**Status:** COMPLETE
+**Duration:** ~15 minutes
+
+**Objective:** Reduce Pushover notification spam from pipeline-health skill. The skill runs every 30 minutes and sends "No captures received in the last 6 hours" every time during active hours when no captures exist — up to ~34 notifications per day.
+
+**Hypothesis:** Changing the cron from every 30 minutes to every 6 hours and adding 24-hour suppression for capture-flow alerts will reduce notifications to at most 1 per day. Expect: all existing tests pass, 2 new suppression tests pass.
+
+**Rollback Plan:** `git revert` the commit (ecfd968 is current HEAD before changes).
+
+**Changes:**
+1. `packages/workers/src/scheduler.ts` — cron changed from `*/30 * * * *` to `0 */6 * * *`
+2. `packages/workers/src/skills/pipeline-health.ts` — added `wasCaptureFlowAlertSentRecently(hours)` method that queries `skills_log` for prior capture-flow alerts within 24 hours; suppresses repeated alerts
+3. `packages/workers/src/__tests__/pipeline-health-heartbeat.test.ts` — 2 new tests for suppression behavior, updated mock DB to handle third query
+
+**Verification:** 32/32 pipeline-health tests pass (30 existing + 2 new).
+
+**What Worked:** Suppression uses existing `skills_log` table (no new state or columns needed). The output_summary already contains `captureFlowStale:true` and `alert:true` flags, so the query is a simple LIKE match.
+
 *Entries continue below.*

--- a/packages/workers/src/__tests__/pipeline-health-heartbeat.test.ts
+++ b/packages/workers/src/__tests__/pipeline-health-heartbeat.test.ts
@@ -13,14 +13,15 @@ function makeMockQueueFactory() {
   })
 }
 
-function makeMockDb(captureCount: string = '5') {
-  // The db.execute mock needs to handle two different queries:
+function makeMockDb(captureCount: string = '5', recentAlertCount: string = '0') {
+  // The db.execute mock needs to handle up to three different queries:
   // 1. pipeline_events failure query (returns rows array)
   // 2. capture flow COUNT query (returns { count: string })
-  // We differentiate by call order: first call = pipeline_events, second = capture flow
+  // 3. suppression check query (only called when captureFlowStale=true; returns { count: string })
   const executeMock = vi.fn()
     .mockResolvedValueOnce({ rows: [] })  // pipeline_events query
     .mockResolvedValueOnce({ rows: [{ count: captureCount }] })  // capture flow query
+    .mockResolvedValueOnce({ rows: [{ count: recentAlertCount }] })  // suppression check (if needed)
 
   return {
     execute: executeMock,
@@ -126,6 +127,49 @@ describe('PipelineHealthSkill — heartbeat (capture flow)', () => {
         message: expect.stringContaining('No captures received in the last 6 hours'),
       }),
     )
+
+    vi.useRealTimers()
+  })
+
+  it('suppresses capture flow alert if one was already sent in the last 24 hours', async () => {
+    const mockDate = new Date('2026-04-02T10:00:00')
+    vi.setSystemTime(mockDate)
+
+    // recentAlertCount = '1' means a prior alert was already sent
+    const mockDb = makeMockDb('0', '1')
+    const sendMock = vi.fn().mockResolvedValue(undefined)
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: true, send: sendMock } as any,
+    })
+
+    const result = await skill.execute()
+    // captureFlowStale should be suppressed to false
+    expect(result.captureFlowStale).toBe(false)
+    expect(sendMock).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
+  })
+
+  it('sends capture flow alert when no prior alert in last 24 hours', async () => {
+    const mockDate = new Date('2026-04-02T10:00:00')
+    vi.setSystemTime(mockDate)
+
+    // recentAlertCount = '0' means no prior alert
+    const mockDb = makeMockDb('0', '0')
+    const sendMock = vi.fn().mockResolvedValue(undefined)
+
+    const skill = new PipelineHealthSkill({
+      db: mockDb as any,
+      queueFactory: makeMockQueueFactory(),
+      pushover: { isConfigured: true, send: sendMock } as any,
+    })
+
+    const result = await skill.execute()
+    expect(result.captureFlowStale).toBe(true)
+    expect(sendMock).toHaveBeenCalled()
 
     vi.useRealTimers()
   })

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -117,9 +117,9 @@ export async function registerScheduledJobs(
   logger.info({ cron: driftCron }, '[scheduler] drift-monitor repeatable job registered')
 
   // --------------------------------------------------------
-  // Pipeline health (every 30 minutes)
+  // Pipeline health (every 6 hours)
   // --------------------------------------------------------
-  const pipelineHealthCron = '*/30 * * * *'
+  const pipelineHealthCron = '0 */6 * * *'
 
   await skillExecutionQueue.add(
     'pipeline-health',

--- a/packages/workers/src/skills/pipeline-health.ts
+++ b/packages/workers/src/skills/pipeline-health.ts
@@ -211,7 +211,6 @@ export class PipelineHealthSkill {
 
     // Step 3.5: Check capture flow (skip during quiet hours)
     let captureFlowStale = false
-    let captureFlowSuppressed = false
     const hour = new Date().getHours()
     const isQuietHours = hour >= 0 && hour < 7  // midnight-7am
     if (!isQuietHours) {
@@ -220,7 +219,6 @@ export class PipelineHealthSkill {
       if (captureFlowStale && await this.wasCaptureFlowAlertSentRecently(24)) {
         logger.info('[pipeline-health] capture flow stale but alert already sent in last 24h — suppressing')
         captureFlowStale = false
-        captureFlowSuppressed = true
       }
     }
 

--- a/packages/workers/src/skills/pipeline-health.ts
+++ b/packages/workers/src/skills/pipeline-health.ts
@@ -211,10 +211,17 @@ export class PipelineHealthSkill {
 
     // Step 3.5: Check capture flow (skip during quiet hours)
     let captureFlowStale = false
+    let captureFlowSuppressed = false
     const hour = new Date().getHours()
     const isQuietHours = hour >= 0 && hour < 7  // midnight-7am
     if (!isQuietHours) {
       captureFlowStale = await this.checkCaptureFlow(6)  // 6 hours threshold
+      // Suppress repeated capture-flow alerts — only alert once per 24 hours
+      if (captureFlowStale && await this.wasCaptureFlowAlertSentRecently(24)) {
+        logger.info('[pipeline-health] capture flow stale but alert already sent in last 24h — suppressing')
+        captureFlowStale = false
+        captureFlowSuppressed = true
+      }
     }
 
     // Step 4: Evaluate thresholds
@@ -408,6 +415,33 @@ export class PipelineHealthSkill {
       return false
     } catch (err) {
       logger.warn({ err }, '[pipeline-health] failed to check capture flow — assuming OK')
+      return false
+    }
+  }
+
+  // ----------------------------------------------------------
+  // Private: capture flow alert suppression
+  // ----------------------------------------------------------
+
+  /**
+   * Check if a capture-flow-stale alert was already sent within the last N hours.
+   * Queries skills_log for pipeline-health entries where output_summary contains
+   * both 'captureFlowStale:true' and 'alert:true'.
+   */
+  private async wasCaptureFlowAlertSentRecently(hours: number): Promise<boolean> {
+    try {
+      const since = new Date(Date.now() - hours * 60 * 60 * 1000)
+      const rows = await this.db.execute<{ count: string }>(sql`
+        SELECT COUNT(*)::text as count
+        FROM skills_log
+        WHERE skill_name = 'pipeline-health'
+          AND created_at >= ${since.toISOString()}::timestamptz
+          AND output_summary LIKE '%captureFlowStale:true%'
+          AND output_summary LIKE '%alert:true%'
+      `)
+      return Number(rows.rows[0]?.count ?? 0) > 0
+    } catch (err) {
+      logger.warn({ err }, '[pipeline-health] failed to check recent alert history — allowing alert')
       return false
     }
   }


### PR DESCRIPTION
## Summary
- Pipeline-health cron changed from every 30 minutes to every 6 hours
- Capture-flow "no captures" alert now suppressed if already sent within 24 hours (queries `skills_log` for prior alerts)
- Eliminates notification spam: was up to ~34 notifications/day, now at most 1/day

## Changes
- `packages/workers/src/scheduler.ts` — cron `*/30 * * * *` → `0 */6 * * *`
- `packages/workers/src/skills/pipeline-health.ts` — added `wasCaptureFlowAlertSentRecently()` method
- `packages/workers/src/__tests__/pipeline-health-heartbeat.test.ts` — 2 new suppression tests

## Test plan
- [x] 32/32 pipeline-health tests pass (30 existing + 2 new)
- [ ] Deploy to homeserver and verify reduced notification frequency

🤖 Generated with [Claude Code](https://claude.com/claude-code)