### PR TITLE
chore: email drafts API improvements (Follow-up #1/#2/#3 from PR #88)

### DIFF
--- a/packages/core-api/src/__tests__/email-compose-draft-route.test.ts
+++ b/packages/core-api/src/__tests__/email-compose-draft-route.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ServiceUnavailableError } from '@open-brain/shared'
+import { createApp } from '../app.js'
+import type { EmailDraftService } from '../services/email-draft.js'
+import type { EmailComposeAssistService } from '../services/email-compose-assist.js'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+function makeMockEmailDraftService(): EmailDraftService {
+  // compose-draft route doesn't use EmailDraftService, but app.ts requires it
+  // to be present for registerEmailRoutes() to mount.
+  return {
+    create: vi.fn(),
+    list: vi.fn(),
+    get: vi.fn(),
+    update: vi.fn(),
+    approve: vi.fn(),
+    reject: vi.fn(),
+    send: vi.fn(),
+    approveThenSend: vi.fn(),
+  } as unknown as EmailDraftService
+}
+
+function makeMockComposeService(
+  overrides: Partial<EmailComposeAssistService> = {},
+): EmailComposeAssistService {
+  return {
+    compose: vi.fn().mockResolvedValue({
+      body: 'Hi Alice,\n\nThanks for the note — I will follow up by Friday.\n\nTroy',
+      subject: 'Follow-up',
+    }),
+    ...overrides,
+  } as unknown as EmailComposeAssistService
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/email/compose-draft
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/email/compose-draft', () => {
+  it('returns the proposed draft for a valid request', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    const emailComposeAssistService = makeMockComposeService()
+    const app = createApp({ emailDraftService, emailComposeAssistService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({
+        instruction: 'Reply to Alice about the Friday follow-up',
+        existing_draft: {
+          to: ['alice@example.com'],
+          subject: 'Re: Friday',
+        },
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.body).toContain('Alice')
+    expect(body.subject).toBe('Follow-up')
+    expect(emailComposeAssistService.compose).toHaveBeenCalledWith({
+      instruction: 'Reply to Alice about the Friday follow-up',
+      existingDraft: {
+        to: ['alice@example.com'],
+        subject: 'Re: Friday',
+      },
+    })
+  })
+
+  it('works without existing_draft', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    const emailComposeAssistService = makeMockComposeService()
+    const app = createApp({ emailDraftService, emailComposeAssistService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ instruction: 'Write a short thank-you note' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(emailComposeAssistService.compose).toHaveBeenCalledWith({
+      instruction: 'Write a short thank-you note',
+      existingDraft: undefined,
+    })
+  })
+
+  it('returns 400 when instruction is missing', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    const emailComposeAssistService = makeMockComposeService()
+    const app = createApp({ emailDraftService, emailComposeAssistService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ existing_draft: { subject: 'X' } }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as any
+    expect(body.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 400 when instruction is empty', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    const emailComposeAssistService = makeMockComposeService()
+    const app = createApp({ emailDraftService, emailComposeAssistService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ instruction: '' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid JSON', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    const emailComposeAssistService = makeMockComposeService()
+    const app = createApp({ emailDraftService, emailComposeAssistService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: 'not json',
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 503 when the compose service is not wired', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    // emailComposeAssistService intentionally NOT passed
+    const app = createApp({ emailDraftService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ instruction: 'Draft something' }),
+    })
+
+    expect(res.status).toBe(503)
+    const body = await res.json() as any
+    expect(body.code).toBe('SERVICE_UNAVAILABLE')
+  })
+
+  it('propagates 503 from ServiceUnavailableError thrown by the service', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    const emailComposeAssistService = makeMockComposeService({
+      compose: vi
+        .fn()
+        .mockRejectedValue(
+          new ServiceUnavailableError('AI compose is unavailable — ANTHROPIC_API_KEY is not configured'),
+        ),
+    })
+    const app = createApp({ emailDraftService, emailComposeAssistService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ instruction: 'Draft something' }),
+    })
+
+    expect(res.status).toBe(503)
+    const body = await res.json() as any
+    expect(body.code).toBe('SERVICE_UNAVAILABLE')
+  })
+
+  it('returns 500 with safe message when the agent fails with an unknown error', async () => {
+    const emailDraftService = makeMockEmailDraftService()
+    const emailComposeAssistService = makeMockComposeService({
+      compose: vi.fn().mockRejectedValue(new Error('AI compose failed — please try again or edit manually')),
+    })
+    const app = createApp({ emailDraftService, emailComposeAssistService })
+
+    const res = await app.request('/api/v1/email/compose-draft', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ instruction: 'Draft something' }),
+    })
+
+    expect(res.status).toBe(500)
+    const body = await res.json() as any
+    expect(body.code).toBe('COMPOSE_FAILED')
+    expect(body.error).toBe('AI compose failed — please try again or edit manually')
+    // Ensure we do NOT leak internal details like anthropic URLs, stack, or tool names
+    expect(body.error).not.toContain('anthropic')
+    expect(body.error).not.toContain('search_brain')
+  })
+})

--- a/packages/core-api/src/__tests__/email-routes.test.ts
+++ b/packages/core-api/src/__tests__/email-routes.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { ConflictError, NotFoundError } from '@open-brain/shared'
 import { createApp } from '../app.js'
 import type { EmailDraftService } from '../services/email-draft.js'
 
