### PR TITLE
P05: autonomy uniform through BaseSkill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,17 @@ After any non-trivial finding (container startup failure, networking quirk, pipe
 - `daily-sweep-skill` (8pm, LLM evening summary) is distinct from `daily-sweep` (3am stale-capture re-queuer). Different BullMQ queues/jobs.
 - Pipeline-health runs every 6h (`cron: 0 */6 * * *`). Capture-flow check alerts if no captures in 6h during active hours (7am–midnight), suppressed 24h if already sent (queries `skills_log`). Parses `REDIS_URL` (not `REDIS_HOST`, which isn't set in Docker) for internal Queue instances.
 - Auto-response handler is async fire-and-forget (`.then()/.catch()`) — never blocks capture/query/command. Autonomy level cached 5 min.
-- Autonomy levels (`app_settings.autonomy_level`): `observe` (default, notifications only) / `assist` (draft + notify) / `advise` (act + report) / `partner` (autonomous). Check via `meetsAutonomyLevel()` from shared.
+- Autonomy levels (`app_settings.autonomy_level`): `observe` (default, notifications only) / `assist` (draft + notify) / `advise` (act + report) / `partner` (autonomous). Check via `meetsAutonomyLevel(current, required)` from shared — pure sync ordinal comparison. Level fetched from `GET /api/v1/settings/autonomy_level` with a 5-min in-process module-level cache per package (slack-bot: `server.ts`, workers: `base-skill.ts`). Default on error: `observe`.
+- **BaseSkill autonomy gate (P05):** `BaseSkill.execute()` checks `static minimum_autonomy` before delegating to `protected abstract run()`. Current level below declared minimum → `execute()` returns `{ status: 'gated', durationMs: 0 }` and logs at INFO. Skills without `static minimum_autonomy` run ungated — reactive pipeline skills (wiki-ingest, extract-entities, stale-captures, etc.) must never declare it. **Never override `execute()` in subclasses — implement `run()`.**
+- **Proactive skills autonomy table (P05):**
+
+| Skill | minimum_autonomy | Rationale |
+|-------|-----------------|-----------|
+| `email-compose` | `advise` | Auto-send email — highest-impact action |
+| `memory-consolidation` | `assist` | Merges + soft-deletes captures destructively |
+| `daily-sweep-skill` | `assist` | Proactive LLM summary + Pushover delivery |
+| `weekly-brief` | `observe` | Informational report — safe at all levels |
+| slack-bot `auto-response` | (inline check, not BaseSkill) | Event handler, not a queued skill |
 - Hebbian co-access tracking is fire-and-forget (try/catch in `update-access-stats`). Association failures never block primary access updates.
 - Memory-consolidation skill is hyphenated `memory-consolidation` (cron `0 4 * * 0`). Merged captures use `source: 'consolidation'`; originals soft-deleted with `deleted_at`.
 - Search `include_related` defaults: **false (API, back-compat) / true (MCP, agents benefit from context).**

--- a/IMPLEMENT_PHASE-P05.md
+++ b/IMPLEMENT_PHASE-P05.md
@@ -1,0 +1,464 @@
+# IMPLEMENT_PHASE-P05 — Autonomy uniform through BaseSkill
+
+**Source card:** PHASED_PLAN.md § P05
+**Tracks issue:** #108 (full close — Theme 6: Autonomy false-uniform)
+**Effort estimate:** ~2 days
+**Branch (Gate 2 will create):** `feat/phase-P05-autonomy-uniform`
+**Gate 5 path:** operator-approval REQUIRED (touches CLAUDE.md + 20+ skill files)
+
+---
+
+## Investigation findings
+
+### BaseSkill shape today
+
+**File:** `packages/workers/src/skills/base-skill.ts` (lines 17–112)
+
+```typescript
+export abstract class BaseSkill<TInput, TResult extends BaseResult> {
+  protected db: Database
+  protected pushover: PushoverService
+  protected skillName: string
+
+  constructor(skillName: string, opts: BaseSkillOpts)
+
+  abstract execute(input: TInput): Promise<TResult>   // async, must return Promise<TResult>
+
+  protected async logResult(result, inputSummary, outputSummary?, captureId?): Promise<void>
+  protected async sendNotification(title, message, priority?): Promise<boolean>
+  protected formatDuration(ms: number): string
+  protected truncate(text: string, max = 100): string
+}
+```
+
+Key design observations:
+- `execute()` is **abstract** — subclasses implement it entirely (no template method / no `super.execute()` call).
+- There is **no existing static-member pattern** in BaseSkill (no `static name`, no `static task_routing_key`).
+- `LLMSkill` extends `BaseSkill` and is itself abstract; all LLM-heavy skills extend `LLMSkill`.
+- The `execute()` return type is `Promise<TResult>` where `TResult extends BaseResult` (minimum: `{ durationMs: number }`).
+
+**Critical implication:** Because `execute()` is abstract and subclasses implement it directly (not via a `run()` hook), adding a gate in BaseSkill requires either:
+- **Option A (recommended):** A non-abstract `execute()` on BaseSkill that calls an abstract `run()` (template method pattern). Subclasses rename `execute()` → `run()`.
+- **Option B:** Leave execute abstract, add a `checkAutonomyGate()` helper on BaseSkill that subclasses call at the top of their execute() — but this requires touching every proactive skill anyway and is opt-in at call-site (fragile).
+
+**Recommendation: Option A — template method.** BaseSkill gains a concrete `execute()` that checks `static minimum_autonomy` and returns `{status: 'gated', durationMs: 0}` if gated, then delegates to abstract `run()`. Subclasses move their execute body to `run()`. This is a mechanical rename for all subclasses (~19 files) but is correct, testable, and enforced at the framework level. Because `run()` is the new abstract, TypeScript prevents forgetting the implementation. Skills without `static minimum_autonomy` skip the gate entirely (reactive-safe).
+
+**Non-trivial refactor flag:** Renaming `execute()` → `run()` across 19+ skill files is mechanical but broad. The implementer must handle:
+- The `runSkill()` helper in `skill-execution.ts` calls `skill.execute(input)` — this now calls the concrete wrapper, which is correct.
+- Existing unit tests that instantiate concrete skill subclasses and call `.execute()` continue to work unchanged (public API preserved).
+- The abstract method signature changes from `execute(input: TInput): Promise<TResult>` to `protected abstract run(input: TInput): Promise<TResult>`. The `run()` method must be `protected` since external callers only use `execute()`.
+- The `ConcreteSkill` test helper in `base-skill.test.ts` must also rename `execute()` → `run()`.
+
+### Autonomy helper shape today
+
+**File:** `packages/shared/src/lib/autonomy.ts`
+
+```typescript
+export type AutonomyLevel = 'observe' | 'assist' | 'advise' | 'partner'
+export const AUTONOMY_LEVELS: AutonomyLevel[] = ['observe', 'assist', 'advise', 'partner']
+export const DEFAULT_AUTONOMY: AutonomyLevel = 'observe'
+
+export function meetsAutonomyLevel(current: AutonomyLevel, required: AutonomyLevel): boolean
+  // ordinal comparison: AUTONOMY_LEVELS.indexOf(current) >= AUTONOMY_LEVELS.indexOf(required)
+  // SYNC — no async, no DB, no network
+```
+
+Exported from `@open-brain/shared` via `lib/index.ts` → `src/index.ts` barrel.
+
+**There is NO `checkAutonomy('proactive')` function.** The card's reference to `checkAutonomy` is informal shorthand for calling `meetsAutonomyLevel(currentLevel, skill.static.minimum_autonomy)`. The implementer uses `meetsAutonomyLevel()` directly.
+
+**Caching:** The helper itself is stateless and synchronous. The autonomy level must be fetched from `app_settings` before calling `meetsAutonomyLevel()`. The slack-bot implements a 5-minute in-process cache for `getAutonomyLevel()` (`packages/slack-bot/src/server.ts` lines 24–52). BaseSkill will need the same pattern: a module-level cache for the autonomy level fetch.
+
+**How autonomy level is fetched:** Via HTTP `GET /api/v1/settings/autonomy_level` → `{ value: string }`. Validated against the 4 known levels; defaults to `'observe'` on error.
+
+**BaseSkill needs `coreApiUrl`:** The fetch requires the API URL. BaseSkillOpts does not currently include `coreApiUrl` — only `LLMSkillOpts` has it. For the 4 proactive skills, all are `LLMSkill` subclasses and already have `this.coreApiUrl`. The BaseSkill autonomy fetch should read `coreApiUrl` from:
+1. `process.env.OPEN_BRAIN_API_URL` (matches the `LLMSkill` default)
+2. Fallback `'http://localhost:3000'`
+
+This avoids adding `coreApiUrl` to `BaseSkillOpts` (which would require updating all 20 skill constructors).
+
+### Proactive skills inventory (P05 scope — exactly 4)
+
+| Skill | File | Class | Current autonomy check | Proposed minimum_autonomy |
+|-------|------|-------|------------------------|---------------------------|
+| email-compose | `packages/workers/src/skills/email-compose.ts` | `EmailComposeSkill` | None | `'advise'` |
+| memory-consolidation | `packages/workers/src/skills/memory-consolidation.ts` | `MemoryConsolidationSkill` | None | `'assist'` |
+| daily-sweep-skill | `packages/workers/src/skills/daily-sweep-skill.ts` | `DailySweepSkill` | None | `'assist'` |
+| weekly-brief | `packages/workers/src/skills/weekly-brief.ts` | `WeeklyBriefSkill` | None | `'observe'` |
+
+Rationale for `weekly-brief → observe`: Weekly brief is informational delivery (generates a report and emails/Pushover notifies). Per card: "observe (informational, safe at all levels)".
+
+### Proactive skills NOT in P05 scope — candidates for P05.1 follow-up
+
+| Skill | Class | Nature |
+|-------|-------|--------|
+| `daily-connections` | `DailyConnectionsSkill` | Proactive cron (weekly) |
+| `drift-monitor` | `DriftMonitorSkill` | Proactive cron (weekly) |
+| `morning-brief` | `MorningBriefSkill` | Proactive cron (daily 6am) |
+| `monthly-reflection` | `MonthlyReflectionSkill` | Proactive cron (monthly) |
+| `cost-analysis` | `CostAnalysisSkill` | Proactive cron (daily 7am) |
+| `capture-dedup-sweep` | `CaptureDedupSweepSkill` | Proactive cron (notifies only) |
+
+P05 gates exactly the 4 skills listed in the card. These 6 are documented for a P05.1 follow-up issue.
+
+### Reactive pipeline skills (MUST NOT be gated)
+
+These skills run as pipeline stages in response to user-triggered captures or as ops monitoring. Gating them at autonomy would stall the capture pipeline when `autonomy_level = observe` (the default):
+
+| Skill | Class | Trigger |
+|-------|-------|---------|
+| `wiki-ingest` | `WikiIngestSkill` | Pipeline stage (capture complete) |
+| `wiki-lint` | `WikiLintSkill` | Pipeline stage |
+| `wiki-synthesis` | `WikiSynthesisSkill` | Pipeline stage |
+| `capture-reminder` | `CaptureReminderSkill` | Cron — nudge notifications |
+| `pipeline-health` | `PipelineHealthSkill` | Ops cron — monitoring |
+| `container-health` | `ContainerHealthSkill` | Ops cron — monitoring |
+| `storage-audit` | `StorageAuditSkill` | Ops cron — reporting |
+| `secret-rotation` | `SecretRotationSkill` | Ops cron — security |
+| `stale-captures` | `StaleCapturesSkill` | Pipeline health |
+| `email-classify` | `EmailClassifySkill` | Pipeline stage (email ingestion) |
+
+**Design rule:** The gate is opt-in. `static minimum_autonomy` absent = ungated. Only skills that explicitly declare `static minimum_autonomy` are gated. This makes BaseSkill safe for all reactive pipeline skills without any changes to them.
+
+### Reference pattern: slack-bot auto-response
+
+**File:** `packages/slack-bot/src/handlers/auto-response.ts` lines 246–250 and 329–334
+
+```typescript
+// assist mode gate (line 247):
+if (
+  meetsAutonomyLevel(autonomyLevel, 'assist') &&
+  confidence.composite >= effectiveAssistThreshold &&
+  synthesis
+) { ... }
+
+// advise mode gate (line 330):
+if (
+  meetsAutonomyLevel(autonomyLevel, 'advise') &&
+  ...
+) { ... }
+```
+
+**Fetch + cache pattern** (`packages/slack-bot/src/server.ts` lines 24–52):
+
+```typescript
+let cachedAutonomyLevel: { level: AutonomyLevel; fetchedAt: number } | null = null
+const AUTONOMY_CACHE_TTL = 5 * 60 * 1000
+
+async function getAutonomyLevel(coreApiClient: CoreApiClient): Promise<AutonomyLevel> {
+  const now = Date.now()
+  if (cachedAutonomyLevel && now - cachedAutonomyLevel.fetchedAt < AUTONOMY_CACHE_TTL) {
+    return cachedAutonomyLevel.level
+  }
+  try {
+    const response = await fetch(`${process.env.CORE_API_URL}/api/v1/settings/autonomy_level`)
+    if (response.ok) {
+      const data = await response.json() as { value: string }
+      const level = (['observe', 'assist', 'advise', 'partner'].includes(data.value)
+        ? data.value : 'observe') as AutonomyLevel
+      cachedAutonomyLevel = { level, fetchedAt: now }
+      return level
+    }
+  } catch { /* default to observe */ }
+  cachedAutonomyLevel = { level: 'observe', fetchedAt: now }
+  return 'observe'
+}
+```
+
+BaseSkill will use an identical module-level cache pattern; the import of `meetsAutonomyLevel` and `AutonomyLevel` comes from `@open-brain/shared`.
+
+**Note on auto-response (slack-bot):** The slack-bot auto-response handler takes the autonomy level as a parameter passed in from `server.ts` (which fetches + caches it). It does NOT use BaseSkill and will NOT be changed by P05. There is no consolidation to do; it's architecturally different (event handler, not a queued skill).
+
+---
+
+## Work items
+
+### 1.1 — Augment BaseSkill with static minimum_autonomy hook
+
+**File:** `packages/workers/src/skills/base-skill.ts`
+
+**Design:**
+- Add module-level autonomy cache (mirrors slack-bot pattern)
+- Change `abstract execute()` to concrete; add `protected abstract run()`
+- `execute()` checks `static minimum_autonomy`; if absent, runs ungated; if present, fetches current level and compares
+- If gated, logs and returns `{ status: 'gated', durationMs: 0, ...}` cast to TResult
+- Export `_resetBaseSkillAutonomyCacheForTest()` for test isolation
+
+**Complete replacement for `base-skill.ts`:**
+
+```typescript
+import { skills_log, logger, PushoverService, meetsAutonomyLevel } from '@open-brain/shared'
+import type { Database, AutonomyLevel } from '@open-brain/shared'
+import type { BaseResult, BaseSkillOpts } from './types.js'
+
+// Module-level autonomy cache (5-minute TTL, matches slack-bot pattern)
+let _autonomyCache: { level: AutonomyLevel; fetchedAt: number } | null = null
+const AUTONOMY_CACHE_TTL = 5 * 60 * 1000
+
+async function fetchAutonomyLevel(coreApiUrl: string): Promise<AutonomyLevel> {
+  const now = Date.now()
+  if (_autonomyCache && now - _autonomyCache.fetchedAt < AUTONOMY_CACHE_TTL) {
+    return _autonomyCache.level
+  }
+  try {
+    const response = await fetch(`${coreApiUrl}/api/v1/settings/autonomy_level`)
+    if (response.ok) {
+      const data = (await response.json()) as { value: string }
+      const level = (['observe', 'assist', 'advise', 'partner'].includes(data.value)
+        ? data.value
+        : 'observe') as AutonomyLevel
+      _autonomyCache = { level, fetchedAt: now }
+      return level
+    }
+  } catch {
+    // Settings unavailable — default to observe (most restrictive)
+  }
+  _autonomyCache = { level: 'observe', fetchedAt: now }
+  return 'observe'
+}
+
+export function _resetBaseSkillAutonomyCacheForTest(): void {
+  _autonomyCache = null
+}
+
+export abstract class BaseSkill<TInput, TResult extends BaseResult> {
+  protected db: Database
+  protected pushover: PushoverService
+  protected skillName: string
+
+  // Declare a minimum autonomy level for proactive skills.
+  // Absence = ungated (reactive pipeline skills are safe).
+  static minimum_autonomy?: AutonomyLevel
+
+  constructor(skillName: string, opts: BaseSkillOpts) {
+    this.skillName = skillName
+    this.db = opts.db
+    this.pushover = opts.pushover ?? new PushoverService()
+  }
+
+  async execute(input: TInput): Promise<TResult> {
+    const ctor = this.constructor as typeof BaseSkill
+    const minimumAutonomy = ctor.minimum_autonomy
+
+    if (minimumAutonomy !== undefined) {
+      const coreApiUrl = process.env.OPEN_BRAIN_API_URL ?? 'http://localhost:3000'
+      const currentLevel = await fetchAutonomyLevel(coreApiUrl)
+
+      if (!meetsAutonomyLevel(currentLevel, minimumAutonomy)) {
+        logger.info(
+          { skillName: this.skillName, currentLevel, minimumAutonomy },
+          `[base-skill] gated — autonomy ${currentLevel} < required ${minimumAutonomy}`,
+        )
+        return {
+          status: 'gated',
+          durationMs: 0,
+          currentAutonomyLevel: currentLevel,
+          requiredAutonomyLevel: minimumAutonomy,
+        } as unknown as TResult
+      }
+    }
+
+    return this.run(input)
+  }
+
+  protected abstract run(input: TInput): Promise<TResult>
+
+  // ... (logResult, sendNotification, formatDuration, truncate unchanged)
+}
+```
+
+**`BaseResult` addition (types.ts):**
+```typescript
+export interface BaseResult {
+  durationMs: number
+  notificationSent?: boolean
+  status?: 'gated'  // set by BaseSkill.execute() when autonomy gate blocks execution
+}
+```
+
+---
+
+### 1.2 — Rename execute() → run() on all BaseSkill subclasses
+
+Mechanical rename — no logic changes. Method must be `protected run()`.
+
+Affected files and classes (20 total):
+
+| # | Skill file | Class |
+|--:|-----------|-------|
+| 1 | `email-compose.ts` | `EmailComposeSkill` |
+| 2 | `memory-consolidation.ts` | `MemoryConsolidationSkill` |
+| 3 | `daily-sweep-skill.ts` | `DailySweepSkill` |
+| 4 | `weekly-brief.ts` | `WeeklyBriefSkill` |
+| 5 | `capture-reminder.ts` | `CaptureReminderSkill` |
+| 6 | `container-health.ts` | `ContainerHealthSkill` |
+| 7 | `cost-analysis.ts` | `CostAnalysisSkill` |
+| 8 | `daily-connections.ts` | `DailyConnectionsSkill` |
+| 9 | `drift-monitor.ts` | `DriftMonitorSkill` |
+| 10 | `email-classify.ts` | `EmailClassifySkill` |
+| 11 | `monthly-reflection.ts` | `MonthlyReflectionSkill` |
+| 12 | `morning-brief.ts` | `MorningBriefSkill` |
+| 13 | `pipeline-health.ts` | `PipelineHealthSkill` |
+| 14 | `secret-rotation.ts` | `SecretRotationSkill` |
+| 15 | `stale-captures.ts` | `StaleCapturesSkill` |
+| 16 | `storage-audit.ts` | `StorageAuditSkill` |
+| 17 | `wiki-ingest.ts` | `WikiIngestSkill` |
+| 18 | `wiki-lint.ts` | `WikiLintSkill` |
+| 19 | `wiki-synthesis.ts` | `WikiSynthesisSkill` |
+| 20 | `capture-dedup-sweep.ts` | `CaptureDedupSweepSkill` |
+
+**LLMSkill** (`llm-skill.ts`) is abstract and does NOT implement `execute()` — no change there.
+
+**Test helper `ConcreteSkill`** in `base-skill.test.ts` must also rename `execute()` → `run()`.
+
+External callers (`skill-execution.ts:runSkill()`, top-level `executeXxx()` functions) call `skill.execute()` which now routes through BaseSkill's concrete wrapper → `run()`. No changes needed in callers.
+
+---
+
+### 1.3 — Declare static minimum_autonomy on each of the 4 proactive skills
+
+After the rename in 1.2, add the static declaration inside the class body (before the constructor):
+
+**`EmailComposeSkill`** (`email-compose.ts`):
+```typescript
+static minimum_autonomy: AutonomyLevel = 'advise'
+```
+
+**`MemoryConsolidationSkill`** (`memory-consolidation.ts`):
+```typescript
+static minimum_autonomy: AutonomyLevel = 'assist'
+```
+
+**`DailySweepSkill`** (`daily-sweep-skill.ts`):
+```typescript
+static minimum_autonomy: AutonomyLevel = 'assist'
+```
+
+**`WeeklyBriefSkill`** (`weekly-brief.ts`):
+```typescript
+static minimum_autonomy: AutonomyLevel = 'observe'
+```
+
+Import required in each skill file:
+```typescript
+import type { AutonomyLevel } from '@open-brain/shared'
+```
+
+---
+
+### 1.4 — Unit tests per proactive skill + BaseSkill gate tests
+
+**New test file:** `packages/workers/src/__tests__/base-skill-autonomy.test.ts`
+
+8 tests:
+1. Runs ungated when `static minimum_autonomy` is absent (no fetch called)
+2. Returns gated result when current level < minimum (observe < assist)
+3. Runs when current level equals minimum (assist == assist)
+4. Runs when current level exceeds minimum (advise > assist)
+5. Gates correctly for advise minimum (assist < advise)
+6. Never gates when `minimum_autonomy = observe` (always-safe)
+7. Caches the autonomy level for 5 minutes (fetch called exactly once for two execute calls)
+8. Defaults to observe when fetch fails (throw → observe → gates when minimum > observe)
+
+**Mock pattern** (per CLAUDE.md rule):
+```typescript
+vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+  ok: true,
+  json: vi.fn().mockResolvedValue({ value: 'observe' }),
+} as Response)
+```
+Use `vi.fn().mockResolvedValue(x)` not `async () => x`.
+
+**Additions to existing per-skill test files** (`describe('autonomy gate', …)` block):
+
+- `memory-consolidation.test.ts` — 3 tests (gated at observe, runs at assist, runs at partner)
+- `daily-sweep-skill.test.ts` — 3 tests (same pattern, minimum 'assist')
+- `weekly-brief.test.ts` — 2 tests (runs at observe, runs at partner — always-safe)
+- `email-compose.test.ts` — 4 tests (gated at observe, gated at assist, runs at advise, runs at partner)
+
+`beforeEach` in all autonomy blocks: `_resetBaseSkillAutonomyCacheForTest()`.
+
+---
+
+### 1.5 — CLAUDE.md autonomy semantics update
+
+**Section to update:** `## Pipeline / workers / skills`
+
+**Current text (one bullet):**
+```
+- Autonomy levels (`app_settings.autonomy_level`): `observe` (default, notifications only) / `assist` (draft + notify) / `advise` (act + report) / `partner` (autonomous). Check via `meetsAutonomyLevel()` from shared.
+```
+
+**Replace with (three bullets + table):**
+```
+- Autonomy levels (`app_settings.autonomy_level`): `observe` (default, notifications only) / `assist` (draft + notify) / `advise` (act + report) / `partner` (autonomous). Check via `meetsAutonomyLevel(current, required)` from shared — pure sync ordinal comparison. Level fetched from `GET /api/v1/settings/autonomy_level` with a 5-min in-process module-level cache per package (slack-bot: `server.ts`, workers: `base-skill.ts`). Default on error: `observe`.
+- **BaseSkill autonomy gate (P05):** `BaseSkill.execute()` checks `static minimum_autonomy` before delegating to `protected abstract run()`. Current level below declared minimum → `execute()` returns `{ status: 'gated', durationMs: 0 }` and logs at INFO. Skills without `static minimum_autonomy` run ungated — reactive pipeline skills (wiki-ingest, extract-entities, stale-captures, etc.) must never declare it. **Never override `execute()` in subclasses — implement `run()`.**
+- **Proactive skills autonomy table (P05):**
+
+| Skill | minimum_autonomy | Rationale |
+|-------|-----------------|-----------|
+| `email-compose` | `advise` | Auto-send email — highest-impact action |
+| `memory-consolidation` | `assist` | Merges + soft-deletes captures destructively |
+| `daily-sweep-skill` | `assist` | Proactive LLM summary + Pushover delivery |
+| `weekly-brief` | `observe` | Informational report — safe at all levels |
+| slack-bot `auto-response` | (inline check, not BaseSkill) | Event handler, not a queued skill |
+```
+
+---
+
+### 1.6 — LAB_NOTEBOOK Entry 099
+
+Append pre-action entry with Objective / Hypothesis / Rollback (see template in ORCHESTRATOR.md); finalize Result after implementation.
+
+---
+
+## Acceptance criteria (Gate 4 reviewer verifies)
+
+- [ ] `BaseSkill.execute()` is concrete; `protected abstract run()` replaces the former abstract `execute()`. TypeScript compiles (`tsc --noEmit`).
+- [ ] All 4 proactive skills declare `static minimum_autonomy` per card.
+- [ ] All 20 subclasses + `ConcreteSkill` test helper have `execute()` renamed to `protected run()` with no logic changes.
+- [ ] `_resetBaseSkillAutonomyCacheForTest()` exported from `base-skill.ts`.
+- [ ] `BaseResult` gains `status?: 'gated'` in `types.ts`.
+- [ ] `base-skill-autonomy.test.ts` passes (8 tests).
+- [ ] `memory-consolidation.test.ts` +3, `daily-sweep-skill.test.ts` +3, `weekly-brief.test.ts` +2, `email-compose.test.ts` +4 tests pass.
+- [ ] slack-bot `auto-response` still works — inline check unchanged (no regression).
+- [ ] `pnpm --filter @open-brain/workers run test` passes.
+- [ ] `pnpm --filter @open-brain/slack-bot run test` passes.
+- [ ] CLAUDE.md has the new autonomy table + "opt-in gate" rule + BaseSkill gate description.
+- [ ] LAB_NOTEBOOK Entry 099 present with full pre-action + finalized Result.
+
+---
+
+## Rollback
+
+`git revert <P05 merge sha>` — no data / schema consequence. Skills fall back to previous unguarded behavior. `app_settings.autonomy_level` remains readable (unused). Revert is safe without maintenance window.
+
+---
+
+## Scope drift check
+
+**Card scope matches: YES.**
+- 4 named skills exactly in scope.
+- execute→run rename is required by the template-method approach (card implies a BaseSkill hook, which requires this).
+- BaseResult `status?: 'gated'` addition is a natural consequence of the gated return shape.
+
+**Scope creep to defer (P05.1 candidates):**
+- Consolidating slack-bot `auto-response` inline check into BaseSkill hook — auto-response is not a BaseSkill subclass; consolidation is a multi-day refactor and out of P05 scope.
+- Adding `minimum_autonomy` to 6 other proactive skills (`daily-connections`, `drift-monitor`, `morning-brief`, `monthly-reflection`, `cost-analysis`, `capture-dedup-sweep`) — open a P05.1 issue.
+- Settings page UI for autonomy-level selector — explicit future work.
+
+---
+
+## Scope divergence
+
+None detected. BaseSkill exists; all 4 named skills exist; `meetsAutonomyLevel()` helper exists. The template-method refactor is non-trivial (20+ files) but mechanically straightforward.
+
+---
+
+## Post-merge CLAUDE.md rule candidates (for doc-sweep)
+
+1. **Proactive skills MUST declare `static minimum_autonomy: AutonomyLevel`; reactive pipeline skills MUST NOT. Absence = unconditional execution.**
+2. **Never override `execute()` in BaseSkill subclasses — implement `protected run()` instead.**
+3. **Gated return shape:** `{ status: 'gated', durationMs: 0, currentAutonomyLevel, requiredAutonomyLevel }`.
+4. **Test cache reset:** `_resetBaseSkillAutonomyCacheForTest()` in `beforeEach` for autonomy-gate tests.
+5. **Module-level autonomy cache per-package** (not Redis — not a distributed concern).

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -6696,3 +6696,31 @@ Commits: `b0c7cd7` (1.1 backup.sh patch), `eb5da9d` (1.2 test script).
 
 
 
+
+## Entry 099 — P05: autonomy uniform through BaseSkill
+
+**Date:** 2026-04-19
+**Phase:** P05 (ORCHESTRATOR.md gate 3)
+**Tags:** [workers] [autonomy] [architecture] [skills]
+**Environment:** laptop (Windows / bash); target = homeserver workers container
+**Duration:** (fill on completion)
+
+### Objective
+Template-method refactor of BaseSkill to add an opt-in autonomy gate. BaseSkill.execute() becomes concrete gate wrapper; subclasses implement protected abstract run(). 4 proactive skills declare static minimum_autonomy (email-compose: advise, memory-consolidation: assist, daily-sweep-skill: assist, weekly-brief: observe). 16 reactive/ops skills remain ungated (no static declaration).
+
+### Hypothesis
+After P05, setting app_settings.autonomy_level='observe' (default) causes email-compose, memory-consolidation, and daily-sweep-skill to return {status: 'gated', durationMs: 0} without executing. weekly-brief continues to run (minimum='observe'). Reactive pipeline skills (wiki-ingest, extract-entities, stale-captures, etc.) unaffected. 8 new BaseSkill gate tests + 12 per-skill gate tests pass. CLAUDE.md table reflects the 4 proactive-skill minimums + the opt-in-gate rule.
+
+### Rollback plan
+`git revert <P05 merge sha>` on main. No data / schema consequence — gates are in-memory checks only. app_settings.autonomy_level remains readable. Skills fall back to previous unguarded behavior. Safe without maintenance window.
+
+### Result
+All tests pass. Final test count: 980 (baseline 960, +20 new tests).
+
+Files touched (26 total): base-skill.ts (rewrite), types.ts, 20 skill files (execute-to-run rename), 4 proactive skills (minimum_autonomy), base-skill.test.ts, NEW base-skill-autonomy.test.ts, memory-consolidation.test.ts (+3), daily-sweep-skill.test.ts (+3, 2 assertions updated), weekly-brief.test.ts (+2), email-compose.test.ts (+4), email-compose-fault-injection.test.ts, CLAUDE.md.
+
+Deviations from plan: (1) Existing test fetch mocks needed URL-awareness - makeSkill helpers stub a single fetch that the autonomy gate now hits first. Fixed by routing settings URL to autonomy response. (2) Two daily-sweep assertions updated to filter by captures URL since autonomy gate adds an extra fetch call. (3) email-compose-fault-injection.test.ts needed fetch mock (not in plan).
+
+Duration: ~2 hours
+
+---

--- a/packages/workers/src/__tests__/base-skill-autonomy.test.ts
+++ b/packages/workers/src/__tests__/base-skill-autonomy.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BaseSkill, _resetBaseSkillAutonomyCacheForTest } from '../skills/base-skill.js'
+import type { BaseResult, BaseSkillOpts } from '../skills/types.js'
+import type { AutonomyLevel } from '@open-brain/shared'
+
+// ============================================================
+// Test subclasses
+// ============================================================
+
+interface GateInput {
+  value: string
+}
+
+interface GateResult extends BaseResult {
+  value: string
+}
+
+/** Ungated — no static minimum_autonomy declared */
+class UngatedSkill extends BaseSkill<GateInput, GateResult> {
+  constructor(opts: BaseSkillOpts) {
+    super('ungated-skill', opts)
+  }
+
+  protected async run(input: GateInput): Promise<GateResult> {
+    return { value: input.value, durationMs: 0 }
+  }
+}
+
+/** Gated at 'assist' */
+class AssistGatedSkill extends BaseSkill<GateInput, GateResult> {
+  static minimum_autonomy: AutonomyLevel = 'assist'
+
+  constructor(opts: BaseSkillOpts) {
+    super('assist-gated-skill', opts)
+  }
+
+  protected async run(input: GateInput): Promise<GateResult> {
+    return { value: input.value, durationMs: 0 }
+  }
+}
+
+/** Gated at 'advise' */
+class AdviseGatedSkill extends BaseSkill<GateInput, GateResult> {
+  static minimum_autonomy: AutonomyLevel = 'advise'
+
+  constructor(opts: BaseSkillOpts) {
+    super('advise-gated-skill', opts)
+  }
+
+  protected async run(input: GateInput): Promise<GateResult> {
+    return { value: input.value, durationMs: 0 }
+  }
+}
+
+/** Gated at 'observe' — always allowed */
+class ObserveGatedSkill extends BaseSkill<GateInput, GateResult> {
+  static minimum_autonomy: AutonomyLevel = 'observe'
+
+  constructor(opts: BaseSkillOpts) {
+    super('observe-gated-skill', opts)
+  }
+
+  protected async run(input: GateInput): Promise<GateResult> {
+    return { value: input.value, durationMs: 0 }
+  }
+}
+
+// ============================================================
+// Mock helpers
+// ============================================================
+
+function makeDb() {
+  return {
+    execute: vi.fn().mockResolvedValue({ rows: [] }),
+    insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+  }
+}
+
+function makeSkillOpts(): BaseSkillOpts {
+  return { db: makeDb() as unknown as import('@open-brain/shared').Database }
+}
+
+function mockFetchAutonomy(level: string) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({ value: level }),
+  } as unknown as Response)
+}
+
+function mockFetchAutonomyError() {
+  return vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fetch failed'))
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('BaseSkill autonomy gate', () => {
+  beforeEach(() => {
+    _resetBaseSkillAutonomyCacheForTest()
+    vi.restoreAllMocks()
+  })
+
+  it('runs ungated when static minimum_autonomy is absent (no fetch called)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const skill = new UngatedSkill(makeSkillOpts())
+
+    const result = await skill.execute({ value: 'hello' })
+
+    expect(result.value).toBe('hello')
+    expect(result.status).toBeUndefined()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns gated result when current level < minimum (observe < assist)', async () => {
+    mockFetchAutonomy('observe')
+    const skill = new AssistGatedSkill(makeSkillOpts())
+
+    const result = await skill.execute({ value: 'test' })
+
+    expect(result.status).toBe('gated')
+    expect(result.durationMs).toBe(0)
+    expect((result as unknown as Record<string, unknown>).currentAutonomyLevel).toBe('observe')
+    expect((result as unknown as Record<string, unknown>).requiredAutonomyLevel).toBe('assist')
+    // run() was NOT called — no value
+    expect(result.value).toBeUndefined()
+  })
+
+  it('runs when current level equals minimum (assist == assist)', async () => {
+    mockFetchAutonomy('assist')
+    const skill = new AssistGatedSkill(makeSkillOpts())
+
+    const result = await skill.execute({ value: 'equal' })
+
+    expect(result.status).toBeUndefined()
+    expect(result.value).toBe('equal')
+  })
+
+  it('runs when current level exceeds minimum (advise > assist)', async () => {
+    mockFetchAutonomy('advise')
+    const skill = new AssistGatedSkill(makeSkillOpts())
+
+    const result = await skill.execute({ value: 'above' })
+
+    expect(result.status).toBeUndefined()
+    expect(result.value).toBe('above')
+  })
+
+  it('gates correctly for advise minimum (assist < advise)', async () => {
+    mockFetchAutonomy('assist')
+    const skill = new AdviseGatedSkill(makeSkillOpts())
+
+    const result = await skill.execute({ value: 'should-gate' })
+
+    expect(result.status).toBe('gated')
+    expect((result as unknown as Record<string, unknown>).currentAutonomyLevel).toBe('assist')
+    expect((result as unknown as Record<string, unknown>).requiredAutonomyLevel).toBe('advise')
+  })
+
+  it('never gates when minimum_autonomy = observe (always-safe)', async () => {
+    mockFetchAutonomy('observe')
+    const skill = new ObserveGatedSkill(makeSkillOpts())
+
+    const result = await skill.execute({ value: 'always-runs' })
+
+    expect(result.status).toBeUndefined()
+    expect(result.value).toBe('always-runs')
+  })
+
+  it('caches the autonomy level for 5 minutes (fetch called exactly once for two execute calls)', async () => {
+    const fetchSpy = mockFetchAutonomy('assist')
+    const skill = new AssistGatedSkill(makeSkillOpts())
+
+    // Two execute calls — cache should prevent second fetch
+    await skill.execute({ value: 'first' })
+    await skill.execute({ value: 'second' })
+
+    expect(fetchSpy.mock.calls.length).toBe(1)
+  })
+
+  it('defaults to observe when fetch fails (throw → observe → gates when minimum > observe)', async () => {
+    mockFetchAutonomyError()
+    const skill = new AssistGatedSkill(makeSkillOpts())
+
+    // fetch throws → defaults to 'observe' → assist > observe → gated
+    const result = await skill.execute({ value: 'fail' })
+
+    expect(result.status).toBe('gated')
+    expect((result as unknown as Record<string, unknown>).currentAutonomyLevel).toBe('observe')
+  })
+})

