### PR TITLE
P02c: AgentResult.finalTierKey → recordAgentCompletion

### DIFF
--- a/IMPLEMENT_PHASE-P02c.md
+++ b/IMPLEMENT_PHASE-P02c.md
@@ -1,0 +1,245 @@
+# IMPLEMENT_PHASE-P02c.md — recordAgentCompletion final-tier plumb-through
+
+**Phase:** P02c (Wave 1, Bootstrap phase 4 of 5)
+**Closes:** #122 (sole PR; fully closes the issue — `Closes #122` is safe here)
+**Severity:** Low
+**Estimated effort:** ~4 hours
+**Dependencies:** None (additive on #101 gateway work)
+**Branch name:** `feat/phase-P02c-final-tier-key`
+**Drift audit date:** 2026-04-18
+**Base HEAD:** `6e4be28` (clean tree, P02b doc sweep)
+**Authored by:** Gate 1 phase-planner subagent (Sonnet 4.6)
+
+---
+
+## 1. Scope Drift
+
+**PROCEEDED** — 5 drift checks cleared:
+
+| Check | Result |
+|---|---|
+| `AgentResult` already has `finalTierKey`? | **No.** 6 existing fields: `text`, `toolCalls`, `tokenUsage`, `duration`, `iterations`, `stopReason`. Grep confirms `finalTierKey` appears only in `PHASED_PLAN.md`. |
+| `runAgent` has a place to track current tier across iterations? | **Yes.** `resolution` variable (L218) is reassigned on fallback swap (L323: `resolution = nextResolution`). At loop exit, `resolution.tierKey` reflects the last-swapped tier. |
+| `recordAgentCompletion()` accepts `finalTierKey` today? | **No.** Current 3-param signature; P02c adds optional 4th param `finalTierKey?: string` (Option A — additive, minimal blast). |
+| Other `recordAgentCompletion` callers besides email-compose? | **No.** Single production caller at `email-compose.ts:368`. |
+| Other `runAgent` callers that consume `AgentResult`? | **Yes — 4** (`email-compose-assist`, `wiki-lint`, `wiki-ingest`, `monthly-reflection`). All use legacy `client+model` path; none call `recordAgentCompletion`. Optional field is backward-compatible. |
+
+---
+
+## 2. Current-State Baseline
+
+### 2.1 `AgentResult` (`run-agent.ts` L78-91)
+
+```ts
+AgentResult {
+  text: string
+  toolCalls: AgentToolCall[]
+  tokenUsage: AgentTokenUsage
+  duration: number
+  iterations: number
+  stopReason: string
+}
+```
+
+### 2.2 `recordAgentCompletion()` (`llm-gateway.ts` L807-814)
+
+```ts
+async recordAgentCompletion(
+  taskName: string,
+  tierKey: string,   // initial, not final
+  result: { iterations, tokenUsage, latencyMs },
+): Promise<void>
+```
+
+Internally: `tier = this.configService.getModelTier(tierKey)` → derives `model` + `clientUsed` for the audit row. **`ai_audit_log` has NO `tier_key` column** — only `model` + `client_used` are written. No schema migration needed.
+
+### 2.3 `runAgent` swap logic
+
+- `let resolution` (L218) — reassigned on fallback swap at L323
+- `let client` (L324) — reassigned from `nextResolution.client`
+- `let model` (L325) — reassigned from `nextResolution.model`
+- Return at L440-447 — single injection point for `finalTierKey`
+
+### 2.4 Current email-compose call (`email-compose.ts:368`)
+
+```ts
+await this.llmGateway.recordAgentCompletion(EMAIL_COMPOSE_TASK, resolvedTierKey, { ... })
+```
+
+`resolvedTierKey` set at L318 from `agentResolution.tierKey` (initial).
+
+### 2.5 Existing test coverage
+
+- `email-compose-fault-injection.test.ts` L175-184: currently asserts `recordCall[1] === 't2_quality'` (INITIAL tier) with a comment documenting the known imprecision. P02c updates to also assert `recordCall[3] === 't1_fast'` (final/fallback tier).
+- `run-agent.test.ts` L782-814: fallback swap test asserts `result.text` + `result.iterations` but not `result.finalTierKey`. P02c extends.
+- `llm-gateway.test.ts` L187-228: `recordAgentCompletion` tests use 3-arg form; backward-compatible with new optional 4th param.
+
+---
+
+## 3. Work Items
+
+### 3.1 Add `finalTierKey?: string` to `AgentResult` and track across iterations
+
+**File:** `packages/shared/src/services/run-agent.ts`
+
+Interface addition (after L90):
+```ts
+/**
+ * Tier key of the tier that ultimately served the final iteration.
+ * Matches the initial resolved tier when no fallback swap occurred.
+ * Undefined when runAgent is called without a clientResolver (legacy path).
+ */
+finalTierKey?: string
+```
+
+Loop tracking — after L261 (before `while`):
+```ts
+let currentTierKey: string | undefined = resolution?.tierKey
+```
+
+After the swap assignment (after L325 `model = nextResolution.model`):
+```ts
+currentTierKey = nextResolution.tierKey
+```
+
+Return statement (L440) add:
+```ts
+finalTierKey: currentTierKey,
+```
+
+**Why optional not required:** 4 legacy callers don't use `clientResolver`. `currentTierKey` will be `undefined` in those runs. Optional field preserves backward compat.
+
+### 3.2 Update `recordAgentCompletion()` — optional 4th parameter
+
+**File:** `packages/shared/src/services/llm-gateway.ts`
+
+Add 4th parameter:
+```ts
+async recordAgentCompletion(
+  taskName: string,
+  tierKey: string,
+  result: { iterations, tokenUsage, latencyMs },
+  finalTierKey?: string,   // NEW
+): Promise<void> {
+  const effectiveTierKey = finalTierKey ?? tierKey
+  const tier = this.configService.getModelTier(effectiveTierKey)
+  // ... rest unchanged; all downstream flows (model, clientUsed, costUsd, logAudit) from tier lookup
+}
+```
+
+Also extend the `logger.info` context at L832 to include `finalTierKey: effectiveTierKey` so operators can see both in the log.
+
+**Why Option A over Option B:** P02c is Low severity. Additive signature change = zero breakage for existing callers. Replacing `tierKey` with full `AgentResult` would touch production + tests unnecessarily.
+
+### 3.3 Update email-compose.ts call site
+
+**File:** `packages/workers/src/skills/email-compose.ts` (L368)
+
+```ts
+await this.llmGateway.recordAgentCompletion(
+  EMAIL_COMPOSE_TASK,
+  resolvedTierKey,
+  {
+    iterations: agentResult.iterations,
+    tokenUsage: { input: agentResult.tokenUsage.inputTokens, output: agentResult.tokenUsage.outputTokens },
+    latencyMs: Date.now() - startMs,
+  },
+  agentResult.finalTierKey,   // NEW — undefined when no swap occurred; gateway falls back to tierKey
+)
+```
+
+No guard needed — the gateway's `finalTierKey ?? tierKey` handles the undefined case.
+
+### 3.4 Update fault-injection test
+
+**File:** `packages/workers/src/__tests__/email-compose-fault-injection.test.ts`
+
+In first test (fallback-to-success scenario):
+- Remove the explanatory imprecision-comment block (L171-183)
+- Keep the existing assertion `expect(recordCall[1]).toBe('t2_quality')` (initial tier param — unchanged)
+- Add new assertion:
+  ```ts
+  const finalTierKeyArg = recordCall[3] as string | undefined
+  expect(finalTierKeyArg).toBe('t1_fast')
+  ```
+- Update file-top test-description comment to reflect final-tier assertion now works
+
+Second test (exhausted chain) — no `recordAgentCompletion` call, no change.
+
+### 3.5 Extend run-agent.test.ts with finalTierKey assertions
+
+**File:** `packages/shared/src/services/__tests__/run-agent.test.ts`
+
+Three small additions:
+
+**3.5a** — Fallback swap test (L782-814): add
+```ts
+expect(result.finalTierKey).toBe('t1_fast')
+```
+
+**3.5b** — Legacy path test (L856-870): add
+```ts
+expect(result.finalTierKey).toBeUndefined()
+```
+
+**3.5c** — No-swap resolver test (L745-767): add
+```ts
+expect(result.finalTierKey).toBe('t2_quality')
+```
+
+---
+
+## 4. Acceptance Criteria
+
+- [ ] `AgentResult` interface has `finalTierKey?: string` field
+- [ ] `runAgent()` sets `finalTierKey` = initial tier key when no swap; = fallback tier key after successful swap; = `undefined` in legacy path
+- [ ] `recordAgentCompletion()` accepts optional 4th `finalTierKey?: string`; uses it for tier lookup when provided, else falls back to the 2nd `tierKey` param
+- [ ] `email-compose.ts` passes `agentResult.finalTierKey` as 4th arg
+- [ ] Fault-injection test asserts `recordCall[3] === 't1_fast'`
+- [ ] `run-agent.test.ts` extended with 3 new `finalTierKey` assertions
+- [ ] `pnpm --filter @open-brain/shared build && test`: green
+- [ ] `pnpm --filter @open-brain/workers build && test`: green
+- [ ] No schema migration (no `tier_key` column in `ai_audit_log`)
+- [ ] LAB_NOTEBOOK Entry 095 with Hypothesis + Rollback before first commit
+- [ ] PR body uses `Closes #122` bare (sole PR closes issue fully — no partial-closure gotcha)
+
+---
+
+## 5. Rollback Plan
+
+Single-commit atomic revert. `git revert <P02c-sha>` on main:
+- `AgentResult` loses `finalTierKey`; 4 non-gateway callers unaffected (optional field)
+- `recordAgentCompletion` loses 4th param; call sites passing it get TS2554 at next build
+- `email-compose.ts` reverts to 3-arg call
+- Tests revert assertions
+- Zero schema/compose change; zero-downtime revert
+
+---
+
+## 6. Test Plan
+
+```bash
+pnpm --filter @open-brain/shared build
+pnpm --filter @open-brain/shared test
+pnpm --filter @open-brain/workers build
+pnpm --filter @open-brain/workers test
+pnpm -r test   # regression
+```
+
+Expected: shared 277/277 + 3 assertion extensions (still 277 files, a few more assertions), workers 960/960 + 1 new assertion.
+
+---
+
+## 7. Homeserver Deploy Notes
+
+No compose/migration/env/config changes. Batch with A70.
+
+**Semantic refinement post-merge:** `ai_audit_log.model` for agent-loop rows written by `recordAgentCompletion` changes meaning — before P02c it was the initial tier's model; after P02c it's the tier that actually served. Operators doing historical cross-PR cost analysis should treat the P02c merge date as a semantic cutover marker. Not a schema change.
+
+---
+
+## 8. Operational Rules Candidates
+
+- **R-P02c-01:** Return-field additions to shared types must be optional (`field?: T`) unless all callers are updated in the same PR.
+- **R-P02c-02:** Gateway audit logs record the tier that *actually served* the request — not the initially-routed tier. Initial routing is config-queryable; audit captures execution.
+- **R-P02c-03:** Additive parameter changes to service methods append optional params to the signature; never reorder or replace existing params.

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -180,7 +180,7 @@
 | A66 | Drizzle pgEnum tightening for `source_type` | 2026-04-17 | Entry 084 | LOW — carried forward from tech-debt cleanup |
 | A67 | LLMGatewayService integration for email-compose (requires agent-loop rework) | 2026-04-17 | Entry 084 | MEDIUM — carried forward from tech-debt cleanup |
 | A68 | Python lint/typecheck CI for `scripts/` + `docker/ingest-sidecar/` | 2026-04-17 | Entry 084 | LOW — carried forward from tech-debt cleanup |
-| A69 | Execute PHASED_PLAN.md bootstrap (P01, P02a-c, P03) via ORCHESTRATOR.md 5-gate pipeline | 2026-04-18 | Entry 092 | CRITICAL — P01 + P02a + P02b merged (PRs #123, #124, #125); P02c + P03 remaining |
+| A69 | Execute PHASED_PLAN.md bootstrap (P01, P02a-c, P03) via ORCHESTRATOR.md 5-gate pipeline | 2026-04-18 | Entry 092 | CRITICAL — P01 + P02a + P02b merged (PRs #123, #124, #125); P02c in progress (Entry 095); P03 remaining |
 | A71 | Rename `memory-consolidation` task key from `'search_synthesis'` → `'memory_consolidation'` | 2026-04-18 | Entry 094 | MEDIUM — P02b-DRIFT3 follow-up. Requires new `task_routing` entry in `ai-routing.yaml` + skill update + audit log migration strategy. Deferred out of P02b scope. |
 | A72 | Partial-closure PR body convention — use `Refs #N` not `Closes #N (partial)`; manually close after final PR merges | 2026-04-18 | Entry 094 | LOW — process improvement. #102 auto-closed twice (P02a + P02b) despite "(partial)" wording. GitHub's parser ignores the qualifier. Apply to P03 PR body. |
 | A70 | Homeserver deploy batch — P01 + subsequent bootstrap phases (deferred for batching) | 2026-04-18 | Entry 092 | HIGH — deploy before running any real workload against new bootstrap changes |
@@ -6011,6 +6011,55 @@ The OpenAI path (`this.client.chat.completions.create(...)`) was always the only
 2. `Closes #N (partial)` triggers auto-close. Use `Refs #N` for partial-PR scenarios. Add manual close comment after final PR lands.
 
 **Status:** P02b ✅ COMPLETE. Orchestrator advances to P02c (recordAgentCompletion final-tier plumb-through — #122).
+
+---
+
+### Entry 095 — P02c Gate 1+2: AgentResult.finalTierKey plan authored — 2026-04-18
+
+**Tags:** [orchestrator] [phased-plan] [bootstrap] [llm-gateway] [agent-loop] [audit-log] [decision]
+**Environment:** Laptop (Windows, bash). Branch `feat/phase-P02c-final-tier-key` (created in this entry's commit). Main at `6e4be28` before branch.
+**Phase:** P02c of PHASED_PLAN.md (Wave 1, bootstrap phase 4 of 5 — LAST small phase before P03)
+**Issue:** #122
+**PR:** TBD (after Gate 3)
+
+**Objective:** Thread `finalTierKey` from `runAgent()` loop state through `AgentResult` → `email-compose.ts` → `recordAgentCompletion()` so the audit log records the tier that ACTUALLY served the call (not the initially-resolved tier). Closes #122. This is the follow-up that was deferred in PR #88 (Entry 088) when the swap-and-retry logic was added but the final-tier signal wasn't propagated back.
+
+**Hypothesis:** Adding `finalTierKey?: string` to `AgentResult` (initialized to the initial resolution's `tierKey`, overwritten at each fallback swap to `nextResolution.tierKey`) + adding an optional 4th parameter to `recordAgentCompletion()` + updating the single email-compose caller + extending 1 fault-injection test + 3 assertions in run-agent.test.ts = complete closure of #122. Expect `ai_audit_log` rows to reflect the fallback tier after a 429 retry succeeds on a lower-tier endpoint. No schema migration required (`ai_audit_log` has no `tier_key` column — only `model` + `client_used`, both derived from the effective tier lookup).
+
+Success criteria:
+- `pnpm --filter @open-brain/shared test`: 277/277 passing + 3 new `finalTierKey` assertions
+- `pnpm --filter @open-brain/workers test`: 960/960 passing + 1 new fault-injection assertion
+- Fault-injection test confirms `recordAgentCompletion` receives `'t1_fast'` as 4th arg when `t2_quality` → `t1_fast` swap occurs
+- Backward compat: 4 non-gateway `runAgent` callers (`email-compose-assist`, `wiki-lint`, `wiki-ingest`, `monthly-reflection`) continue to compile without modification
+- PR body: `Closes #122` (sole PR; issue closes fully — safe to use bare `Closes` per A72 convention)
+- No homeserver deploy gate 5.5 required
+
+**Rollback Plan:**
+1. `git revert <squash-sha>` — single atomic commit; pure TypeScript.
+2. `AgentResult.finalTierKey` disappears; 4 legacy callers unaffected (optional field).
+3. `recordAgentCompletion` 4th param disappears; call sites passing it get TS2554 at next build.
+4. `email-compose.ts` reverts to 3-arg call.
+5. Test assertions revert.
+6. Zero schema/compose change → zero-downtime revert.
+
+**Gate 1 scope drifts (5 cleared; PROCEEDED):**
+
+1. `AgentResult` has 6 fields currently, no `finalTierKey` anywhere — the field genuinely doesn't exist. P02c is not a no-op.
+2. `runAgent`'s `resolution` variable (L218) is reassigned on swap (L323: `resolution = nextResolution`). That's the capture point — update a loop-scoped `currentTierKey` at the same line.
+3. `recordAgentCompletion` has 3-param signature; P02c uses Option A (append optional 4th param) over Option B (replace with full AgentResult) because P02c is Low severity and additive signature changes keep blast radius minimal.
+4. Single production caller (`email-compose.ts:368`). Test fixtures + docs add 2 more refs. Scope is surgical.
+5. 4 non-gateway `runAgent` callers exist but use legacy `client+model` path — they don't call `recordAgentCompletion`. Optional-field design preserves their compile-time + runtime behavior.
+
+**Key design decision captured:** `ai_audit_log.model` semantics change meaning at P02c merge date — before, it recorded the *initial* routed tier's model; after, it records the tier that *ultimately served* the call. This is a semantic refinement, not a breaking schema change. Operators building historical cost dashboards across the P02c cutover should treat the merge date as a cutover marker.
+
+**What changed so far (Gate 1 + Gate 2):**
+- Created `IMPLEMENT_PHASE-P02c.md` — 5-work-item plan (AgentResult extension, gateway signature, email-compose call site, fault-injection assertion, run-agent test extensions).
+- Added LAB_NOTEBOOK Entry 095 (this entry).
+- Updated Action Item A69 (will reflect P02c in progress after commit).
+
+**Next (Gate 3):** dispatch `implement-executor` (Sonnet 4.6). Expected very small diff (~40 LoC net change across 5 files + test files). Single atomic commit recommended given co-dependencies.
+
+**Status:** Gate 2 in progress — committing plan + LAB_NOTEBOOK to `feat/phase-P02c-final-tier-key`.
 
 ---
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -6061,5 +6061,20 @@ Success criteria:
 
 **Status:** Gate 2 in progress — committing plan + LAB_NOTEBOOK to `feat/phase-P02c-final-tier-key`.
 
+#### Gate 3 — Work item 3.1 — COMPLETE
+Added `finalTierKey?: string` field to `AgentResult` interface in `run-agent.ts` with JSDoc. Added `let currentTierKey: string | undefined = resolution?.tierKey` before the while loop. Added `currentTierKey = nextResolution.tierKey` after the swap assignment. Updated return to include `finalTierKey: currentTierKey`. Shared build: clean. Shared tests: 277/277 passing.
+
+#### Gate 3 — Work item 3.2 — COMPLETE
+Added optional 4th parameter `finalTierKey?: string` to `recordAgentCompletion()` in `llm-gateway.ts`. First line of body: `const effectiveTierKey = finalTierKey ?? tierKey`. Changed tier lookup to use `effectiveTierKey`. Extended `logger.info` context to include `finalTierKey: effectiveTierKey`. Workers build: clean.
+
+#### Gate 3 — Work item 3.3 — COMPLETE
+Updated `recordAgentCompletion` call in `email-compose.ts` to multiline form, passing `agentResult.finalTierKey` as 4th arg. No guard needed — gateway's `finalTierKey ?? tierKey` handles undefined. Workers build: clean.
+
+#### Gate 3 — Work item 3.4 — COMPLETE
+Updated file-top comment to describe the 4th arg assertion. Removed the imprecision-comment block from Assertion 4 in the first test. Added `const finalTierKeyArg = recordCall[3]` and `expect(finalTierKeyArg).toBe('t1_fast')`. Updated type annotation on `recordCall` to include 4th element. Workers tests: 960/960 passing.
+
+#### Gate 3 — Work item 3.5 — COMPLETE
+Extended `run-agent.test.ts` with 3 assertions: (5a) fallback swap test — `expect(result.finalTierKey).toBe('t1_fast')`; (5b) legacy path test — `expect(result.finalTierKey).toBeUndefined()`; (5c) no-swap resolver test — `expect(result.finalTierKey).toBe('t2_quality')`. Shared tests: 277/277 passing (no new test cases added, assertions extended in-place).
+
 ---
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -6076,5 +6076,21 @@ Updated file-top comment to describe the 4th arg assertion. Removed the imprecis
 #### Gate 3 — Work item 3.5 — COMPLETE
 Extended `run-agent.test.ts` with 3 assertions: (5a) fallback swap test — `expect(result.finalTierKey).toBe('t1_fast')`; (5b) legacy path test — `expect(result.finalTierKey).toBeUndefined()`; (5c) no-swap resolver test — `expect(result.finalTierKey).toBe('t2_quality')`. Shared tests: 277/277 passing (no new test cases added, assertions extended in-place).
 
+#### Gate 3 — Overall result — ALL_COMPLETE
+
+**Result:** All 5 work items committed in one atomic commit (4959a6a). No surprises — the plan was precise and all co-dependencies resolved cleanly in a single pass.
+
+**Test counts:**
+- `@open-brain/shared`: 277/277 before → 277/277 after (3 new assertions in existing tests, no new test count)
+- `@open-brain/workers`: 960/960 before → 960/960 after (1 new assertion in existing test, no new test count)
+
+**Grep verification:** 12 occurrences of `finalTierKey` across shared and workers source + test files — all in expected locations.
+
+**What worked:** The plan's co-dependency analysis was correct — a single atomic commit was the right structure. The optional-field design (`finalTierKey?: string`) kept all 4 legacy callers untouched. The `currentTierKey` loop variable initialized from `resolution?.tierKey` naturally handles both the resolver path (defined) and legacy path (undefined). The `effectiveTierKey = finalTierKey ?? tierKey` fallback in the gateway is clean and requires no call-site guard.
+
+**What changed (semantic):** `ai_audit_log.model` and `client_used` now record the tier that *actually served* the agent call, not the initially-routed tier. This is a semantic refinement — not a schema change. P02c merge date (2026-04-19) is the cutover marker for historical cost analysis.
+
+**Status:** ALL_COMPLETE. Ready for Gate 4 (code-reviewer).
+
 ---
 

--- a/packages/shared/src/services/__tests__/run-agent.test.ts
+++ b/packages/shared/src/services/__tests__/run-agent.test.ts
@@ -765,6 +765,7 @@ describe('runAgent', () => {
       const [params] = createSpy.mock.calls[0]
       expect(params.model).toBe('claude-sonnet-resolved')
       expect(result.text).toBe('Done')
+      expect(result.finalTierKey).toBe('t2_quality')
     })
 
     it('invokes clientResolver exactly once at loop start', async () => {
@@ -811,6 +812,7 @@ describe('runAgent', () => {
       expect(fallbackParams.model).toBe('claude-haiku-fallback')
       expect(result.text).toBe('Recovered')
       expect(result.iterations).toBe(1)
+      expect(result.finalTierKey).toBe('t1_fast')
     })
 
     it('propagates the error when fallback chain is exhausted', async () => {
@@ -867,6 +869,7 @@ describe('runAgent', () => {
       const [params] = createSpy.mock.calls[0]
       expect(params.model).toBe('claude-legacy-model')
       expect(result.text).toBe('Legacy works')
+      expect(result.finalTierKey).toBeUndefined()
     })
   })
 })

--- a/packages/shared/src/services/llm-gateway.ts
+++ b/packages/shared/src/services/llm-gateway.ts
@@ -812,8 +812,10 @@ export class LLMGatewayService {
       tokenUsage: { input: number; output: number }
       latencyMs: number
     },
+    finalTierKey?: string,
   ): Promise<void> {
-    const tier = this.configService.getModelTier(tierKey)
+    const effectiveTierKey = finalTierKey ?? tierKey
+    const tier = this.configService.getModelTier(effectiveTierKey)
     const model = tier?.model ?? 'unknown'
     const clientUsed: AIClientType = tier ? this.resolveProviderClient(tier.provider) : 'litellm'
     const costUsd = estimateTierCostUsd(clientUsed, result.tokenUsage.input, result.tokenUsage.output)
@@ -833,6 +835,7 @@ export class LLMGatewayService {
       {
         task: taskName,
         tierKey,
+        finalTierKey: effectiveTierKey,
         model,
         iterations: result.iterations,
         inputTokens: result.tokenUsage.input,

--- a/packages/shared/src/services/run-agent.ts
+++ b/packages/shared/src/services/run-agent.ts
@@ -88,6 +88,12 @@ export interface AgentResult {
   iterations: number
   /** The stop reason from the final API response. */
   stopReason: string
+  /**
+   * Tier key of the tier that ultimately served the final iteration.
+   * Matches the initial resolved tier when no fallback swap occurred.
+   * Undefined when runAgent is called without a clientResolver (legacy path).
+   */
+  finalTierKey?: string
 }
 
 /** Options for runAgent(). */
@@ -259,6 +265,7 @@ export async function runAgent(
   let iteration = 0
   let lastStopReason = 'end_turn'
   let finalText = ''
+  let currentTierKey: string | undefined = resolution?.tierKey
 
   while (iteration < maxIterations) {
     iteration++
@@ -323,6 +330,7 @@ export async function runAgent(
       resolution = nextResolution
       client = nextResolution.client as Anthropic
       model = nextResolution.model
+      currentTierKey = nextResolution.tierKey
 
       // Retry once. If this also throws, the error propagates — no infinite loop.
       response = await client.messages.create(buildParams(), { signal: options?.abortSignal })
@@ -444,5 +452,6 @@ export async function runAgent(
     duration,
     iterations: iteration,
     stopReason: lastStopReason,
+    finalTierKey: currentTierKey,
   }
 }

--- a/packages/workers/src/__tests__/email-compose-fault-injection.test.ts
+++ b/packages/workers/src/__tests__/email-compose-fault-injection.test.ts
@@ -7,7 +7,8 @@
  *   3. runAgent calls resolution.fallback(), swaps to the fallback tier's
  *      Anthropic client, retries the same iteration, succeeds.
  *   4. After the loop, gateway.recordAgentCompletion is invoked with the
- *      final tier key (the one that succeeded).
+ *      initial tier key as 2nd arg and the final (succeeding) tier key as
+ *      the optional 4th arg (agentResult.finalTierKey = 't1_fast').
  *
  * This complements `run-agent.test.ts` (which tests the resolver path in
  * isolation) by exercising the full skill → gateway → runAgent wiring.
@@ -167,24 +168,22 @@ describe('email-compose fault injection — gateway fallback', () => {
     const fallbackCall = fallbackCreate.mock.calls[0] as unknown as [{ model: string }]
     expect(fallbackCall[0].model).toBe('claude-haiku-fallback')
 
-    // Assertion 4: recordAgentCompletion called with the final (succeeding) tier
-    // NOTE: The current implementation records with the *initial* resolved tier
-    // rather than the one that succeeded. We assert on what's actually recorded
-    // and flag it in the test as the observed behavior.
+    // Assertion 4: recordAgentCompletion called with initial tier as 2nd arg and
+    // final (succeeding) tier as optional 4th arg.
     expect(recordSpy).toHaveBeenCalledTimes(1)
     const recordCall = recordSpy.mock.calls[0] as unknown as [
       string,
       string,
       { iterations: number; tokenUsage: { input: number; output: number }; latencyMs: number },
+      string | undefined,
     ]
     expect(recordCall[0]).toBe('email_compose')
-    // Tier key recorded is the one the skill knows about at init time
-    // (t2_quality). This is acceptable: the gateway can cross-reference via
-    // ai_audit_log.model for the actual serving tier if needed.
     expect(recordCall[1]).toBe('t2_quality')
     expect(recordCall[2].iterations).toBe(1)
     expect(recordCall[2].tokenUsage).toEqual({ input: 100, output: 50 })
     expect(recordCall[2].latencyMs).toBeGreaterThanOrEqual(0)
+    const finalTierKeyArg = recordCall[3] as string | undefined
+    expect(finalTierKeyArg).toBe('t1_fast')
 
     // Assertion 5: skill completed without error
     expect(result.agentIterations).toBe(1)

--- a/packages/workers/src/skills/email-compose.ts
+++ b/packages/workers/src/skills/email-compose.ts
@@ -365,14 +365,19 @@ export class EmailComposeSkill extends LLMSkill<EmailComposeOptions, EmailCompos
     // break the caller's success path.
     if (this.llmGateway && resolvedTierKey) {
       try {
-        await this.llmGateway.recordAgentCompletion(EMAIL_COMPOSE_TASK, resolvedTierKey, {
-          iterations: agentResult.iterations,
-          tokenUsage: {
-            input: agentResult.tokenUsage.inputTokens,
-            output: agentResult.tokenUsage.outputTokens,
+        await this.llmGateway.recordAgentCompletion(
+          EMAIL_COMPOSE_TASK,
+          resolvedTierKey,
+          {
+            iterations: agentResult.iterations,
+            tokenUsage: {
+              input: agentResult.tokenUsage.inputTokens,
+              output: agentResult.tokenUsage.outputTokens,
+            },
+            latencyMs: Date.now() - startMs,
           },
-          latencyMs: Date.now() - startMs,
-        })
+          agentResult.finalTierKey,
+        )
       } catch (err) {
         logger.warn(
           { err: err instanceof Error ? err.message : String(err) },


### PR DESCRIPTION
## Summary

Bootstrap phase 4 of 5 — last small phase before P03. Threads `finalTierKey` from `runAgent()` loop state through `AgentResult` → `email-compose` → `recordAgentCompletion()` so the audit log records the tier that **actually served** the call (not the initially-resolved tier). Previously, if the primary tier 429'd and the call succeeded on a fallback, `ai_audit_log.model` recorded the primary — making historical cost analysis misleading.

Closes #122.

## Changes (~50 net insertions across 5 files)

- **`packages/shared/src/services/run-agent.ts`**: `AgentResult` gains optional `finalTierKey?: string`. A loop-scoped `currentTierKey` initializes from `resolution?.tierKey` and updates at each fallback swap (after `model = nextResolution.model`). Undefined in the legacy `client+model` path (4 non-gateway callers).
- **`packages/shared/src/services/llm-gateway.ts`**: `recordAgentCompletion()` gains optional 4th parameter `finalTierKey?: string`. Internally: `effectiveTierKey = finalTierKey ?? tierKey` for tier/model/client_used lookup. Logger context extended to include `finalTierKey` so operators see both initial + final in log lines.
- **`packages/workers/src/skills/email-compose.ts`**: call site passes `agentResult.finalTierKey` as the 4th arg. No guard needed — gateway handles `undefined` via `??`.
- **`email-compose-fault-injection.test.ts`**: imprecision comment removed; added `expect(recordCall[3] as string | undefined).toBe('t1_fast')` alongside the existing `recordCall[1] === 't2_quality'` initial-tier assertion.
- **`run-agent.test.ts`**: 3 new assertions — fallback swap asserts `finalTierKey === 't1_fast'`, legacy path asserts `undefined`, no-swap resolver path asserts `'t2_quality'`.

## Test plan

- [x] `pnpm --filter @open-brain/shared test`: **277/277** (unchanged; 3 new assertions extended existing tests)
- [x] `pnpm --filter @open-brain/workers test`: **960/960** (unchanged; 1 new assertion in fault-injection test)
- [x] `pnpm --filter @open-brain/shared build`: clean
- [x] `pnpm --filter @open-brain/workers build`: clean
- [ ] Homeserver deploy: batched with A70 (no compose/migration)

## No schema migration

`ai_audit_log` has no `tier_key` column — only `model` and `client_used`, both derived from the effective tier lookup. No DB changes. Semantic refinement only: post-merge, `ai_audit_log.model` for agent-loop rows written by `recordAgentCompletion` reflects the tier that ultimately served the call. Operators doing historical cost analysis should treat the P02c merge date as a semantic cutover marker.

## Rollback

Single-commit atomic revert. `git revert <squash-sha>`. `AgentResult.finalTierKey` disappears; 4 legacy callers unaffected (optional field). `recordAgentCompletion` 4th param disappears; any callers passing it get TS2554 at next build. Zero-downtime (no schema/compose change).

## References

- Plan: `IMPLEMENT_PHASE-P02c.md`
- Log: `LAB_NOTEBOOK.md` Entry 095
- Precursor: Entry 088 deferred this follow-up when runAgent's swap-and-retry logic was added in PR #88

## Bootstrap note

P01-P03 are bootstrap phases requiring operator approval at Gate 5 until P03 merges. Do NOT auto-merge. P02c is the last small phase — P03 is the critical estimator widening + Composio quota meter that closes the bootstrap entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)