@@ -40,6 +41,7 @@ function makeMockService(overrides: Partial<EmailDraftService> = {}): EmailDraft
     create: vi.fn().mockResolvedValue(SAMPLE_DRAFT),
     list: vi.fn().mockResolvedValue({ items: [SAMPLE_DRAFT], total: 1 }),
     get: vi.fn().mockResolvedValue(SAMPLE_DRAFT),
+    update: vi.fn().mockResolvedValue(SAMPLE_DRAFT),
     approve: vi.fn().mockResolvedValue({ ...SAMPLE_DRAFT, status: 'approved' }),
     reject: vi.fn().mockResolvedValue(REJECTED_DRAFT),
     send: vi.fn().mockResolvedValue(SENT_DRAFT),
@@ -286,5 +288,172 @@ describe('DELETE /api/v1/email/drafts/:id', () => {
     const body = await res.json() as any
     expect(body.status).toBe('rejected')
     expect(emailDraftService.reject).toHaveBeenCalledWith('draft-uuid-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/email/drafts/:id
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/v1/email/drafts/:id', () => {
+  it('updates a draft-status draft and returns the full record', async () => {
+    const emailDraftService = makeMockService({
+      update: vi.fn().mockResolvedValue({ ...SAMPLE_DRAFT, subject: 'Updated Subject' }),
+    })
+    const app = createApp({ emailDraftService })
+
+    const res = await app.request('/api/v1/email/drafts/draft-uuid-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ subject: 'Updated Subject', body: 'Updated body' }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.id).toBe('draft-uuid-1')
+    expect(body.subject).toBe('Updated Subject')
+    expect(emailDraftService.update).toHaveBeenCalledWith(
+      'draft-uuid-1',
+      expect.objectContaining({ subject: 'Updated Subject', body: 'Updated body' }),
+    )
+  })
+
+  it('joins array to/cc into comma-separated strings before passing to service', async () => {
+    const emailDraftService = makeMockService()
+    const app = createApp({ emailDraftService })
+
+    await app.request('/api/v1/email/drafts/draft-uuid-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({
+        to: ['a@example.com', 'b@example.com'],
+        cc: ['c@example.com'],
+      }),
+    })
+
+    expect(emailDraftService.update).toHaveBeenCalledWith(
+      'draft-uuid-1',
+      expect.objectContaining({
+        to: 'a@example.com, b@example.com',
+        cc: 'c@example.com',
+      }),
+    )
+  })
+
+  it('passes cc: null when the cc array is empty (clears the field)', async () => {
+    const emailDraftService = makeMockService()
+    const app = createApp({ emailDraftService })
+
+    await app.request('/api/v1/email/drafts/draft-uuid-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ cc: [] }),
+    })
+
+    expect(emailDraftService.update).toHaveBeenCalledWith(
+      'draft-uuid-1',
+      expect.objectContaining({ cc: null }),
+    )
+  })
+
+  it('returns 400 when no fields are provided', async () => {
+    const emailDraftService = makeMockService()
+    const app = createApp({ emailDraftService })
+
+    const res = await app.request('/api/v1/email/drafts/draft-uuid-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as any
+    expect(body.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 400 for invalid body shape (non-string subject)', async () => {
+    const emailDraftService = makeMockService()
+    const app = createApp({ emailDraftService })
+
+    const res = await app.request('/api/v1/email/drafts/draft-uuid-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ subject: 42 }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid JSON', async () => {
+    const emailDraftService = makeMockService()
+    const app = createApp({ emailDraftService })
+
+    const res = await app.request('/api/v1/email/drafts/draft-uuid-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: 'not-json',
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when the draft is missing', async () => {
+    const emailDraftService = makeMockService({
+      update: vi.fn().mockRejectedValue(new NotFoundError('Email draft not found: missing-id')),
+    })
+    const app = createApp({ emailDraftService })
+
+    const res = await app.request('/api/v1/email/drafts/missing-id', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ subject: 'Hi' }),
+    })
+
+    expect(res.status).toBe(404)
+    const body = await res.json() as any
+    expect(body.code).toBe('NOT_FOUND')
+  })
+
+  it('returns 409 when the draft is not in draft status', async () => {
+    const emailDraftService = makeMockService({
+      update: vi
+        .fn()
+        .mockRejectedValue(new ConflictError("Cannot update draft in status 'sent' — only 'draft' status can be edited")),
+    })
+    const app = createApp({ emailDraftService })
+
+    const res = await app.request('/api/v1/email/drafts/draft-uuid-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'integration-test',
+      },
+      body: JSON.stringify({ subject: 'Hi' }),
+    })
+
+    expect(res.status).toBe(409)
+    const body = await res.json() as any
+    expect(body.code).toBe('CONFLICT')
   })
 })

--- a/packages/core-api/src/app.ts
+++ b/packages/core-api/src/app.ts
@@ -42,6 +42,7 @@ import type { SystemHealthService } from './services/system-health.js'
 import type { WikiService } from './services/wiki.js'
 import type { ActivityFeedService } from './services/activity-feed.js'
 import type { EmailDraftService } from './services/email-draft.js'