--- a/packages/workers/src/__tests__/base-skill.test.ts
+++ b/packages/workers/src/__tests__/base-skill.test.ts
@@ -21,7 +21,7 @@ class ConcreteSkill extends BaseSkill<TestInput, TestResult> {
     super('test-skill', opts)
   }
 
-  async execute(input: TestInput): Promise<TestResult> {
+  protected async run(input: TestInput): Promise<TestResult> {
     const startMs = Date.now()
     const output = `processed: ${input.value}`
     const durationMs = Date.now() - startMs
@@ -67,7 +67,7 @@ class ConcreteLLMSkill extends LLMSkill<TestInput, TestResult> {
     super('test-llm-skill', opts)
   }
 
-  async execute(input: TestInput): Promise<TestResult> {
+  protected async run(input: TestInput): Promise<TestResult> {
     const startMs = Date.now()
     const template = this.renderTemplate('test.txt', { value: input.value })
     const durationMs = Date.now() - startMs

--- a/packages/workers/src/__tests__/daily-sweep-skill.test.ts
+++ b/packages/workers/src/__tests__/daily-sweep-skill.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../skills/daily-sweep-skill.js'
 import type { DailySweepOutput, VoiceStats } from '../skills/daily-sweep-skill.js'
 import { PushoverService } from '../services/pushover.js'
+import { _resetBaseSkillAutonomyCacheForTest } from '../skills/base-skill.js'
 
 // Prompt templates live at <repo-root>/config/prompts/
 const REPO_PROMPTS_DIR = join(import.meta.dirname, '..', '..', '..', '..', 'config', 'prompts')
@@ -152,11 +153,22 @@ function makeSkill(opts: {
   const pushover = makePushoverService(opts.pushoverConfigured ?? true)
 
   const fetchResponse = opts.coreApiResponse ?? { ok: true, json: { id: 'saved-cap-id' } }
-  const mockFetch = vi.fn().mockResolvedValue({
-    ok: fetchResponse.ok,
-    status: fetchResponse.status ?? (fetchResponse.ok ? 200 : 500),
-    json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
-    text: vi.fn().mockResolvedValue(''),
+  // URL-aware fetch mock: autonomy settings call returns partner level; all other calls use coreApiResponse
+  const mockFetch = vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/v1/settings/autonomy_level')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ value: 'partner' }),
+        text: vi.fn().mockResolvedValue(''),
+      })
+    }
+    return Promise.resolve({
+      ok: fetchResponse.ok,
+      status: fetchResponse.status ?? (fetchResponse.ok ? 200 : 500),
+      json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
+      text: vi.fn().mockResolvedValue(''),
+    })
   })
 
   const skill = new DailySweepSkill({
@@ -445,6 +457,7 @@ describe('queryNewEntities', () => {
 
 describe('DailySweepSkill', () => {
   beforeEach(() => {
+    _resetBaseSkillAutonomyCacheForTest()
     vi.restoreAllMocks()
   })
 
@@ -463,7 +476,11 @@ describe('DailySweepSkill', () => {
       const { skill, mockFetch } = makeSkill()
       const result = await skill.execute()
       expect(result.savedCaptureId).toBeNull()
-      expect(mockFetch).not.toHaveBeenCalled()
+      // Autonomy gate calls fetch for settings check; captures POST should not be called
+      const capturePostCalls = mockFetch.mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('/api/v1/captures'),
+      )
+      expect(capturePostCalls).toHaveLength(0)
     })
 
     it('returns savedCaptureId when storeCapture is true', async () => {
@@ -511,7 +528,11 @@ describe('DailySweepSkill', () => {
         expect.objectContaining({ method: 'POST' }),
       )
 
-      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      // Find the captures POST call (autonomy gate may also call fetch first)
+      const capturePostCall = mockFetch.mock.calls.find(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('/api/v1/captures'),
+      )
+      const fetchBody = JSON.parse(capturePostCall[1].body)
       expect(fetchBody.capture_type).toBe('reflection')
       expect(fetchBody.brain_view).toBe('personal')
       expect(fetchBody.tags).toEqual(['daily-sweep', 'skill-output'])
@@ -665,6 +686,74 @@ describe('DailySweepSkill', () => {
       ;(mockLitellm.chat.completions.create as MockInstance).mockRejectedValue(new Error('Request timed out'))
 
       await expect(skill.execute()).rejects.toThrow('Request timed out')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Autonomy gate (P05)
+  // ----------------------------------------------------------
+
+  describe('autonomy gate', () => {
+    beforeEach(() => {
+      _resetBaseSkillAutonomyCacheForTest()
+      vi.restoreAllMocks()
+    })
+
+    it('gates at observe level (minimum_autonomy = assist)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ value: 'observe' }),
+      } as unknown as Response)
+      const skill = new DailySweepSkill({
+        db: makeMockDb() as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+      })
+
+      const result = await skill.execute()
+
+      expect(result.status).toBe('gated')
+      expect(result.durationMs).toBe(0)
+    })
+
+    it('runs at assist level (meets minimum_autonomy = assist)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ value: 'assist' }),
+      } as unknown as Response)
+      const skill = new DailySweepSkill({
+        db: makeMockDb() as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+      })
+      // @ts-ignore — inject litellm for test
+      skill.litellmClient = {
+        chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: JSON.stringify(SAMPLE_OUTPUT) } }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }) } },
+      }
+
+      const result = await skill.execute()
+
+      expect(result.status).toBeUndefined()
+    })
+
+    it('runs at partner level (exceeds minimum_autonomy = assist)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ value: 'partner' }),
+      } as unknown as Response)
+      const skill = new DailySweepSkill({
+        db: makeMockDb() as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+      })
+      // @ts-ignore — inject litellm for test
+      skill.litellmClient = {
+        chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: JSON.stringify(SAMPLE_OUTPUT) } }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }) } },
+      }
+
+      const result = await skill.execute()
+
+      expect(result.status).toBeUndefined()
     })
   })
 })

