### PR TITLE
fix(financial): sidecar posts to internal core-api URL (Cloudflare Access 302 bug)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -355,6 +355,11 @@ services:
       FINANCIAL_INBOX_DIR: /inbox
       FINANCIAL_PIPE_DIR: /data
       FINANCIAL_CONFIG_DIR: /app/config/financial
+      # Post captures to core-api over the internal Docker network, not via
+      # the public brain.troy-davis.com URL. Public URL is fronted by
+      # Cloudflare Access which 302s unauthenticated POSTs.
+      CAPTURE_API_URL: http://core-api:3000/api/v1/captures
+      CAPTURE_API_CALLER: financial-pipeline
       TZ: America/New_York
     volumes:
       # Host inbox — drop CSVs here and they'll be processed on next cron run.

--- a/scripts/financial-pipeline.py
+++ b/scripts/financial-pipeline.py
@@ -99,6 +99,26 @@ def _load_bws_secrets() -> list:
         sys.exit(1)
 
 
+def _get_capture_api(cfg: dict) -> tuple[str, str]:
+    """Resolve the (url, caller_header) for POSTing captures.
+
+    Precedence: CAPTURE_API_URL / CAPTURE_API_CALLER env vars win over the
+    plaid-config.yaml `capture_api` block. This lets the Docker sidecar post
+    to the internal container URL (http://core-api:3000/api/v1/captures)
+    while the VM deployment keeps hitting the external Cloudflare Tunnel
+    URL out of the same config file.
+
+    Default url falls back to the public endpoint for backward compat, but
+    that path is fronted by Cloudflare Access — unauthenticated POSTs get
+    302'd to the login page, which requests follows and silently "succeeds"
+    as 200. Using the internal URL from the sidecar avoids that entirely.
+    """
+    cap_cfg = cfg.get("capture_api", {}) if cfg else {}
+    url = os.environ.get("CAPTURE_API_URL") or cap_cfg.get("url", "https://brain.troy-davis.com/api/v1/captures")
+    caller = os.environ.get("CAPTURE_API_CALLER") or cap_cfg.get("caller_header", "financial-pipeline")
+    return url, caller
+
+
 def get_bws_secret(secret_name: str) -> str:
     """Retrieve a secret value from Bitwarden Secrets Manager via bws CLI."""
     secrets = _load_bws_secrets()
@@ -517,9 +537,7 @@ def cmd_daily_summary(cfg: dict, conn: sqlite3.Connection):
         }
 
     # POST to Open Brain
-    cap_cfg = cfg.get("capture_api", {})
-    url = cap_cfg.get("url", "https://brain.troy-davis.com/api/v1/captures")
-    caller = cap_cfg.get("caller_header", "financial-pipeline")
+    url, caller = _get_capture_api(cfg)
 
     try:
         resp = requests.post(
@@ -706,9 +724,7 @@ def cmd_balances(cfg: dict, conn: sqlite3.Connection):
         }
 
     # ── POST capture to Open Brain ───────────────────────────────────────
-    cap_cfg = cfg.get("capture_api", {})
-    url = cap_cfg.get("url", "https://brain.troy-davis.com/api/v1/captures")
-    caller = cap_cfg.get("caller_header", "financial-pipeline")
+    url, caller = _get_capture_api(cfg)
 
     try:
         resp = requests.post(
@@ -950,9 +966,7 @@ def cmd_investments(cfg: dict, conn: sqlite3.Connection):
               if weekly_delta is not None else ""))
 
     # ── POST capture to Open Brain ───────────────────────────────────────
-    cap_cfg = cfg.get("capture_api", {})
-    url = cap_cfg.get("url", "https://brain.troy-davis.com/api/v1/captures")
-    caller = cap_cfg.get("caller_header", "financial-pipeline")
+    url, caller = _get_capture_api(cfg)
 
     source_meta = {
         "type": "investment_weekly",
@@ -1347,9 +1361,7 @@ def cmd_monthly_report(cfg: dict, conn: sqlite3.Connection):
     if has_yoy:
         source_metadata["yoy_prior_total"] = round(sum(abs(v) for v in yoy_cat.values()), 2)
 
-    cap_cfg = cfg.get("capture_api", {})
-    url = cap_cfg.get("url", "https://brain.troy-davis.com/api/v1/captures")
-    caller = cap_cfg.get("caller_header", "financial-pipeline")
+    url, caller = _get_capture_api(cfg)
 
     try:
         resp = requests.post(
@@ -2200,19 +2212,28 @@ def _parse_amazon_csv(filepath: Path) -> Optional[dict]:
 
 def _post_capture(cfg: dict, content: str, source_metadata: dict):
     """POST a capture to the Open Brain API."""
-    cap_cfg = cfg.get("capture_api", {})
-    url = cap_cfg.get("url", "https://brain.troy-davis.com/api/v1/captures")
-    caller = cap_cfg.get("caller_header", "financial-pipeline")
+    url, caller = _get_capture_api(cfg)
     try:
+        # allow_redirects=False — if the endpoint is fronted by Cloudflare
+        # Access without a service token, an unauthenticated POST returns
+        # 302 -> login page (HTML). With redirects enabled, requests would
+        # follow and return a 200 for the login HTML, which would appear
+        # successful to the status-code check but dump the capture into
+        # the void. Fail fast on 302 instead.
         resp = requests.post(
             url,
             json={"content": content, "source": "api", "source_metadata": source_metadata},
             headers={"Content-Type": "application/json", "X-Open-Brain-Caller": caller},
             timeout=30,
+            allow_redirects=False,
         )
         if resp.status_code in (200, 201):
             log.info(f"Capture posted: {content[:60]}...")
             return True
+        elif resp.status_code in (301, 302, 303, 307, 308):
+            loc = resp.headers.get("Location", "")[:120]
+            log.warning(f"Brain POST {resp.status_code} redirect to {loc} — likely Cloudflare Access; set CAPTURE_API_URL to an internal URL")
+            return False
         else:
             log.warning(f"Brain POST {resp.status_code}: {resp.text[:200]}")
             return False


### PR DESCRIPTION
## Summary

Caught during G-C.1 sidecar first-deploy (LAB_NOTEBOOK Entry 069): unauthenticated POSTs to `https://brain.troy-davis.com/api/v1/captures` get 302'd by Cloudflare Access to a login page. `requests.post()` followed the redirect and returned 200 on the login HTML, making `_post_capture` log success and move the CSV to `processed/` while zero captures reached the DB.

## Fix

- `_get_capture_api(cfg)` helper: `(url, caller)` with env-var override (`CAPTURE_API_URL` / `CAPTURE_API_CALLER`) winning over `plaid-config.yaml`. Lets the sidecar use `http://core-api:3000/api/v1/captures` while the VM keeps the external URL.
- DRYs 5 copies of the cap_cfg pattern down to one-liner.
- `_post_capture`: `allow_redirects=False` + explicit 3xx logging with the Location header so this fails loudly next time.
- `docker-compose.yml` financial-ingest: `CAPTURE_API_URL=http://core-api:3000/api/v1/captures`.

## Test plan

- [x] Helper precedence verified locally (defaults / cfg / env)
- [x] All 5 cap_cfg sites replaced, no stale references
- [x] Parsers still work (Amex 834 txns)
- [ ] CI green
- [ ] Homeserver redeploy + reprocess Amex CSV + verify capture in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)