+import type { EmailComposeAssistService } from './services/email-compose-assist.js'
 import type { VoiceSessionService } from './services/voice-session.js'
 
 interface AppDependencies {
@@ -75,6 +76,8 @@ interface AppDependencies {
   activityFeedService?: ActivityFeedService
   /** Email draft service — required for email draft management endpoints */
   emailDraftService?: EmailDraftService
+  /** Email-compose AI-assist service — optional, enables POST /api/v1/email/compose-draft */
+  emailComposeAssistService?: EmailComposeAssistService
   /** Voice session service — required for voice conversation session endpoints */
   voiceSessionService?: VoiceSessionService
   /** Ingest-process BullMQ queue — required for POST /api/v1/ingest/upload pipeline dispatch (CS3.4/CS3.5) */
@@ -83,7 +86,7 @@ interface AppDependencies {
 
 export function createApp(deps: AppDependencies = {}): Hono {
   const app = new Hono()
-  const { configService, captureService, searchService, pipelineService, db, redisConnection, skillQueue, triggerService, entityService, betService, sessionService, documentPipelineQueue, llmGateway, systemHealthService, wikiService, activityFeedService, emailDraftService, voiceSessionService, ingestProcessQueue } = deps
+  const { configService, captureService, searchService, pipelineService, db, redisConnection, skillQueue, triggerService, entityService, betService, sessionService, documentPipelineQueue, llmGateway, systemHealthService, wikiService, activityFeedService, emailDraftService, emailComposeAssistService, voiceSessionService, ingestProcessQueue } = deps
 
   // Rate limiter instances (in-memory, no persistence needed for single-user)
   const defaultLimiter = new RateLimiter(RATE_LIMIT_TIERS.default)
@@ -187,7 +190,7 @@ export function createApp(deps: AppDependencies = {}): Hono {
 
   // Email drafts API
   if (emailDraftService) {
-    registerEmailRoutes(app, emailDraftService)
+    registerEmailRoutes(app, emailDraftService, emailComposeAssistService)
   }
 
   // Voice session API

--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -20,6 +20,7 @@ import { SystemHealthService } from './services/system-health.js'
 import { WikiService } from './services/wiki.js'
 import { ActivityFeedService } from './services/activity-feed.js'
 import { EmailDraftService } from './services/email-draft.js'
+import { EmailComposeAssistService } from './services/email-compose-assist.js'
 import { VoiceSessionService } from './services/voice-session.js'
 import { HimalayaService, PushoverService } from '@open-brain/shared'
 import { pgNotify } from './lib/pg-notify.js'
@@ -117,6 +118,10 @@ const himalayaService = new HimalayaService()
 const emailPushover = new PushoverService({ onError: 'swallow' })
 const emailDraftService = new EmailDraftService(db, himalayaService, emailPushover)
 emailDraftService.setActivityFeedService(activityFeedService)
+
+// Email-compose AI-assist service — used by POST /api/v1/email/compose-draft.
+// Disabled gracefully if no Anthropic client (returns 503).
+const emailComposeAssistService = new EmailComposeAssistService(db, anthropicClient)
 if (himalayaService.isConfigured) {
   logger.info('HimalayaService configured — outbound email enabled')
 } else {
@@ -173,6 +178,7 @@ const app = createApp({
   wikiService,
   activityFeedService,
   emailDraftService,
+  emailComposeAssistService,
   voiceSessionService,
 })
 const port = Number(process.env.PORT ?? 3000)

--- a/packages/core-api/src/routes/email.ts
+++ b/packages/core-api/src/routes/email.ts
@@ -1,9 +1,43 @@
 import type { Hono } from 'hono'
+import { z } from 'zod'
 import { logger } from '@open-brain/shared'
 import type { EmailDraftService } from '../services/email-draft.js'
+import type { EmailComposeAssistService } from '../services/email-compose-assist.js'
 
 const VALID_STATUSES = ['draft', 'approved', 'sent', 'rejected', 'failed'] as const
 const VALID_SEND_MODES = ['review-required', 'auto-send'] as const
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+const patchDraftSchema = z
+  .object({
+    to: z.array(z.string()).optional(),
+    cc: z.array(z.string()).optional(),
+    subject: z.string().optional(),
+    body: z.string().optional(),
+  })
+  .refine(
+    (v) =>
+      v.to !== undefined ||
+      v.cc !== undefined ||
+      v.subject !== undefined ||
+      v.body !== undefined,
+    { message: 'At least one of to, cc, subject, body must be provided' },
+  )
+
+const composeDraftSchema = z.object({
+  instruction: z.string().min(1, 'instruction is required'),
+  existing_draft: z
+    .object({
+      to: z.array(z.string()).optional(),
+      cc: z.array(z.string()).optional(),
+      subject: z.string().optional(),
+      body: z.string().optional(),
+    })
+    .optional(),
+})
 
 /**
  * Register email draft management API routes.
@@ -11,12 +45,15 @@ const VALID_SEND_MODES = ['review-required', 'auto-send'] as const
  * GET    /api/v1/email/drafts         — list drafts (optional ?status= filter, ?limit=, ?offset=)
  * GET    /api/v1/email/drafts/:id     — get a single draft
  * POST   /api/v1/email/drafts         — create a new draft
+ * PATCH  /api/v1/email/drafts/:id     — partially update an existing draft (status='draft' only)
  * POST   /api/v1/email/drafts/:id/send — approve and send a draft
  * DELETE /api/v1/email/drafts/:id     — reject/discard a draft
+ * POST   /api/v1/email/compose-draft  — AI-assist: generate a proposed draft (not persisted)
  */
 export function registerEmailRoutes(
   app: Hono,
   emailDraftService: EmailDraftService,
+  emailComposeAssistService?: EmailComposeAssistService,
 ): void {
   // -----------------------------------------------------------------------
   // GET /api/v1/email/drafts
@@ -118,6 +155,57 @@ export function registerEmailRoutes(
   })
 
   // -----------------------------------------------------------------------
+  // PATCH /api/v1/email/drafts/:id — partial update of a draft-status draft
+  // Body: { to?: string[]; cc?: string[]; subject?: string; body?: string }
+  //
+  // Notes:
+  //  - EmailDraftService stores to/cc as comma-joined strings; arrays coming
+  //    from the web client are joined with ', ' here before hitting the
+  //    service layer to keep the storage shape consistent.
+  //  - 409 CONFLICT if the draft is not in status='draft' (already sent,
+  //    approved, failed, or rejected).
+  // -----------------------------------------------------------------------
+  app.patch('/api/v1/email/drafts/:id', async (c) => {
+    const id = c.req.param('id')
+
+    let rawBody: unknown
+    try {
+      rawBody = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', code: 'VALIDATION_ERROR' }, 400)
+    }
+
+    const parsed = patchDraftSchema.safeParse(rawBody)
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: parsed.error.issues.map((i) => i.message).join('; ') || 'Invalid body',
+          code: 'VALIDATION_ERROR',
+        },
+        400,
+      )
+    }
+
+    const patch = parsed.data
+
+    const draft = await emailDraftService.update(id, {
+      to: patch.to !== undefined ? patch.to.join(', ') : undefined,
+      cc: patch.cc !== undefined
+        ? (patch.cc.length > 0 ? patch.cc.join(', ') : null)
+        : undefined,
+      subject: patch.subject,
+      body: patch.body,
+    })
+
+    logger.info(
+      { draftId: id, fields: Object.keys(patch) },
+      '[email-routes] draft patched',
+    )
+
+    return c.json(draft)
+  })
+
+  // -----------------------------------------------------------------------
   // POST /api/v1/email/drafts/:id/send — approve and send
   // -----------------------------------------------------------------------
   app.post('/api/v1/email/drafts/:id/send', async (c) => {
@@ -148,5 +236,71 @@ export function registerEmailRoutes(
       id: draft.id,
       status: draft.status,
     })
+  })
+
+  // -----------------------------------------------------------------------
+  // POST /api/v1/email/compose-draft — synchronous AI-assist
+  // Body: { instruction: string, existing_draft?: { to?, cc?, subject?, body? } }
+  // Returns: { body, subject?, to?, cc? }
+  //
+  // Invokes the shared runAgent() tool-use loop against the brain DB
+  // (search_brain / get_entity) to produce a context-aware proposed draft.
+  // The result is NOT persisted — the web drawer saves via POST/PATCH
+  // /email/drafts when the user chooses to.
+  // -----------------------------------------------------------------------
+  app.post('/api/v1/email/compose-draft', async (c) => {
+    if (!emailComposeAssistService) {
+      return c.json(
+        {
+          error: 'AI compose is unavailable — compose service is not configured',
+          code: 'SERVICE_UNAVAILABLE',
+        },
+        503,
+      )
+    }
+
+    let rawBody: unknown
+    try {
+      rawBody = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', code: 'VALIDATION_ERROR' }, 400)
+    }
+
+    const parsed = composeDraftSchema.safeParse(rawBody)
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: parsed.error.issues.map((i) => i.message).join('; ') || 'Invalid body',
+          code: 'VALIDATION_ERROR',
+        },
+        400,
+      )
+    }
+
+    try {
+      const result = await emailComposeAssistService.compose({
+        instruction: parsed.data.instruction,
+        existingDraft: parsed.data.existing_draft,
+      })
+
+      return c.json(result)
+    } catch (err) {
+      // ServiceUnavailableError and other AppError subclasses propagate to
+      // the global onError handler (returns their statusCode). Unknown
+      // errors from the agent loop get a generic 500 with a safe message.
+      const message = err instanceof Error ? err.message : 'AI compose failed'
+      logger.warn(
+        { err: message },
+        '[email-routes] compose-draft failed',
+      )
+      // Re-throw AppErrors so the global handler maps them correctly.
+      if (err && typeof err === 'object' && 'statusCode' in err) {
+        throw err
+      }
+      return c.json(
+        { error: message, code: 'COMPOSE_FAILED' },
+        500,
+      )
+    }
   })
 }