--- a/packages/workers/src/__tests__/daily-sweep-skill.test.ts
+++ b/packages/workers/src/__tests__/daily-sweep-skill.test.ts
@@ -726,8 +726,8 @@ describe('DailySweepSkill', () => {
         promptsDir: REPO_PROMPTS_DIR,
         coreApiUrl: 'http://localhost:3000',
       })
-      // @ts-ignore — inject litellm for test
-      skill.litellmClient = {
+      // inject litellm for test
+      ;(skill as unknown as { litellmClient: unknown }).litellmClient = {
         chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: JSON.stringify(SAMPLE_OUTPUT) } }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }) } },
       }
 
@@ -746,8 +746,8 @@ describe('DailySweepSkill', () => {
         promptsDir: REPO_PROMPTS_DIR,
         coreApiUrl: 'http://localhost:3000',
       })
-      // @ts-ignore — inject litellm for test
-      skill.litellmClient = {
+      // inject litellm for test
+      ;(skill as unknown as { litellmClient: unknown }).litellmClient = {
         chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: JSON.stringify(SAMPLE_OUTPUT) } }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }) } },
       }
 

--- a/packages/workers/src/__tests__/email-compose-fault-injection.test.ts
+++ b/packages/workers/src/__tests__/email-compose-fault-injection.test.ts
@@ -114,6 +114,11 @@ describe('email-compose fault injection — gateway fallback', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.restoreAllMocks()
+    // Stub fetch so autonomy gate (minimum_autonomy='advise') passes
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ value: 'partner' }),
+    } as unknown as Response)
   })
 
   it('swaps to the fallback tier on 429 and records completion with the succeeding tier', async () => {

--- a/packages/workers/src/__tests__/email-compose.test.ts
+++ b/packages/workers/src/__tests__/email-compose.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Database, ConfigService } from '@open-brain/shared'
+import { _resetBaseSkillAutonomyCacheForTest } from '../skills/base-skill.js'
 
 // ---------------------------------------------------------------------------
 // Mock DB
@@ -235,6 +236,11 @@ describe('EmailComposeSkill model resolution', () => {
   beforeEach(async () => {
     vi.resetModules()
     runAgentMock.mockReset()
+    // Stub fetch so autonomy gate (minimum_autonomy='advise') passes for all model-resolution tests
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ value: 'partner' }),
+    } as unknown as Response)
     const skillMod = await import('../skills/email-compose.js')
     EmailComposeSkill = skillMod.EmailComposeSkill
     const sharedMod = await import('@open-brain/shared')
@@ -342,3 +348,102 @@ describe('EmailComposeSkill model resolution', () => {
     expect(runAgentOpts.model).toBe('claude-override-xyz')
   })
 })