--- a/packages/core-api/src/services/email-compose-assist.ts
+++ b/packages/core-api/src/services/email-compose-assist.ts
@@ -1,0 +1,311 @@
+import type Anthropic from '@anthropic-ai/sdk'
+import { sql } from 'drizzle-orm'
+import {
+  logger,
+  runAgent,
+  ServiceUnavailableError,
+} from '@open-brain/shared'
+import type { AgentTool, Database } from '@open-brain/shared'
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface ExistingDraft {
+  to?: string[]
+  cc?: string[]
+  subject?: string
+  body?: string
+}
+
+export interface EmailComposeAssistInput {
+  instruction: string
+  existingDraft?: ExistingDraft
+}
+
+export interface EmailComposeAssistResult {
+  body: string
+  subject?: string
+  to?: string[]
+  cc?: string[]
+}
+
+// ============================================================
+// EmailComposeAssistService
+// ============================================================
+
+/**
+ * Synchronous email-compose assistant backing POST /api/v1/email/compose-draft.
+ *
+ * Mirrors the agent-based approach used by the worker-side email-compose skill
+ * (packages/workers/src/skills/email-compose.ts) but returns the proposed draft
+ * fields directly to the caller instead of persisting a draft. That lets the
+ * web drawer keep the draft in its local form state and only persist via the
+ * existing POST/PATCH /email/drafts endpoints when the user chooses to save.
+ *
+ * Tools exposed to Claude:
+ *  - search_brain: ILIKE search over captures.content for context
+ *  - get_entity:   entity lookup by name (for contact/context info)
+ *  - submit_draft: capture structured output (body, optional subject/to/cc)
+ *
+ * The service is intentionally decoupled from the worker skill to avoid a
+ * circular workspace dependency (core-api does not depend on @open-brain/workers).
+ */
+export class EmailComposeAssistService {
+  constructor(
+    private db: Database,
+    private anthropicClient: Anthropic | null,
+  ) {}
+
+  async compose(input: EmailComposeAssistInput): Promise<EmailComposeAssistResult> {
+    if (!this.anthropicClient) {
+      throw new ServiceUnavailableError(
+        'AI compose is unavailable — ANTHROPIC_API_KEY is not configured',
+      )
+    }
+
+    const tools = this.buildTools()
+    const userMessage = this.buildUserMessage(input)
+
+    let agentResult
+    try {
+      agentResult = await runAgent(SYSTEM_PROMPT, tools, userMessage, {
+        client: this.anthropicClient,
+        model: 'claude-sonnet-4-5-20250929',
+        maxIterations: 8,
+        maxTokens: 4096,
+        temperature: 0.3,
+      })
+    } catch (err) {
+      logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        '[email-compose-assist] agent loop failed',
+      )
+      // Surface a safe, generic message — do not leak skill/agent internals.
+      throw new Error('AI compose failed — please try again or edit manually')
+    }
+
+    // Extract the submitted draft from tool calls. Prefer the last successful
+    // submit_draft call (agent may refine across iterations).
+    const submitCalls = agentResult.toolCalls.filter(
+      (tc) => tc.name === 'submit_draft' && !tc.isError,
+    )
+    const last = submitCalls[submitCalls.length - 1]
+
+    if (!last) {
+      // Fall back to final text if the agent didn't call submit_draft.
+      const text = agentResult.text.trim()
+      if (!text) {
+        throw new Error('AI returned an empty response — please try rephrasing')
+      }
+      return { body: text }
+    }
+
+    const body = typeof last.input.body === 'string' ? last.input.body : ''
+    if (!body.trim()) {
+      throw new Error('AI returned an empty body — please try rephrasing')
+    }
+
+    const result: EmailComposeAssistResult = { body }
+
+    if (typeof last.input.subject === 'string' && last.input.subject.trim()) {
+      result.subject = last.input.subject.trim()
+    }
+    if (Array.isArray(last.input.to)) {
+      const to = (last.input.to as unknown[])
+        .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+        .map((x) => x.trim())
+      if (to.length > 0) result.to = to
+    }
+    if (Array.isArray(last.input.cc)) {
+      const cc = (last.input.cc as unknown[])
+        .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+        .map((x) => x.trim())
+      if (cc.length > 0) result.cc = cc
+    }
+
+    logger.info(
+      {
+        iterations: agentResult.iterations,
+        toolCalls: agentResult.toolCalls.length,
+        durationMs: agentResult.duration,
+        hasSubject: Boolean(result.subject),
+        toCount: result.to?.length ?? 0,
+      },
+      '[email-compose-assist] draft produced',
+    )
+
+    return result
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  // Private helpers
+  // ──────────────────────────────────────────────────────────────────
+
+  private buildUserMessage(input: EmailComposeAssistInput): string {
+    const parts: string[] = [
+      `Instruction:\n"${input.instruction.trim()}"`,
+    ]
+
+    const d = input.existingDraft
+    if (d) {
+      const ctx: string[] = []
+      if (d.to && d.to.length > 0) ctx.push(`To: ${d.to.join(', ')}`)
+      if (d.cc && d.cc.length > 0) ctx.push(`Cc: ${d.cc.join(', ')}`)
+      if (d.subject && d.subject.trim()) ctx.push(`Subject: ${d.subject.trim()}`)
+      if (d.body && d.body.trim()) {
+        ctx.push(`Existing body (revise if relevant):\n${d.body.trim()}`)
+      }
+      if (ctx.length > 0) {
+        parts.push(`\nExisting draft context:\n${ctx.join('\n')}`)
+      }
+    }
+
+    return parts.join('\n')
+  }
+
+  private buildTools(): AgentTool[] {
+    const db = this.db
+    return [
+      {
+        name: 'search_brain',
+        description:
+          'Search the brain knowledge base for relevant context. Use this to find information about topics, people, or projects before composing an email.',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            query: { type: 'string', description: 'Search query' },
+            limit: {
+              type: 'number',
+              description: 'Max results to return (default: 8, max: 15)',
+            },
+          },
+          required: ['query'],
+        },
+        execute: async (inp: Record<string, unknown>): Promise<string> => {
+          const query = String(inp.query ?? '')
+          const limit = Math.min(Number(inp.limit) || 8, 15)
+
+          const rows = await db.execute(sql`
+            SELECT id, content, capture_type, brain_view, source, created_at
+            FROM captures
+            WHERE deleted_at IS NULL
+              AND content ILIKE ${'%' + query + '%'}
+            ORDER BY created_at DESC
+            LIMIT ${limit}
+          `)
+
+          if (!rows.rows || rows.rows.length === 0) {
+            return 'No results found.'
+          }
+
+          return rows.rows
+            .map(
+              (r: Record<string, unknown>) =>
+                `[${r.capture_type}/${r.brain_view}] ${String(r.content).slice(0, 300)} (${r.created_at})`,
+            )
+            .join('\n\n---\n\n')
+        },
+      },
+
+      {
+        name: 'get_entity',
+        description:
+          'Look up an entity (person, organization, project) by name. Useful for finding background on a recipient or topic.',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Entity name to search for (case-insensitive partial match)',
+            },
+          },
+          required: ['name'],
+        },
+        execute: async (inp: Record<string, unknown>): Promise<string> => {
+          const name = String(inp.name ?? '')
+
+          const rows = await db.execute(sql`
+            SELECT e.name, e.entity_type, e.canonical_name, e.metadata,
+                   COUNT(el.id) as mention_count
+            FROM entities e
+            LEFT JOIN entity_links el ON el.entity_id = e.id
+            WHERE e.canonical_name ILIKE ${'%' + name + '%'}
+               OR e.name ILIKE ${'%' + name + '%'}
+            GROUP BY e.id
+            ORDER BY COUNT(el.id) DESC
+            LIMIT 5
+          `)
+
+          if (!rows.rows || rows.rows.length === 0) {
+            return `No entity found matching "${name}".`
+          }
+
+          return rows.rows
+            .map(
+              (r: Record<string, unknown>) =>
+                `${r.name} (${r.entity_type}) — ${r.mention_count} mentions${
+                  r.metadata ? `, metadata: ${JSON.stringify(r.metadata)}` : ''
+                }`,
+            )
+            .join('\n')
+        },
+      },
+
+      {
+        name: 'submit_draft',
+        description:
+          'Submit the proposed email fields. Call this EXACTLY ONCE at the end after gathering context. The caller will persist or discard as they see fit.',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            body: {
+              type: 'string',
+              description:
+                'The proposed email BODY text only. Do not include a Subject: line or a "From:/To:" header inside the body.',
+            },
+            subject: {
+              type: 'string',
+              description:
+                'Optional proposed subject line. Omit if the caller already set one and it still fits.',
+            },
+            to: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Optional list of recipient email addresses. Omit if the caller already set recipients.',
+            },
+            cc: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'Optional list of CC email addresses. Omit if no CC change is needed.',
+            },
+          },
+          required: ['body'],
+        },
+        execute: async (inp: Record<string, unknown>): Promise<string> => {
+          const body = String(inp.body ?? '').trim()
+          if (!body) return 'Error: body is required.'
+          return 'Draft submitted.'
+        },
+      },
+    ]
+  }
+}
+
+// ============================================================
+// System prompt
+// ============================================================
+
+const SYSTEM_PROMPT = `You are an email-composition assistant for Troy Davis's personal AI knowledge system (Open Brain).
+
+Your job is to produce a single proposed email draft based on the user's instruction and any existing draft context provided. You have access to the brain's knowledge base to look up relevant context before composing.
+
+Guidelines:
+- Search the brain when the instruction references a topic, project, or person that may already have context recorded.
+- Look up entities (people, organizations) when the recipient or topic appears entity-like.
+- Write in Troy's voice — direct, substantive, no filler, respects the reader's time.
+- Never invent contact details. If the caller provided recipients in existing-draft context, keep them.
+- Always finish by calling the submit_draft tool with at minimum a body field. Do NOT describe the email in prose and skip the tool.
+- If the caller's existing draft already has a reasonable body and they only asked for a tweak, refine rather than rewrite wholesale.`