+
+// ---------------------------------------------------------------------------
+// EmailComposeSkill autonomy gate (P05)
+// Uses vi.resetModules() like the model-resolution tests to get a fresh module
+// instance. Fetch is set up per-test to control the autonomy level.
+// ---------------------------------------------------------------------------
+
+describe('EmailComposeSkill autonomy gate', () => {
+  let EmailComposeSkill: typeof import('../skills/email-compose.js').EmailComposeSkill
+  let resetAutonomyCache: () => void
+
+  beforeEach(async () => {
+    vi.resetModules()
+    runAgentMock.mockReset()
+    const skillMod = await import('../skills/email-compose.js')
+    EmailComposeSkill = skillMod.EmailComposeSkill
+    const baseSkillMod = await import('../skills/base-skill.js')
+    resetAutonomyCache = baseSkillMod._resetBaseSkillAutonomyCacheForTest
+    resetAutonomyCache()
+    vi.restoreAllMocks()
+  })
+
+  function makeEmailSkill() {
+    return new EmailComposeSkill({
+      db: makeDb(),
+      configService: makeConfigService('claude-sonnet-4-6'),
+      anthropicClient: {} as never,
+    })
+  }
+
+  it('gates at observe level (minimum_autonomy = advise)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ value: 'observe' }),
+    } as unknown as Response)
+    const skill = makeEmailSkill()
+
+    const result = await skill.execute({ instruction: 'send email' })
+
+    expect(result.status).toBe('gated')
+    expect(result.durationMs).toBe(0)
+    expect(runAgentMock).not.toHaveBeenCalled()
+  })
+
+  it('gates at assist level (minimum_autonomy = advise, assist < advise)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ value: 'assist' }),
+    } as unknown as Response)
+    const skill = makeEmailSkill()
+
+    const result = await skill.execute({ instruction: 'send email' })
+
+    expect(result.status).toBe('gated')
+    expect(result.durationMs).toBe(0)
+    expect(runAgentMock).not.toHaveBeenCalled()
+  })
+
+  it('runs at advise level (meets minimum_autonomy = advise)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ value: 'advise' }),
+    } as unknown as Response)
+    runAgentMock.mockResolvedValue({
+      iterations: 1,
+      toolCalls: [],
+      finalMessage: { role: 'assistant', content: [] },
+      stopReason: 'end_turn',
+      totalTokens: { input: 10, output: 10 },
+    })
+    const skill = makeEmailSkill()
+
+    const result = await skill.execute({ instruction: 'send email' })
+
+    expect(result.status).toBeUndefined()
+    expect(runAgentMock).toHaveBeenCalledOnce()
+  })
+
+  it('runs at partner level (exceeds minimum_autonomy = advise)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ value: 'partner' }),
+    } as unknown as Response)
+    runAgentMock.mockResolvedValue({
+      iterations: 1,
+      toolCalls: [],
+      finalMessage: { role: 'assistant', content: [] },
+      stopReason: 'end_turn',
+      totalTokens: { input: 10, output: 10 },
+    })
+    const skill = makeEmailSkill()
+
+    const result = await skill.execute({ instruction: 'send email' })
+
+    expect(result.status).toBeUndefined()
+    expect(runAgentMock).toHaveBeenCalledOnce()
+  })
+})
+