--- a/packages/core-api/src/services/email-draft.ts
+++ b/packages/core-api/src/services/email-draft.ts
@@ -4,6 +4,7 @@ import {
   captures,
   logger,
   NotFoundError,
+  ConflictError,
   contentHash,
   HimalayaService,
   PushoverService,
@@ -26,6 +27,17 @@ export interface CreateEmailDraftInput {
   source?: string
   sendMode?: EmailSendMode
   metadata?: Record<string, unknown>
+}
+
+/**
+ * Partial-update input for PATCH /api/v1/email/drafts/:id.
+ * All fields are optional; only provided fields are updated.
+ */
+export interface UpdateEmailDraftInput {
+  to?: string
+  cc?: string | null
+  subject?: string
+  body?: string
 }
 
 export interface EmailDraftRecord {
@@ -195,6 +207,43 @@ export class EmailDraftService {
     }
 
     return rows[0] as EmailDraftRecord
+  }
+
+  /**
+   * Partially update an existing draft's recipient/content fields.
+   *
+   * Only drafts with status='draft' can be updated. Any other status
+   * (approved, sent, failed, rejected) raises ConflictError. Undefined
+   * fields are left unchanged.
+   */
+  async update(id: string, patch: UpdateEmailDraftInput): Promise<EmailDraftRecord> {
+    const draft = await this.get(id)
+
+    if (draft.status !== 'draft') {
+      throw new ConflictError(
+        `Cannot update draft in status '${draft.status}' — only 'draft' status can be edited`,
+      )
+    }
+
+    // Build the update set, only including provided fields
+    const set: Record<string, unknown> = { updated_at: new Date() }
+    if (patch.to !== undefined) set.to_address = patch.to
+    if (patch.cc !== undefined) set.cc_address = patch.cc === null || patch.cc === '' ? null : patch.cc
+    if (patch.subject !== undefined) set.subject = patch.subject
+    if (patch.body !== undefined) set.body = patch.body
+
+    const [updated] = await this.db
+      .update(email_drafts)
+      .set(set)
+      .where(eq(email_drafts.id, id))
+      .returning()
+
+    logger.info(
+      { draftId: id, fields: Object.keys(patch) },
+      '[email-draft] draft updated',
+    )
+
+    return updated as EmailDraftRecord
   }
 
   /**

--- a/packages/web/src/components/EmailComposeDrawer.tsx
+++ b/packages/web/src/components/EmailComposeDrawer.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { emailApi, synthesizeApi } from '@/lib/api'
+import { emailApi } from '@/lib/api'
 import type { EmailDraft } from '@/lib/types'
 import { cn } from '@/lib/utils'
 
@@ -34,9 +34,10 @@ interface FormState {
 const EMPTY_FORM: FormState = { to: '', cc: '', subject: '', body: '' }
 
 /**
- * Drawer UI for composing or editing an email draft. Provides LLM-assist via
- * the existing `/synthesize` endpoint (no dedicated compose-skill HTTP route
- * exists yet — see CS4b.2 notes). Save persists via POST /email/drafts; Send
+ * Drawer UI for composing or editing an email draft. LLM-assist hits the
+ * dedicated `POST /email/compose-draft` endpoint (context-aware agent with
+ * search_brain + get_entity tools). Save persists via POST /email/drafts for
+ * new drafts or PATCH /email/drafts/:id for existing ones. Send
  * approves-and-sends via POST /email/drafts/:id/send.
  */
 export function EmailComposeDrawer({
@@ -117,25 +118,34 @@ export function EmailComposeDrawer({
     setAssisting(true)
     setAssistWarning(null)
     try {
-      const contextBits: string[] = []
-      if (form.to.trim()) contextBits.push(`Recipient: ${form.to.trim()}`)
-      if (form.subject.trim()) contextBits.push(`Subject: ${form.subject.trim()}`)
-      if (form.body.trim())
-        contextBits.push(`Existing draft body (revise if relevant):\n${form.body.trim()}`)
+      // Build existing-draft context from current form fields. The server-side
+      // compose agent uses this to refine rather than rewrite wholesale.
+      const existing: {
+        to?: string[]
+        subject?: string
+        body?: string
+      } = {}
+      const toList = form.to
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+      if (toList.length > 0) existing.to = toList
+      if (form.subject.trim()) existing.subject = form.subject.trim()
+      if (form.body.trim()) existing.body = form.body.trim()
 
-      const prompt =
-        `Draft the BODY of a professional email based on this instruction:\n` +
-        `"${assistPrompt.trim()}"\n\n` +
-        (contextBits.length ? `Context:\n${contextBits.join('\n')}\n\n` : '') +
-        `Return only the email body text — no subject line, no "To:" header, no salutation markers like "[Your Name]". ` +
-        `Keep it concise, natural, and ready to send.`
-
-      const result = await synthesizeApi.query(prompt, 8)
-      const body = (result.response ?? '').trim()
+      const result = await emailApi.composeDraft(
+        assistPrompt.trim(),
+        Object.keys(existing).length > 0 ? existing : undefined,
+      )
+      const body = (result.body ?? '').trim()
       if (!body) {
         setAssistWarning('AI returned an empty response. Try rephrasing.')
       } else {
         update('body', body)
+        // If the agent proposed a subject and the user hadn't set one, fill it in.
+        if (result.subject && !form.subject.trim()) {
+          update('subject', result.subject)
+        }
         setAssistPrompt('')
       }
     } catch (err) {
@@ -155,9 +165,29 @@ export function EmailComposeDrawer({
     setSaving(true)
     setError(null)
     try {
-      // Backend has no PATCH endpoint for drafts. When editing an existing
-      // draft, we create a fresh draft (original is preserved for reference).
-      // New drafts go through POST /email/drafts directly.
+      // Editing existing draft → PATCH in place. The server returns the full
+      // updated EmailDraft (not the minimal create response).
+      if (loadedDraftId) {
+        const toList = form.to
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+        const ccList = form.cc
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+        const updated = await emailApi.update(loadedDraftId, {
+          to: toList,
+          cc: ccList,
+          subject: form.subject.trim(),
+          body: form.body.trim(),
+        })
+        onSaved?.(updated)
+        return updated
+      }
+
+      // New draft → POST. Backend returns { id, status, send_mode, created_at };
+      // refetch for the full draft record to hand back to the caller.
       const created = await emailApi.create({
         to: form.to.trim(),
         subject: form.subject.trim(),
@@ -165,7 +195,6 @@ export function EmailComposeDrawer({
         cc: form.cc.trim() || undefined,
         source: 'web-compose',
       })
-      // `create` returns a partial shape; refetch for full draft record.
       const full = await emailApi.get(created.id)
       setLoadedDraftId(full.id)
       onSaved?.(full)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -667,6 +667,42 @@ export const mcpActivityApi = {
 
 // Email Drafts API
 
+/**
+ * What `POST /api/v1/email/drafts` actually returns — NOT a full EmailDraft.
+ * The backend returns only `{ id, status, send_mode, created_at }` and callers
+ * must `emailApi.get(id)` for the full record. (See `packages/core-api/src/routes/email.ts`.)
+ */
+export interface CreatedEmailDraftResponse {
+  id: string
+  status: string
+  send_mode: string
+  created_at: string
+}
+
+/** Patch body for PATCH /api/v1/email/drafts/:id. At least one field required. */
+export interface UpdateEmailDraftPatch {
+  to?: string[]
+  cc?: string[]
+  subject?: string
+  body?: string
+}
+
+/** Existing-draft context for POST /api/v1/email/compose-draft. */
+export interface ComposeDraftExisting {
+  to?: string[]
+  cc?: string[]
+  subject?: string
+  body?: string
+}
+
+/** Response shape from POST /api/v1/email/compose-draft. */
+export interface ComposeDraftResponse {
+  body: string
+  subject?: string
+  to?: string[]
+  cc?: string[]
+}
+
 export const emailApi = {
   /** List email drafts with optional status filter */
   list: async (params?: { status?: string; limit?: number; offset?: number }) => {
@@ -681,11 +717,22 @@ export const emailApi = {
     return request<EmailDraft>(`/email/drafts/${id}`)
   },
 
-  /** Create a new email draft */
+  /** Create a new email draft. Backend returns a minimal response — use `get()` for the full draft. */
   create: (payload: { to: string; subject: string; body: string; cc?: string; source?: string }) => {
-    return request<EmailDraft>('/email/drafts', {
+    return request<CreatedEmailDraftResponse>('/email/drafts', {
       method: 'POST',
       body: JSON.stringify(payload),
+    })
+  },
+
+  /**
+   * Partial update of a draft. Only drafts with status='draft' can be updated —
+   * the backend returns 409 CONFLICT for any other status.
+   */
+  update: (id: string, patch: UpdateEmailDraftPatch) => {
+    return request<EmailDraft>(`/email/drafts/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
     })
   },
 
@@ -700,6 +747,18 @@ export const emailApi = {
   reject: (id: string) => {
     return request<EmailDraft>(`/email/drafts/${id}`, {
       method: 'DELETE',
+    })
+  },
+
+  /**
+   * Synchronous AI-assist: returns a proposed draft (not persisted).
+   * Calls the email-compose agent server-side with `search_brain` / `get_entity`
+   * tools for context-aware composition. Returns at least `{ body }`.
+   */
+  composeDraft: (instruction: string, existing?: ComposeDraftExisting) => {
+    return request<ComposeDraftResponse>('/email/compose-draft', {
+      method: 'POST',
+      body: JSON.stringify({ instruction, existing_draft: existing }),
     })
   },
 }


### PR DESCRIPTION
Resolves Follow-ups #1, #2, #3 from PR #88's post-merge checklist.

## Changes

- **POST /api/v1/email/compose-draft** — new endpoint for context-aware AI-assist (replaces the `synthesizeApi.query()` stopgap in the Compose drawer). Reuses `runAgent()` from `@open-brain/shared` with `search_brain` + `get_entity` tools, wrapped in a synchronous `EmailComposeAssistService`. Returns structured `{ body, subject?, to?, cc? }`.
- **PATCH /api/v1/email/drafts/:id** — in-place partial edit of draft-status drafts. 409 Conflict on already-sent/failed/approved drafts.
- **emailApi.create() return type fix** — new exported `CreatedEmailDraftResponse = { id, status, send_mode, created_at }`. Wire drawer's existing-draft save through PATCH instead of creating a new draft.

## Architecture decision

Built a parallel synchronous service (`EmailComposeAssistService`) in core-api rather than importing from `@open-brain/workers` (would introduce circular workspace dep) or going through BullMQ (async, fragile for an interactive drawer). Reuses the same `runAgent()` + same tool surface as the worker-side skill.

## Known limitation (carried, non-blocking)

Anthropic model hard-coded to `claude-sonnet-4-5-20250929` (matches existing worker skill). Future work: resolve via `configService.get('ai').models[alias]` if tier-routing is desired.

## Test plan

- [x] tsc PASS both packages
- [x] 30/30 new + updated email route tests green
- [x] web 97/97 green
- [x] 3 pre-existing Windows ioredis flakes confirmed unrelated (reproduce on clean tree)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)