--- a/packages/workers/src/__tests__/memory-consolidation.test.ts
+++ b/packages/workers/src/__tests__/memory-consolidation.test.ts
@@ -4,6 +4,7 @@ import { MemoryConsolidationSkill } from '../skills/memory-consolidation.js'
 import type { MemoryConsolidationOptions, ConsolidationLLMOutput } from '../skills/memory-consolidation.js'
 import { PushoverService } from '@open-brain/shared'
 import type { LLMGatewayService } from '@open-brain/shared'
+import { _resetBaseSkillAutonomyCacheForTest } from '../skills/base-skill.js'
 
 // Prompt templates live at <repo-root>/config/prompts/
 const REPO_PROMPTS_DIR = join(import.meta.dirname, '..', '..', '..', '..', 'config', 'prompts')
@@ -134,11 +135,22 @@ function makeSkillWithGateway(opts: {
   const pushover = makeMockPushover(false)
 
   const fetchResponse = opts.coreApiResponse ?? { ok: true, json: { id: 'new-consolidated-cap-id' } }
-  const mockFetch = vi.fn().mockResolvedValue({
-    ok: fetchResponse.ok,
-    status: fetchResponse.ok ? 200 : 500,
-    json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
-    text: vi.fn().mockResolvedValue(''),
+  // URL-aware fetch mock: autonomy settings call returns partner level; all other calls use coreApiResponse
+  const mockFetch = vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/v1/settings/autonomy_level')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ value: 'partner' }),
+        text: vi.fn().mockResolvedValue(''),
+      })
+    }
+    return Promise.resolve({
+      ok: fetchResponse.ok,
+      status: fetchResponse.ok ? 200 : 500,
+      json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
+      text: vi.fn().mockResolvedValue(''),
+    })
   })
   vi.stubGlobal('fetch', mockFetch)
 
@@ -164,11 +176,22 @@ function makeSkillWithLitellm(opts: {
   const mockLitellm = makeMockOpenAI(opts.llmResponse ?? SAMPLE_LLM_OUTPUT)
   const pushover = makeMockPushover(false)
 
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    json: vi.fn().mockResolvedValue({ id: 'new-litellm-cap-id' }),
-    text: vi.fn().mockResolvedValue(''),
+  // URL-aware fetch mock: autonomy settings call returns partner level; all other calls return litellm cap id
+  vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/v1/settings/autonomy_level')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ value: 'partner' }),
+        text: vi.fn().mockResolvedValue(''),
+      })
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ id: 'new-litellm-cap-id' }),
+      text: vi.fn().mockResolvedValue(''),
+    })
   }))
 
   const skill = new MemoryConsolidationSkill({
@@ -190,6 +213,7 @@ function makeSkillWithLitellm(opts: {
 
 describe('MemoryConsolidationSkill', () => {
   beforeEach(() => {
+    _resetBaseSkillAutonomyCacheForTest()
     vi.restoreAllMocks()
     vi.mocked(findConsolidationCandidates).mockResolvedValue({
       clusters: [SAMPLE_CLUSTER],
@@ -310,6 +334,67 @@ describe('MemoryConsolidationSkill', () => {
       await skill.execute()
 
       expect(db.insert).toHaveBeenCalled()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Autonomy gate (P05)
+  // ----------------------------------------------------------
+
+  describe('autonomy gate', () => {
+    beforeEach(() => {
+      _resetBaseSkillAutonomyCacheForTest()
+      vi.restoreAllMocks()
+      vi.mocked(findConsolidationCandidates).mockResolvedValue(EMPTY_QUERY_RESULT)
+    })
+
+    it('gates at observe level (minimum_autonomy = assist)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ value: 'observe' }),
+      } as unknown as Response)
+      const skill = new MemoryConsolidationSkill({
+        db: makeMockDb([]) as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+      })
+
+      const result = await skill.execute()
+
+      expect(result.status).toBe('gated')
+      expect(result.durationMs).toBe(0)
+    })
+
+    it('runs at assist level (meets minimum_autonomy = assist)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ value: 'assist' }),
+      } as unknown as Response)
+      const skill = new MemoryConsolidationSkill({
+        db: makeMockDb([]) as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+      })
+
+      const result = await skill.execute()
+
+      expect(result.status).toBeUndefined()
+    })
+
+    it('runs at partner level (exceeds minimum_autonomy = assist)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ value: 'partner' }),
+      } as unknown as Response)
+      const skill = new MemoryConsolidationSkill({
+        db: makeMockDb([]) as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+      })
+
+      const result = await skill.execute()
+
+      expect(result.status).toBeUndefined()
     })
   })
 })

--- a/packages/workers/src/__tests__/weekly-brief.test.ts
+++ b/packages/workers/src/__tests__/weekly-brief.test.ts
@@ -697,7 +697,8 @@ describe('WeeklyBriefSkill', () => {
     })
 
     it('runs at observe level (minimum_autonomy = observe, always-safe)', async () => {
-      vi.spyOn(globalThis, 'fetch').mockImplementation((url: string) => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation((input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
         if (url.includes('/api/v1/settings/autonomy_level')) {
           return Promise.resolve({
             ok: true,
@@ -726,7 +727,8 @@ describe('WeeklyBriefSkill', () => {
     })
 
     it('runs at partner level (exceeds minimum_autonomy = observe)', async () => {
-      vi.spyOn(globalThis, 'fetch').mockImplementation((url: string) => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation((input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
         if (url.includes('/api/v1/settings/autonomy_level')) {
           return Promise.resolve({
             ok: true,

--- a/packages/workers/src/__tests__/weekly-brief.test.ts
+++ b/packages/workers/src/__tests__/weekly-brief.test.ts
@@ -5,6 +5,7 @@ import type { WeeklyBriefOutput } from '../skills/weekly-brief.js'
 import { PushoverService, HimalayaService } from '@open-brain/shared'
 import type { LLMGatewayService } from '@open-brain/shared'
 import { EmailService } from '../services/email.js'
+import { _resetBaseSkillAutonomyCacheForTest } from '../skills/base-skill.js'
 
 // Prompt templates live at <repo-root>/config/prompts/ — go up two levels from packages/workers
 const REPO_PROMPTS_DIR = join(import.meta.dirname, '..', '..', '..', '..', 'config', 'prompts')
@@ -147,11 +148,22 @@ function makeSkillWithGateway(opts: {
   const himalaya = makeHimalayaService(false)
 
   const fetchResponse = opts.coreApiResponse ?? { ok: true, json: { id: 'saved-cap-id' } }
-  const mockFetch = vi.fn().mockResolvedValue({
-    ok: fetchResponse.ok,
-    status: fetchResponse.ok ? 200 : 500,
-    json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
-    text: vi.fn().mockResolvedValue(''),
+  // URL-aware fetch mock: autonomy settings returns observe (always passes for weekly-brief); other calls use coreApiResponse
+  const mockFetch = vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/v1/settings/autonomy_level')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ value: 'observe' }),
+        text: vi.fn().mockResolvedValue(''),
+      })
+    }
+    return Promise.resolve({
+      ok: fetchResponse.ok,
+      status: fetchResponse.ok ? 200 : 500,
+      json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
+      text: vi.fn().mockResolvedValue(''),
+    })
   })
   vi.stubGlobal('fetch', mockFetch)
 
@@ -186,13 +198,23 @@ function makeSkill(opts: {
   const email = makeEmailService(opts.emailConfigured ?? true)
   const himalaya = makeHimalayaService(opts.himalayaConfigured ?? false)
 
-  // Mock fetch for save-brief-capture
+  // Mock fetch — URL-aware: autonomy settings returns observe (always passes for weekly-brief); other calls use coreApiResponse
   const fetchResponse = opts.coreApiResponse ?? { ok: true, json: { id: 'saved-cap-id' } }
-  const mockFetch = vi.fn().mockResolvedValue({
-    ok: fetchResponse.ok,
-    status: fetchResponse.status ?? (fetchResponse.ok ? 200 : 500),
-    json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
-    text: vi.fn().mockResolvedValue(''),
+  const mockFetch = vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/v1/settings/autonomy_level')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ value: 'observe' }),
+        text: vi.fn().mockResolvedValue(''),
+      })
+    }
+    return Promise.resolve({
+      ok: fetchResponse.ok,
+      status: fetchResponse.status ?? (fetchResponse.ok ? 200 : 500),
+      json: vi.fn().mockResolvedValue(fetchResponse.json ?? {}),
+      text: vi.fn().mockResolvedValue(''),
+    })
   })
 
   const skill = new WeeklyBriefSkill({
@@ -220,6 +242,7 @@ function makeSkill(opts: {
 
 describe('WeeklyBriefSkill', () => {
   beforeEach(() => {
+    _resetBaseSkillAutonomyCacheForTest()
     vi.restoreAllMocks()
   })
 
@@ -660,6 +683,75 @@ describe('WeeklyBriefSkill', () => {
       expect(result).toHaveProperty('captureCount')
       expect(result).toHaveProperty('durationMs')
       expect(result).toHaveProperty('savedCaptureId')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // Autonomy gate (P05)
+  // ----------------------------------------------------------
+
+  describe('autonomy gate', () => {
+    beforeEach(() => {
+      _resetBaseSkillAutonomyCacheForTest()
+      vi.restoreAllMocks()
+    })
+
+    it('runs at observe level (minimum_autonomy = observe, always-safe)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation((url: string) => {
+        if (url.includes('/api/v1/settings/autonomy_level')) {
+          return Promise.resolve({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ value: 'observe' }),
+          } as unknown as Response)
+        }
+        return Promise.resolve({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ id: 'cap-id' }),
+        } as unknown as Response)
+      })
+      const skill = new WeeklyBriefSkill({
+        db: makeMockDb() as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+        himalaya: makeHimalayaService(false),
+        email: makeEmailService(false),
+      })
+      const mockLitellm = makeMockOpenAI()
+      // @ts-ignore
+      skill.litellmClient = mockLitellm
+
+      const result = await skill.execute({ emailTo: 'test@example.com' })
+
+      expect(result.status).toBeUndefined()
+    })
+
+    it('runs at partner level (exceeds minimum_autonomy = observe)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation((url: string) => {
+        if (url.includes('/api/v1/settings/autonomy_level')) {
+          return Promise.resolve({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ value: 'partner' }),
+          } as unknown as Response)
+        }
+        return Promise.resolve({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ id: 'cap-id' }),
+        } as unknown as Response)
+      })
+      const skill = new WeeklyBriefSkill({
+        db: makeMockDb() as unknown as import('@open-brain/shared').Database,
+        promptsDir: REPO_PROMPTS_DIR,
+        coreApiUrl: 'http://localhost:3000',
+        himalaya: makeHimalayaService(false),
+        email: makeEmailService(false),
+      })
+      const mockLitellm = makeMockOpenAI()
+      // @ts-ignore
+      skill.litellmClient = mockLitellm
+
+      const result = await skill.execute({ emailTo: 'test@example.com' })
+
+      expect(result.status).toBeUndefined()
     })
   })
 })

--- a/packages/workers/src/skills/base-skill.ts
+++ b/packages/workers/src/skills/base-skill.ts
@@ -1,6 +1,36 @@
-import { skills_log, logger, PushoverService } from '@open-brain/shared'
-import type { Database } from '@open-brain/shared'
+import { skills_log, logger, PushoverService, meetsAutonomyLevel } from '@open-brain/shared'
+import type { Database, AutonomyLevel } from '@open-brain/shared'
 import type { BaseResult, BaseSkillOpts } from './types.js'
+
+// Module-level autonomy cache (5-minute TTL, matches slack-bot pattern)
+let _autonomyCache: { level: AutonomyLevel; fetchedAt: number } | null = null
+const AUTONOMY_CACHE_TTL = 5 * 60 * 1000
+
+async function fetchAutonomyLevel(coreApiUrl: string): Promise<AutonomyLevel> {
+  const now = Date.now()
+  if (_autonomyCache && now - _autonomyCache.fetchedAt < AUTONOMY_CACHE_TTL) {
+    return _autonomyCache.level
+  }
+  try {
+    const response = await fetch(`${coreApiUrl}/api/v1/settings/autonomy_level`)
+    if (response.ok) {
+      const data = (await response.json()) as { value: string }
+      const level = (['observe', 'assist', 'advise', 'partner'].includes(data.value)
+        ? data.value
+        : 'observe') as AutonomyLevel
+      _autonomyCache = { level, fetchedAt: now }
+      return level
+    }
+  } catch {
+    // Settings unavailable — default to observe (most restrictive)
+  }
+  _autonomyCache = { level: 'observe', fetchedAt: now }
+  return 'observe'
+}
+
+export function _resetBaseSkillAutonomyCacheForTest(): void {
+  _autonomyCache = null
+}
 
 /**
  * BaseSkill — abstract base class for all Open Brain skills.
@@ -11,13 +41,21 @@ import type { BaseResult, BaseSkillOpts } from './types.js'
  * - `sendNotification()` — Pushover with error handling (20/27 skills)
  * - `formatDuration()` / `truncate()` — common formatting utilities
  *
- * Subclasses implement `execute(input)` with their domain logic.
+ * Subclasses implement `run(input)` with their domain logic.
+ * The `execute()` method is a concrete template-method wrapper that checks
+ * `static minimum_autonomy` before delegating to `run()`.
+ * Never override `execute()` in subclasses — implement `run()`.
+ *
  * The return type must extend `BaseResult` (at minimum includes `durationMs`).
  */
 export abstract class BaseSkill<TInput, TResult extends BaseResult> {
   protected db: Database
   protected pushover: PushoverService
   protected skillName: string
+
+  // Declare a minimum autonomy level for proactive skills.
+  // Absence = ungated (reactive pipeline skills are safe).
+  static minimum_autonomy?: AutonomyLevel
 
   constructor(skillName: string, opts: BaseSkillOpts) {
     this.skillName = skillName
@@ -26,9 +64,39 @@ export abstract class BaseSkill<TInput, TResult extends BaseResult> {
   }
 
   /**
-   * Execute the skill's core logic. Subclasses must implement this.
+   * Template-method wrapper. Checks `static minimum_autonomy` before delegating
+   * to `run()`. Do NOT override this in subclasses — implement `run()` instead.
    */
-  abstract execute(input: TInput): Promise<TResult>
+  async execute(input: TInput): Promise<TResult> {
+    const ctor = this.constructor as typeof BaseSkill
+    const minimumAutonomy = ctor.minimum_autonomy
+
+    if (minimumAutonomy !== undefined) {
+      const coreApiUrl = process.env.OPEN_BRAIN_API_URL ?? 'http://localhost:3000'
+      const currentLevel = await fetchAutonomyLevel(coreApiUrl)
+
+      if (!meetsAutonomyLevel(currentLevel, minimumAutonomy)) {
+        logger.info(
+          { skillName: this.skillName, currentLevel, minimumAutonomy },
+          `[base-skill] gated — autonomy ${currentLevel} < required ${minimumAutonomy}`,
+        )
+        return {
+          status: 'gated',
+          durationMs: 0,
+          currentAutonomyLevel: currentLevel,
+          requiredAutonomyLevel: minimumAutonomy,
+        } as unknown as TResult
+      }
+    }
+
+    return this.run(input)
+  }
+
+  /**
+   * Execute the skill's core logic. Subclasses must implement this.
+   * This is called by `execute()` after passing the autonomy gate.
+   */
+  protected abstract run(input: TInput): Promise<TResult>
 
   // ──────────────────────────────────────────────────────────────
   // Shared: skills_log

--- a/packages/workers/src/skills/base-skill.ts
+++ b/packages/workers/src/skills/base-skill.ts
@@ -66,8 +66,13 @@ export abstract class BaseSkill<TInput, TResult extends BaseResult> {
   /**
    * Template-method wrapper. Checks `static minimum_autonomy` before delegating
    * to `run()`. Do NOT override this in subclasses — implement `run()` instead.
+   *
+   * `input` is optional at the base layer to preserve backwards compatibility
+   * with subclasses whose `run()` declares a default value (e.g.,
+   * `run(opts: T = {})`). The optionality is normalized here and `run()` still
+   * receives whatever default the subclass defined.
    */
-  async execute(input: TInput): Promise<TResult> {
+  async execute(input?: TInput): Promise<TResult> {
     const ctor = this.constructor as typeof BaseSkill
     const minimumAutonomy = ctor.minimum_autonomy
 
@@ -89,7 +94,7 @@ export abstract class BaseSkill<TInput, TResult extends BaseResult> {
       }
     }
 
-    return this.run(input)
+    return this.run(input as TInput)
   }
 
   /**

--- a/packages/workers/src/skills/capture-dedup-sweep.ts
+++ b/packages/workers/src/skills/capture-dedup-sweep.ts
@@ -89,7 +89,7 @@ export class CaptureDedupSweepSkill extends BaseSkill<CaptureDedupSweepOptions, 
     super('capture-dedup-sweep', opts)
   }
 
-  async execute(options: CaptureDedupSweepOptions = {}): Promise<CaptureDedupSweepResult> {
+  protected async run(options: CaptureDedupSweepOptions = {}): Promise<CaptureDedupSweepResult> {
     const {
       similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD,
       maxPairs = DEFAULT_MAX_PAIRS,

--- a/packages/workers/src/skills/capture-reminder.ts
+++ b/packages/workers/src/skills/capture-reminder.ts
@@ -40,7 +40,7 @@ export class CaptureReminderSkill extends BaseSkill<CaptureReminderOptions, Capt
     super('capture-reminder', opts)
   }
 
-  async execute(options: CaptureReminderOptions): Promise<CaptureReminderResult> {
+  protected async run(options: CaptureReminderOptions): Promise<CaptureReminderResult> {
     const startMs = Date.now()
     const { mode } = options
 

--- a/packages/workers/src/skills/container-health.ts
+++ b/packages/workers/src/skills/container-health.ts
@@ -121,7 +121,7 @@ export class ContainerHealthSkill extends BaseSkill<ContainerHealthOptions, Cont
     this.endpoints = opts.endpoints ?? DEFAULT_ENDPOINTS
   }
 
-  async execute(options: ContainerHealthOptions = {}): Promise<ContainerHealthResult> {
+  protected async run(options: ContainerHealthOptions = {}): Promise<ContainerHealthResult> {
     const startMs = Date.now()
     const endpoints = options.endpoints ?? this.endpoints
     const consecutiveThreshold = options.consecutiveFailureThreshold ?? DEFAULT_CONSECUTIVE_FAILURE_THRESHOLD

--- a/packages/workers/src/skills/cost-analysis.ts
+++ b/packages/workers/src/skills/cost-analysis.ts
@@ -56,7 +56,7 @@ export class CostAnalysisSkill extends BaseSkill<CostAnalysisOptions, CostAnalys
     this.litellmApiKey = opts.litellmApiKey ?? process.env.LLM_SPEND_API_KEY ?? ''
   }
 
-  async execute(options: CostAnalysisOptions = {}): Promise<CostAnalysisResult> {
+  protected async run(options: CostAnalysisOptions = {}): Promise<CostAnalysisResult> {
     const startMs = Date.now()
     const now = options.now ?? new Date()
     const dailyAlertThreshold = options.dailyAlertThreshold ?? DEFAULT_DAILY_ALERT_THRESHOLD

--- a/packages/workers/src/skills/daily-connections.ts
+++ b/packages/workers/src/skills/daily-connections.ts
@@ -44,7 +44,7 @@ export class DailyConnectionsSkill extends LLMSkill<DailyConnectionsOptions, Dai
     this.wikiService = opts.wikiService ?? null
   }
 
-  async execute(options: DailyConnectionsOptions = {}): Promise<DailyConnectionsResult> {
+  protected async run(options: DailyConnectionsOptions = {}): Promise<DailyConnectionsResult> {
     const {
       windowDays: rawWindowDays = DEFAULT_WINDOW_DAYS,
       tokenBudget: rawTokenBudget = DEFAULT_TOKEN_BUDGET,

--- a/packages/workers/src/skills/daily-sweep-skill.ts
+++ b/packages/workers/src/skills/daily-sweep-skill.ts
@@ -48,7 +48,7 @@ export class DailySweepSkill extends LLMSkill<DailySweepOptions, DailySweepResul
     super('daily-sweep-skill', opts)
   }
 
-  async execute(options: DailySweepOptions = {}): Promise<DailySweepResult> {
+  protected async run(options: DailySweepOptions = {}): Promise<DailySweepResult> {
     const {
       tokenBudget: rawBudget = DEFAULT_TOKEN_BUDGET,
       storeCapture = false,

--- a/packages/workers/src/skills/daily-sweep-skill.ts
+++ b/packages/workers/src/skills/daily-sweep-skill.ts
@@ -1,4 +1,4 @@
-import type { Database, LLMGatewayService } from '@open-brain/shared'
+import type { Database, LLMGatewayService, AutonomyLevel } from '@open-brain/shared'
 import { logger } from '@open-brain/shared'
 import { LLMSkill } from './llm-skill.js'
 import type { LLMSkillOpts } from './types.js'
@@ -44,6 +44,8 @@ export {
  * save as capture, log to skills_log.
  */
 export class DailySweepSkill extends LLMSkill<DailySweepOptions, DailySweepResult> {
+  static minimum_autonomy: AutonomyLevel = 'assist'
+
   constructor(opts: LLMSkillOpts) {
     super('daily-sweep-skill', opts)
   }

--- a/packages/workers/src/skills/drift-monitor.ts
+++ b/packages/workers/src/skills/drift-monitor.ts
@@ -49,7 +49,7 @@ export class DriftMonitorSkill extends LLMSkill<DriftMonitorOptions, DriftMonito
     this.wikiService = opts.wikiService ?? null
   }
 
-  async execute(options: DriftMonitorOptions = {}): Promise<DriftMonitorResult> {
+  protected async run(options: DriftMonitorOptions = {}): Promise<DriftMonitorResult> {
     const {
       betActivityDays: rawBetDays = DEFAULT_BET_ACTIVITY_DAYS,
       commitmentDays: rawCommitDays = DEFAULT_COMMITMENT_DAYS,

--- a/packages/workers/src/skills/email-classify.ts
+++ b/packages/workers/src/skills/email-classify.ts
@@ -110,7 +110,7 @@ export class EmailClassifySkill extends BaseSkill<EmailClassifyOptions, EmailCla
     this.coreApiUrl = opts.coreApiUrl ?? process.env.OPEN_BRAIN_API_URL ?? 'http://localhost:3000'
   }
 
-  async execute(input: EmailClassifyOptions = {}): Promise<EmailClassifyResult> {
+  protected async run(input: EmailClassifyOptions = {}): Promise<EmailClassifyResult> {
     const startMs = Date.now()
     const providers = input.providers ?? ['hotmail', 'gmail']
     const sinceHours = input.sinceHours ?? 24

--- a/packages/workers/src/skills/email-compose.ts
+++ b/packages/workers/src/skills/email-compose.ts
@@ -286,7 +286,7 @@ export class EmailComposeSkill extends LLMSkill<EmailComposeOptions, EmailCompos
     }
   }
 
-  async execute(options: EmailComposeOptions): Promise<EmailComposeResult> {
+  protected async run(options: EmailComposeOptions): Promise<EmailComposeResult> {
     const startMs = Date.now()
     const instruction = options.instruction
     const coreApiUrl = options.coreApiUrl ?? this.coreApiUrl

--- a/packages/workers/src/skills/email-compose.ts
+++ b/packages/workers/src/skills/email-compose.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm'
 import type Anthropic from '@anthropic-ai/sdk'
-import type { Database } from '@open-brain/shared'
+import type { Database, AutonomyLevel } from '@open-brain/shared'
 import { logger, runAgent, resolveTaskModel, ModelResolverError } from '@open-brain/shared'
 import type { AgentTool, AgentResult, AgentClientResolution } from '@open-brain/shared'
 import { LLMSkill } from './llm-skill.js'
@@ -261,6 +261,8 @@ Always create the draft via the draft_email tool — do not just describe what y
  * `ConfigService`.
  */
 export class EmailComposeSkill extends LLMSkill<EmailComposeOptions, EmailComposeResult> {
+  static minimum_autonomy: AutonomyLevel = 'advise'
+
   /** Resolved concrete model string (e.g. `claude-sonnet-4-6`). */
   private readonly resolvedModel: string | null
   /** Tier key the task resolved to (e.g. `t2_quality`). Logged for observability. */

--- a/packages/workers/src/skills/memory-consolidation.ts
+++ b/packages/workers/src/skills/memory-consolidation.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm'
-import type { Database, LLMGatewayService } from '@open-brain/shared'
+import type { Database, LLMGatewayService, AutonomyLevel } from '@open-brain/shared'
 import { logger } from '@open-brain/shared'
 import { LLMSkill } from './llm-skill.js'
 import type { LLMSkillOpts, BaseResult } from './types.js'
@@ -88,6 +88,8 @@ interface CaptureRow {
  * query data, call LLM, persist results, deliver notification, log to skills_log.
  */
 export class MemoryConsolidationSkill extends LLMSkill<MemoryConsolidationOptions, MemoryConsolidationResult> {
+  static minimum_autonomy: AutonomyLevel = 'assist'
+
   constructor(opts: LLMSkillOpts) {
     super('memory-consolidation', opts)
   }

--- a/packages/workers/src/skills/memory-consolidation.ts
+++ b/packages/workers/src/skills/memory-consolidation.ts
@@ -92,7 +92,7 @@ export class MemoryConsolidationSkill extends LLMSkill<MemoryConsolidationOption
     super('memory-consolidation', opts)
   }
 
-  async execute(options: MemoryConsolidationOptions = {}): Promise<MemoryConsolidationResult> {
+  protected async run(options: MemoryConsolidationOptions = {}): Promise<MemoryConsolidationResult> {
     const {
       similarityThreshold,
       minClusterSize,

--- a/packages/workers/src/skills/monthly-reflection.ts
+++ b/packages/workers/src/skills/monthly-reflection.ts
@@ -290,7 +290,7 @@ export class MonthlyReflectionSkill extends BaseSkill<MonthlyReflectionOptions, 
     this.maxIterations = opts.maxIterations ?? 10
   }
 
-  async execute(options: MonthlyReflectionOptions = {}): Promise<MonthlyReflectionResult> {
+  protected async run(options: MonthlyReflectionOptions = {}): Promise<MonthlyReflectionResult> {
     const startMs = Date.now()
     const now = new Date()
     const windowStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)

--- a/packages/workers/src/skills/morning-brief.ts
+++ b/packages/workers/src/skills/morning-brief.ts
@@ -415,7 +415,7 @@ export class MorningBriefSkill extends BaseSkill<MorningBriefOptions, MorningBri
     this.composioPushover = opts.composioPushover
   }
 
-  async execute(options: MorningBriefOptions = {}): Promise<MorningBriefResult> {
+  protected async run(options: MorningBriefOptions = {}): Promise<MorningBriefResult> {
     const startMs = Date.now()
     const now = options.now ?? new Date()
 

--- a/packages/workers/src/skills/pipeline-health.ts
+++ b/packages/workers/src/skills/pipeline-health.ts
@@ -192,7 +192,7 @@ export class PipelineHealthSkill extends BaseSkill<PipelineHealthOptions, Pipeli
    *
    * Never throws — returns a degraded result on error.
    */
-  async execute(options: PipelineHealthOptions = {}): Promise<PipelineHealthResult> {
+  protected async run(options: PipelineHealthOptions = {}): Promise<PipelineHealthResult> {
     const {
       failureLookbackMinutes = DEFAULT_FAILURE_LOOKBACK_MINUTES,
       failedThreshold = DEFAULT_FAILED_THRESHOLD,

--- a/packages/workers/src/skills/secret-rotation.ts
+++ b/packages/workers/src/skills/secret-rotation.ts
@@ -109,7 +109,7 @@ export class SecretRotationSkill extends BaseSkill<SecretRotationOptions, Secret
    *
    * Never throws — returns a degraded result on error.
    */
-  async execute(options: SecretRotationOptions = {}): Promise<SecretRotationResult> {
+  protected async run(options: SecretRotationOptions = {}): Promise<SecretRotationResult> {
     const {
       maxAgeDays = DEFAULT_MAX_AGE_DAYS,
       bwsBinary = process.env.BWS_PATH ?? DEFAULT_BWS_BINARY,

--- a/packages/workers/src/skills/stale-captures.ts
+++ b/packages/workers/src/skills/stale-captures.ts
@@ -83,7 +83,7 @@ export class StaleCapturesSkill extends BaseSkill<StaleCapturesOptions, StaleCap
    * Non-fatal errors (individual re-queue failures, Pushover, skills_log) are
    * caught and logged — the skill does not throw on partial failure.
    */
-  async execute(options: StaleCapturesOptions = {}): Promise<StaleCapturesResult> {
+  protected async run(options: StaleCapturesOptions = {}): Promise<StaleCapturesResult> {
     const { thresholdMinutes = 60 } = options
     const startMs = Date.now()
 

--- a/packages/workers/src/skills/storage-audit.ts
+++ b/packages/workers/src/skills/storage-audit.ts
@@ -128,7 +128,7 @@ export class StorageAuditSkill extends BaseSkill<StorageAuditOptions, StorageAud
     this.execFn = opts.execFn ?? execFileAsync
   }
 
-  async execute(options: StorageAuditOptions = {}): Promise<StorageAuditResult> {
+  protected async run(options: StorageAuditOptions = {}): Promise<StorageAuditResult> {
     const startMs = Date.now()
     const now = options.now ?? new Date()
     const postgresContainer = options.postgresContainer ?? DEFAULT_POSTGRES_CONTAINER

--- a/packages/workers/src/skills/types.ts
+++ b/packages/workers/src/skills/types.ts
@@ -9,6 +9,7 @@ import type { Database, PushoverService, LLMGatewayService, TemplateCache, Confi
 export interface BaseResult {
   durationMs: number
   notificationSent?: boolean
+  status?: 'gated'  // set by BaseSkill.execute() when autonomy gate blocks execution
 }
 
 // ============================================================

--- a/packages/workers/src/skills/weekly-brief.ts
+++ b/packages/workers/src/skills/weekly-brief.ts
@@ -38,7 +38,7 @@ export class WeeklyBriefSkill extends LLMSkill<WeeklyBriefOptions, WeeklyBriefRe
     this.email = opts.email ?? new EmailService()
   }
 
-  async execute(options: WeeklyBriefOptions = {}): Promise<WeeklyBriefResult> {
+  protected async run(options: WeeklyBriefOptions = {}): Promise<WeeklyBriefResult> {
     const { windowDays = DEFAULT_WINDOW_DAYS, tokenBudget = DEFAULT_TOKEN_BUDGET, emailTo = process.env.WEEKLY_BRIEF_EMAIL } = options
     const startMs = Date.now()
     const now = new Date()

--- a/packages/workers/src/skills/weekly-brief.ts
+++ b/packages/workers/src/skills/weekly-brief.ts
@@ -1,4 +1,4 @@
-import type { Database, LLMGatewayService } from '@open-brain/shared'
+import type { Database, LLMGatewayService, AutonomyLevel } from '@open-brain/shared'
 import { logger, HimalayaService } from '@open-brain/shared'
 import { EmailService } from '../services/email.js'
 import { LLMSkill } from './llm-skill.js'
@@ -29,6 +29,8 @@ export interface WeeklyBriefSkillOpts extends LLMSkillOpts {
  * Email delivery chain: Himalaya (primary) -> nodemailer (fallback) -> Pushover (last resort).
  */
 export class WeeklyBriefSkill extends LLMSkill<WeeklyBriefOptions, WeeklyBriefResult> {
+  static minimum_autonomy: AutonomyLevel = 'observe'
+
   private himalaya: HimalayaService
   private email: EmailService
 

--- a/packages/workers/src/skills/wiki-ingest.ts
+++ b/packages/workers/src/skills/wiki-ingest.ts
@@ -247,7 +247,7 @@ export class WikiIngestSkill extends BaseSkill<string, WikiIngestResult> {
     )
   }
 
-  async execute(captureId: string): Promise<WikiIngestResult> {
+  protected async run(captureId: string): Promise<WikiIngestResult> {
     const startMs = Date.now()
 
     logger.info({ captureId }, '[wiki-ingest] starting execution')

--- a/packages/workers/src/skills/wiki-lint.ts
+++ b/packages/workers/src/skills/wiki-lint.ts
@@ -82,7 +82,7 @@ export class WikiLintSkill extends BaseSkill<void, WikiLintResult> {
     )
   }
 
-  async execute(_input?: void): Promise<WikiLintResult> {
+  protected async run(_input?: void): Promise<WikiLintResult> {
     const startMs = Date.now()
     const dateStr = new Date().toISOString().slice(0, 10)
 

--- a/packages/workers/src/skills/wiki-synthesis.ts
+++ b/packages/workers/src/skills/wiki-synthesis.ts
@@ -94,7 +94,7 @@ export class WikiSynthesisSkill extends BaseSkill<WikiSynthesisOptions, WikiSynt
     super('wiki-synthesis', opts)
   }
 
-  async execute(options: WikiSynthesisOptions = {}): Promise<WikiSynthesisResult> {
+  protected async run(options: WikiSynthesisOptions = {}): Promise<WikiSynthesisResult> {
     const startMs = Date.now()
     const lookbackHours = options.lookbackHours ?? 24
 


### PR DESCRIPTION
## Summary

- **BaseSkill template-method refactor:** `execute()` is now a concrete gate-check wrapper; subclasses implement `protected abstract run()`. Adds `static minimum_autonomy?: AutonomyLevel` opt-in. Absence = ungated (reactive pipeline skills unaffected).
- **4 proactive skills gated** per PHASED_PLAN.md § P05 card:
  - `EmailComposeSkill` → `'advise'`
  - `MemoryConsolidationSkill` → `'assist'`
  - `DailySweepSkill` → `'assist'`
  - `WeeklyBriefSkill` → `'observe'`
- **20 subclasses renamed** `execute()` → `protected run()` (mechanical, no logic change).
- **+20 tests** in workers (960 → 980) including a new `base-skill-autonomy.test.ts` (8 tests) plus per-skill autonomy blocks.
- **CLAUDE.md updated** with proactive-skills autonomy table + opt-in-gate design rule + 'never override execute()' instruction.

## Why

#108 (Theme 6 — Autonomy false-uniform). Before P05, all proactive skills ran unconditionally regardless of `app_settings.autonomy_level`. Setting autonomy to `observe` (default) did nothing to cron skills. P05 makes the gate uniform and framework-enforced.

Closes #108.

## Scope boundaries

- **Not gated (by design):** 16 reactive/ops skills (wiki-ingest, extract-entities, stale-captures, pipeline-health, etc.). No `static minimum_autonomy` → runs ungated.
- **Not touched:** slack-bot `auto-response` handler — uses inline `meetsAutonomyLevel()` check and is NOT a BaseSkill subclass. Its behavior is unchanged.
- **Deferred to P05.1 (new issue):** 6 additional proactive skills (`daily-connections`, `drift-monitor`, `morning-brief`, `monthly-reflection`, `cost-analysis`, `capture-dedup-sweep`) — out of card scope. They've been renamed `execute()→run()` (required by the framework refactor) but do NOT declare `static minimum_autonomy` yet.

## Test plan

- [x] `pnpm --filter @open-brain/workers run test` — 980 passing (+20 from baseline 960)
- [x] `pnpm --filter @open-brain/workers exec tsc --noEmit` — 0 errors in non-test sources (test files retain 171 pre-existing TS2554 errors, down 51 from baseline 222)
- [x] `pnpm --filter @open-brain/slack-bot exec tsc --noEmit` — clean
- [x] `pnpm --filter @open-brain/slack-bot run test` — unchanged (slack-bot doesn't import BaseSkill)
- [x] `pnpm --filter @open-brain/shared run build` — clean
- [ ] Homeserver deploy deferred (A70 batch window) — code-only change, no DB migration, env compatible; next cron run exercises gates

## Rollback

`git revert <merge sha>` on main. No data/schema consequence — gates are in-memory checks only. `app_settings.autonomy_level` remains readable (unused). Skills fall back to previous unguarded behavior. Safe without maintenance window.

## Artifacts

- Plan: \`IMPLEMENT_PHASE-P05.md\`
- Lab notebook: Entry 099

## Operator-approval note

P05 touches CLAUDE.md (autonomy semantics table) — operator approval required at Gate 5 per ORCHESTRATOR.md matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)