### PR TITLE
P06: cognitive memory producer + schedule

### DIFF
--- a/IMPLEMENT_PHASE-P06.md
+++ b/IMPLEMENT_PHASE-P06.md
@@ -1,0 +1,433 @@
+# IMPLEMENT_PHASE-P06 — Cognitive memory producer + schedule
+
+**Source card:** PHASED_PLAN.md § P06
+**Tracks issue:** #109 (Theme 7 full close)
+**Effort estimate:** ~2 days
+**Branch (Gate 2 will create):** `feat/phase-P06-cognitive-memory-producer`
+**Gate 5 path:** operator-approval required — touches search hot path (user-visible regression risk) + scheduler cron slot
+
+---
+
+## Investigation findings
+
+### Current state of search path (core-api)
+
+Two entry points both complete without any post-search side-effect hook today:
+
+**`packages/core-api/src/routes/search.ts` (lines 36–108)**
+- `GET /api/v1/search` — calls `searchService.search()` OR `searchService.searchWithRelated()` depending on `include_related`, then immediately `c.json(...)`. No hook.
+- `POST /api/v1/search` — same, dual sub-paths based on `body.include_related`. No hook.
+
+Producer insertion point is AFTER the search call resolves and BEFORE `return c.json(...)` in all four sub-paths (GET×2 + POST×2).
+
+**`packages/core-api/src/mcp/tools/search-brain.ts` (lines 39–91)**
+`searchBrainTool()` always calls `searchService.searchWithRelated()` (include_related=true by default per schema line 13). Only one enqueue site in this file.
+
+**Shared search logic:** Both paths call `searchService.searchWithRelated()` / `searchService.search()`. There is NO shared post-search hook in `SearchService`. The producer must be wired at both call sites independently (clean — keep it explicit, don't refactor into a shared helper).
+
+**Queue threading (core-api wiring):**
+```
+core-api/src/index.ts
+  → new Queue('access-stats', {connection})   [NEW]
+  → createApp({ ..., accessStatsQueue })       [NEW arg]
+  → registerSearchRoutes(app, searchService, accessStatsQueue)  [NEW arg]
+  → mountMcpServer(app, { ..., accessStatsQueue })              [NEW arg]
+```
+
+`bullmq` is already in `core-api/package.json` (used in `app.ts` line 4) — no new dependency.
+
+### Current state of update-access-stats job
+
+**File:** `packages/workers/src/jobs/update-access-stats.ts` (213 lines)
+
+Current logic:
+- `processAccessStatsJob()` lines 76–110 — takes `{captureIds, accessedAt}`; does (1) batch `UPDATE captures SET access_count+1` via `inArray()` — already batched, (2) calls `upsertCoAccessAssociations()` for all pairs — **loops serially**.
+- `upsertCoAccessAssociations()` lines 34–63 — loops `for (const [idA, idB] of pairs)` with `db.insert().values(...).onConflictDoUpdate(...)`. **This is the 45-statement source: C(10,2) = 45 pairs = 45 individual INSERTs.**
+- `generateCanonicalPairs()` lines 16–26 — pure, already tested, enforces `a < b`.
+- `pruneStaleAssociations()` lines 178–212 — **already fully implemented** in TypeScript using `db.delete().where(and(lt(weight, 0.1), lt(last_co_access, 90_days_ago)))`. No SQL function needed.
+- `createAccessStatsWorker()` lines 116–140 — already registered in `main.ts`.
+
+**Job payload shape (existing):** `interface AccessStatsJobData { captureIds: string[]; accessedAt: string }` — the card's suggested `{ capture_ids, search_query?, timestamp }` is NOT the current shape. Implementation uses the existing `AccessStatsJobData`; do NOT change the interface.
+
+### Current scheduler + memory-consolidation cron
+
+**`packages/workers/src/scheduler.ts` — Sunday schedule audit:**
+- `0 3 * * 0` — **storage-audit (ALREADY TAKEN, line 348)**
+- `0 4 * * 0` — memory-consolidation (line 177)
+- `0 5 * * 0` — wiki-lint (line 253)
+
+**CRON COLLISION RESOLUTION:** Card specifies `0 3 * * 0`. Use **`30 3 * * 0` (03:30 Sundays)** — still staggered before memory-consolidation at 04:00, runs 30 min after `storage-audit` starts (disk-size check typically completes in seconds).
+
+### BullMQ queue shape
+
+**Name:** `'access-stats'` — already exists in `packages/workers/src/queues/access-stats.ts`. Core-api instantiates its own `new Queue('access-stats', { connection })` — same name string, same Redis, no cross-package code import (workers `AccessStatsJobData` type is inlined in core-api as `{captureIds: string[]; accessedAt: string}`).
+
+**Redis connection:** Existing `redisConnection` object in `core-api/src/index.ts` lines 44–51.
+
+### D26 reference
+
+`LAB_NOTEBOOK.md` line 38: "D26 — Hebbian co-access tracking pairs top-10 results only; active 2026-04-09; Entry 019; alternatives All pairs (N^2 explosion), top-5 (insufficient signal)". Top-10 cap already enforced in worker via `MAX_PAIR_RESULTS = 10`. Enqueue passes `results.slice(0, 10).map(r => r.capture.id!)`.
+
+**Design call on empty searches:** Enqueue only when `results.length >= 1`. Empty-result searches would enqueue zero-payload jobs that the worker returns early from — redundant.
+
+### Integration test pattern
+
+Existing integration infrastructure:
+- `packages/workers/src/__tests__/integration/pipeline.test.ts` — real Redis + real Postgres via `docker-compose.test.yml`.
+- `waitForJobState()` polls `queue.getJob(jobId).getState()` until target or timeout.
+- `initTestDatabase()`, `teardownTestDatabase()`, `getTestDb()`, `cleanDatabase()`, `createTestCapture()` helpers all exist.
+
+**Pattern for P06:** **Simpler alternative preferred** — call `processAccessStatsJob(payload, realDb)` directly with real Postgres and assert DB state. BullMQ plumbing is already E2E-tested by `pipeline.test.ts`; the new test focuses on the batch-UPSERT correctness + canonical pair ordering + second-call accumulation.
+
+---
+
+## Work items
+
+### 1.1 — Producer: instantiate access-stats queue in core-api + thread through app
+
+**File: `packages/core-api/src/index.ts`**
+
+After existing `ingestProcessQueue` creation (around line 77):
+```typescript
+const accessStatsQueue = new Queue<{ captureIds: string[]; accessedAt: string }>(
+  'access-stats',
+  { connection: redisConnection },
+)
+```
+Ensure `Queue` is imported from `bullmq`.
+
+Add to graceful shutdown cleanup block (around line 204):
+```typescript
+accessStatsQueue.close(),
+```
+
+Pass `accessStatsQueue` into `createApp({...})`.
+
+**File: `packages/core-api/src/app.ts`**
+
+Add to `AppDependencies` interface:
+```typescript
+/** Access-stats BullMQ queue — fire-and-forget after search completion */
+accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>
+```
+
+Thread into `registerSearchRoutes(app, searchService, accessStatsQueue)` call.
+Thread into `mountMcpServer(app, { ..., accessStatsQueue })`.
+
+### 1.2 — Producer: enqueue access-stats on HTTP search completion
+
+**File: `packages/core-api/src/routes/search.ts`**
+
+Update signature:
+```typescript
+export function registerSearchRoutes(
+  app: Hono,
+  searchService: SearchService,
+  accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>,
+): void
+```
+
+For each of the 4 sub-paths (GET include_related=true, GET include_related=false, POST include_related=true, POST include_related=false), insert BEFORE `return c.json(...)`:
+```typescript
+if (accessStatsQueue && /* results.length >= 1 */) {
+  const captureIds = /* top-10 ids */.slice(0, 10)
+  accessStatsQueue.add('access-stats', {
+    captureIds,
+    accessedAt: new Date().toISOString(),
+  }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+}
+```
+
+For `searchWithRelated` paths, `results` is `response.results`. For `search` paths, `results` is the flat array. Map `.capture.id!` for `SearchResult`, `.id!` for plain capture rows.
+
+**DO NOT extract to a shared helper.** Keep inline and explicit for traceability (4 enqueue sites, all near their `return c.json`).
+
+### 1.3 — Producer: enqueue access-stats on MCP search completion
+
+**File: `packages/core-api/src/mcp/server.ts`**
+Add `accessStatsQueue?` to `McpServerDeps`.
+Thread to `registerMcpTools({ ..., accessStatsQueue })`.
+
+**File: `packages/core-api/src/mcp/tools/index.ts`**
+Add `accessStatsQueue?` to `RegisterToolsDeps`.
+Pass to `searchBrainTool(input, searchService, accessStatsQueue)` call site.
+
+**File: `packages/core-api/src/mcp/tools/search-brain.ts`**
+Signature:
+```typescript
+export async function searchBrainTool(
+  input: SearchBrainInput,
+  searchService: SearchService,
+  accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>,
+): Promise<string>
+```
+
+After `const response = await searchService.searchWithRelated(...)` (~line 44), before building `lines[]`:
+```typescript
+if (accessStatsQueue && response.results.length > 0) {
+  const captureIds = response.results.slice(0, 10).map(r => r.capture.id!)
+  accessStatsQueue.add('access-stats', {
+    captureIds,
+    accessedAt: new Date().toISOString(),
+  }).catch(() => { /* fire-and-forget */ })
+}
+```
+
+### 1.4 — Consumer: batch UPSERT in update-access-stats job
+
+**File: `packages/workers/src/jobs/update-access-stats.ts`**
+
+Replace the for-loop body of `upsertCoAccessAssociations()` with ONE batch `db.execute(sql`INSERT ... VALUES (…), (…) ON CONFLICT ... DO UPDATE …`)`:
+
+```typescript
+export async function upsertCoAccessAssociations(
+  pairs: Array<[string, string]>,
+  accessedAt: string,
+  db: Database,
+): Promise<number> {
+  if (pairs.length === 0) return 0
+
+  const accessedAtDate = new Date(accessedAt)
+  const valueFragments = pairs.map(([idA, idB]) =>
+    sql`(${idA}::uuid, ${idB}::uuid, 1, 1.0, ${accessedAtDate})`
+  )
+  const valuesClause = sql.join(valueFragments, sql`, `)
+
+  await db.execute(sql`
+    INSERT INTO capture_associations
+      (capture_id_a, capture_id_b, co_access_count, weight, last_co_access)
+    VALUES ${valuesClause}
+    ON CONFLICT (capture_id_a, capture_id_b) DO UPDATE SET
+      co_access_count = capture_associations.co_access_count + 1,
+      last_co_access  = EXCLUDED.last_co_access,
+      weight          = (capture_associations.co_access_count + 1)
+                        * exp(-0.005
+                          * EXTRACT(EPOCH FROM (
+                              EXCLUDED.last_co_access - capture_associations.last_co_access
+                            )) / 3600.0)
+  `)
+
+  return pairs.length
+}
+```
+
+45 serial INSERTs → 1 batch `INSERT ... VALUES`. Access_count UPDATE is unchanged (already batched).
+
+**Unit test update required:** `packages/workers/src/__tests__/update-access-stats.test.ts` currently asserts `db.insert` called N times for `upsertCoAccessAssociations` and `processAccessStatsJob`. Change those assertions to `db.execute` called once with an SQL fragment. `generateCanonicalPairs` tests are pure-function — no change.
+
+### 1.5 — Schedule: weekly pruneStaleAssociations
+
+**File: `packages/workers/src/scheduler.ts`**
+
+Add new repeatable job (cron `30 3 * * 0`):
+```typescript
+const pruneAssociationsCron = '30 3 * * 0'
+
+const pruneAssociationsQueue = new Queue<{ triggeredAt: string }>(
+  'prune-associations',
+  {
+    connection,
+    defaultJobOptions: {
+      attempts: 1,
+      removeOnComplete: { count: 10 },
+      removeOnFail: { count: 10 },
+    },
+  },
+)
+
+await pruneAssociationsQueue.add(
+  'prune-associations',
+  { triggeredAt: new Date().toISOString() },
+  {
+    repeat: { pattern: pruneAssociationsCron },
+    jobId: 'prune-associations-recurring',
+  },
+)
+
+logger.info({ cron: pruneAssociationsCron }, '[scheduler] prune-associations repeatable job registered')
+```
+
+Add `pruneAssociations: Queue<{ triggeredAt: string }>` to `ScheduledQueues` interface. Return it from `registerScheduledJobs()`.
+
+**File: `packages/workers/src/jobs/update-access-stats.ts` — add worker factory:**
+```typescript
+export function createPruneAssociationsWorker(
+  connection: ConnectionOptions,
+  db: Database,
+): Worker<{ triggeredAt: string }> {
+  const worker = new Worker<{ triggeredAt: string }>(
+    'prune-associations',
+    async (_job) => { await pruneStaleAssociations(db) },
+    { connection, concurrency: 1 },
+  )
+  worker.on('failed', (job, err) => {
+    logger.warn({ jobId: job?.id, err: err.message }, 'prune-associations job failed')
+  })
+  return worker
+}
+```
+
+**File: `packages/workers/src/main.ts`:**
+```typescript
+import { createAccessStatsWorker, createPruneAssociationsWorker } from './jobs/update-access-stats.js'
+...
+workers.push(createPruneAssociationsWorker(connection, db))
+```
+Include `pruneAssociations` queue in the shutdown close loop.
+
+### 1.6 — Integration test
+
+**New file:** `packages/workers/src/__tests__/integration/access-stats-e2e.test.ts`
+
+Simple pattern (direct function call, real DB — BullMQ E2E already covered by pipeline.test.ts):
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { eq, and, inArray } from 'drizzle-orm'
+import { captures, captureAssociations } from '@open-brain/shared'
+import { initTestDatabase, teardownTestDatabase, getTestDb } from './setup.js'
+import { cleanDatabase, createTestCapture } from './helpers.js'
+import { processAccessStatsJob } from '../../jobs/update-access-stats.js'
+
+beforeAll(async () => { await initTestDatabase() })
+afterAll(async () => { await teardownTestDatabase() })
+beforeEach(async () => { await cleanDatabase() })
+
+describe('access-stats integration', () => {
+  it('populates access_count and capture_associations with canonical ordering', async () => {
+    const db = getTestDb()
+    const c1 = await createTestCapture({ content: 'Access test A' })
+    const c2 = await createTestCapture({ content: 'Access test B' })
+    const captureIds = [c1.id as string, c2.id as string]
+    const accessedAt = new Date().toISOString()
+
+    await processAccessStatsJob({ captureIds, accessedAt }, db)
+
+    // access_count incremented for both
+    const rows = await db.select({ id: captures.id, access_count: captures.access_count })
+      .from(captures).where(inArray(captures.id, captureIds))
+    for (const r of rows) expect(r.access_count).toBeGreaterThanOrEqual(1)
+
+    // capture_associations: canonical (a < b) ordering
+    const [idA, idB] = captureIds[0] < captureIds[1]
+      ? [captureIds[0], captureIds[1]]
+      : [captureIds[1], captureIds[0]]
+    const [assoc] = await db.select().from(captureAssociations)
+      .where(and(
+        eq(captureAssociations.capture_id_a, idA),
+        eq(captureAssociations.capture_id_b, idB),
+      ))
+    expect(assoc).toBeDefined()
+    expect(assoc.co_access_count).toBe(1)
+    expect(Number(assoc.weight)).toBeCloseTo(1.0)
+
+    // Second call: co_access_count should increment, weight recomputed
+    await processAccessStatsJob({ captureIds, accessedAt: new Date().toISOString() }, db)
+    const [assoc2] = await db.select({ co_access_count: captureAssociations.co_access_count })
+      .from(captureAssociations)
+      .where(and(
+        eq(captureAssociations.capture_id_a, idA),
+        eq(captureAssociations.capture_id_b, idB),
+      ))
+    expect(assoc2.co_access_count).toBe(2)
+  })
+})
+```
+
+### 1.7 — LAB_NOTEBOOK Entry 100
+
+Pre-action entry:
+```markdown
+## Entry 100 — P06: Cognitive memory producer + schedule
+
+**Date:** 2026-04-19
+**Phase:** P06 (ORCHESTRATOR.md gate 3)
+**Tags:** [workers] [core-api] [cognitive-memory] [bullmq] [scheduler]
+**Environment:** laptop (Windows / bash); target = homeserver core-api + workers containers
+**Duration:** (fill on completion)
+
+### Objective
+Wire Hebbian co-access producer into both search paths (HTTP route + MCP tool), convert 45 serial pair INSERTs to single batch UPSERT, and schedule weekly pruneStaleAssociations at 03:30 Sundays (slotted between storage-audit at 03:00 and memory-consolidation at 04:00). Activates the idle capture_associations table from migrations 0011/0012 (dormant since 2026-04-09).
+
+### Hypothesis
+After P06, every search returning ≥1 result fires an access-stats job. After the job processes: captures.access_count is incremented, capture_associations rows are created/updated for all top-10 result pairs (canonical a < b ordering enforced by generateCanonicalPairs), and the Hebbian association boost in SearchService begins providing signal. The batch UPSERT (1 db.execute per job) is measurably faster than 45 serial statements at scale. P24 (spreading activation quality tuning) becomes unblockable after 4 weeks of accumulated data.
+
+### Rollback plan
+`git revert <P06 merge sha>` — no schema change (tables pre-exist from 0011/0012). Producer removal stops new jobs from being enqueued; existing association data is preserved but becomes stale. Prune schedule removal is one block delete in scheduler.ts. Search response behavior reverts to no side-effects. Safe without maintenance window.
+
+### Result
+(fill on completion)
+```
+
+Commit after tests pass as the final commit in the series.
+
+---
+
+## Acceptance criteria (Gate 4 reviewer verifies)
+
+- [ ] HTTP `GET /api/v1/search` and `POST /api/v1/search` produce access-stats jobs on completion (both include_related paths). Enqueue when `results.length >= 1`.
+- [ ] MCP `search_brain` tool produces access-stats jobs on completion when `response.results.length >= 1`.
+- [ ] `access_count` incremented for returned capture IDs (integration test asserts real DB).
+- [ ] `capture_associations` populated on search, canonical ordering (`a < b`) verified (integration test asserts).
+- [ ] `update-access-stats.ts` `upsertCoAccessAssociations` uses exactly 1 `db.execute(sql\`INSERT...\`)` call — grep confirms no `for`-loop with `db.insert` inside.
+- [ ] Weekly prune runs: `30 3 * * 0` cron visible in scheduler.ts; `prune-associations` worker registered in main.ts.
+- [ ] Fire-and-forget: search/MCP response never blocks on Redis — all 5 enqueue sites wrapped in `.catch(() => {})`.
+- [ ] Unit tests updated: `update-access-stats.test.ts` asserts `db.execute` called once (not `db.insert` 45 times). All existing tests still pass.
+- [ ] New integration test `access-stats-e2e.test.ts` passes.
+- [ ] LAB_NOTEBOOK Entry 100 present with Result section filled.
+- [ ] No cron slot reuse — `grep -n "0 3 \* \* 0" packages/workers/src/scheduler.ts` returns only storage-audit (the new prune job is at `30 3 * * 0`).
+
+---
+
+## Rollback
+
+`git revert <merge sha>` — no schema change (tables already exist from migrations 0011 + 0012). Producer wiring removal stops new jobs; existing association data remains in place (not harmful). Batch UPSERT reverts to serial loop (no correctness change, just performance). Prune schedule removal is one block deletion in `scheduler.ts`. Safe, no maintenance window.
+
+---
+
+## Scope drift check
+
+**No drift.** All items map 1:1 to card deliverables:
+- Producer in both search paths: card specifies `search.ts` + `search-brain.ts` ✓
+- Batch upsert: card specifies `update-access-stats.ts` batch INSERT ✓
+- Scheduler: card specifies `pruneStaleAssociations()` weekly ✓ (slot shifted `0 3` → `30 3` due to pre-existing `storage-audit` at `0 3`; still staggered before memory-consolidation at `0 4`)
+- Integration test: card specifies post-search job verification ✓
+
+**Minor in-scope addition (not drift):** `30 3 * * 0` instead of `0 3 * * 0`. Pre-existing slot collision — 30-minute stagger preserves intent.
+
+---
+
+## Scope creep to defer
+
+- **Tuning association boost weights** (hardcoded 0.1 max in `SearchService.lookupAssociationBoosts`): no usage data yet; defer to P24.
+- **Co-access tracking on `get_capture` MCP tool:** single-capture fetches generate 0 pairs; not meaningful.
+- **Spreading activation weight curve experiments:** defer until 4 weeks of data.
+- **Backfill historical associations from captures.access_count:** out of scope.
+- **`search_query` field on job payload:** card suggests it but existing `AccessStatsJobData` shape is `{captureIds, accessedAt}`. Don't add without consensus — would require queue interface migration.
+
+---
+
+## Post-merge CLAUDE.md rule candidates
+
+1. **Scheduler slot registry:** Before adding a new cron to `scheduler.ts`, grep for the exact cron string. Current Sunday slots: `0 3 * * 0` storage-audit, `30 3 * * 0` prune-associations (P06), `0 4 * * 0` memory-consolidation, `0 5 * * 0` wiki-lint.
+2. **Access-stats producer pattern:** HTTP search route (4 sub-paths) + MCP search tool (1 site) enqueue `access-stats` after every search with `results.length >= 1`. Fire-and-forget (`.catch(() => {})`). Never extract to a shared helper — 5 enqueue sites, all near their `return`.
+3. **Batch UPSERT invariant:** `upsertCoAccessAssociations` uses exactly 1 `db.execute(sql\`INSERT...VALUES...ON CONFLICT\`)` call regardless of pair count. No serial per-pair inserts.
+4. **D26 top-10:** Access-stats job receives `results.slice(0, 10).map(r => r.capture.id!)`. Worker also caps at `MAX_PAIR_RESULTS = 10`.
+5. **Cross-package queue usage:** `core-api` instantiates `new Queue('access-stats', {connection})` directly — same name string as `packages/workers/src/queues/access-stats.ts`. Do NOT import from `@open-brain/workers` (no such cross-package import exists). Job payload type is inlined as `{captureIds: string[]; accessedAt: string}` in core-api.
+
+---
+
+## Critical Files for Implementation
+
+- `packages/workers/src/jobs/update-access-stats.ts` (batch UPSERT + new `createPruneAssociationsWorker`)
+- `packages/core-api/src/routes/search.ts` (4 enqueue sites)
+- `packages/core-api/src/mcp/tools/search-brain.ts` (1 enqueue site)
+- `packages/core-api/src/mcp/tools/index.ts` (thread `accessStatsQueue`)
+- `packages/core-api/src/mcp/server.ts` (add to `McpServerDeps`)
+- `packages/core-api/src/app.ts` (add to `AppDependencies`)
+- `packages/core-api/src/index.ts` (instantiate queue, pass to app)
+- `packages/workers/src/scheduler.ts` (new `prune-associations` queue + cron)
+- `packages/workers/src/main.ts` (register prune worker)
+- `packages/workers/src/__tests__/update-access-stats.test.ts` (assertion update)
+- `packages/workers/src/__tests__/integration/access-stats-e2e.test.ts` (NEW)
+- `LAB_NOTEBOOK.md` (Entry 100)

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -6724,3 +6724,56 @@ Deviations from plan: (1) Existing test fetch mocks needed URL-awareness - makeS
 Duration: ~2 hours
 
 ---
+
+## Entry 100 — P06: Cognitive memory producer + schedule
+
+**Date:** 2026-04-19
+**Phase:** P06 (ORCHESTRATOR.md gate 3)
+**Tags:** [workers] [core-api] [cognitive-memory] [bullmq] [scheduler]
+**Environment:** laptop (Windows / bash); target = homeserver core-api + workers containers
+**Duration:** (fill on completion)
+
+### Objective
+Wire Hebbian co-access producer into both search paths (HTTP route + MCP tool), convert 45 serial pair INSERTs to single batch UPSERT, and schedule weekly pruneStaleAssociations at 03:30 Sundays (slotted between storage-audit at 03:00 and memory-consolidation at 04:00). Activates the idle capture_associations table from migrations 0011/0012 (dormant since 2026-04-09).
+
+### Hypothesis
+After P06, every search returning ≥1 result fires an access-stats job. After the job processes: captures.access_count is incremented, capture_associations rows are created/updated for all top-10 result pairs (canonical a < b ordering enforced by generateCanonicalPairs), and the Hebbian association boost in SearchService begins providing signal. The batch UPSERT (1 db.execute per job) is measurably faster than 45 serial statements at scale. P24 (spreading activation quality tuning) becomes unblockable after 4 weeks of accumulated data.
+
+### Rollback plan
+`git revert <P06 merge sha>` — no schema change (tables pre-exist from 0011/0012). Producer removal stops new jobs from being enqueued; existing association data is preserved but becomes stale. Prune schedule removal is one block delete in scheduler.ts. Search response behavior reverts to no side-effects. Safe without maintenance window.
+
+### Result
+All work items implemented and committed to feat/phase-P06-cognitive-memory-producer branch.
+
+**Commits landed (5):**
+1. `226bfeb` — feat(phase-P06)/1.1+1.4: batch UPSERT in update-access-stats + prune worker factory
+2. `02820b9` — feat(phase-P06)/1.2+1.3: access-stats producer on HTTP + MCP search paths
+3. `4571b61` — feat(phase-P06)/1.5: weekly prune-associations scheduler (30 3 * * 0)
+4. `4991da6` — test(phase-P06)/1.6: integration test for access-stats batch UPSERT + canonical ordering
+5. (this commit) — docs(lab-notebook): entry 100 — P06 cognitive memory producer
+
+**Tests:** baseline 980 (workers), 732 (core-api). After P06: workers 980 (unchanged — test updates are in-place replacements), core-api 732 (unchanged — no new tests added, no regressions).
+
+**tsc --noEmit:** clean for both packages (workers + core-api).
+
+**Integration test:** TypeScript-clean; skipped locally (docker-compose.test.yml Postgres at :5433 not running). Will exercise in CI. Test verifies: access_count increment, canonical a<b pair ordering, co_access_count accumulation on second call.
+
+**Deviations from plan:**
+- Cron slot collision resolved cleanly: `30 3 * * 0` as planned.
+- `accessStatsQueue` threaded cleanly through all 7 touch points (index.ts, app.ts, search.ts×4, mcp/server.ts, mcp/tools/index.ts, search-brain.ts).
+- All 4 `search.ts` sub-paths use `r.capture.id!` — `search()` returns `SearchResult[]` (not plain captures), so the accessor is consistent across all 4 sub-paths.
+- `main.ts` shutdown now captures `scheduledQueues` return value and closes all scheduler-created queues including `pruneAssociations`.
+- No unexpected surprises in MCP tool wiring — `registerMcpTools` accepts a flat deps object, straightforward to extend.
+
+**Acceptance criteria verified:**
+- [x] 4 HTTP search sub-paths enqueue access-stats when results.length >= 1
+- [x] MCP search_brain enqueues access-stats when results.length >= 1
+- [x] Batch UPSERT: exactly 1 db.execute() call in upsertCoAccessAssociations
+- [x] prune-associations cron = 30 3 * * 0 (no collision with storage-audit at 0 3 * * 0)
+- [x] All 5 enqueue sites fire-and-forget (.catch(() => {}))
+- [x] Unit tests updated: db.execute once (not db.insert N times)
+- [x] Integration test written (TS-clean, CI-only)
+
+**Duration:** ~45 minutes
+
+---

--- a/packages/core-api/src/app.ts
+++ b/packages/core-api/src/app.ts
@@ -82,11 +82,13 @@ interface AppDependencies {
   voiceSessionService?: VoiceSessionService
   /** Ingest-process BullMQ queue — required for POST /api/v1/ingest/upload pipeline dispatch (CS3.4/CS3.5) */
   ingestProcessQueue?: Queue<IngestProcessJobData>
+  /** Access-stats BullMQ queue — fire-and-forget after search completion (P06 Hebbian co-access) */
+  accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>
 }
 
 export function createApp(deps: AppDependencies = {}): Hono {
   const app = new Hono()
-  const { configService, captureService, searchService, pipelineService, db, redisConnection, skillQueue, triggerService, entityService, betService, sessionService, documentPipelineQueue, llmGateway, systemHealthService, wikiService, activityFeedService, emailDraftService, emailComposeAssistService, voiceSessionService, ingestProcessQueue } = deps
+  const { configService, captureService, searchService, pipelineService, db, redisConnection, skillQueue, triggerService, entityService, betService, sessionService, documentPipelineQueue, llmGateway, systemHealthService, wikiService, activityFeedService, emailDraftService, emailComposeAssistService, voiceSessionService, ingestProcessQueue, accessStatsQueue } = deps
 
   // Rate limiter instances (in-memory, no persistence needed for single-user)
   const defaultLimiter = new RateLimiter(RATE_LIMIT_TIERS.default)
@@ -129,7 +131,7 @@ export function createApp(deps: AppDependencies = {}): Hono {
   }
 
   if (searchService) {
-    registerSearchRoutes(app, searchService)
+    registerSearchRoutes(app, searchService, accessStatsQueue)
   }
 
   // Synthesize API
@@ -212,7 +214,7 @@ export function createApp(deps: AppDependencies = {}): Hono {
 
   // MCP endpoint — requires all services to be available
   if (captureService && searchService && configService && db) {
-    mountMcpServer(app, { captureService, searchService, configService, db, entityService, wikiService, activityFeedService, emailDraftService })
+    mountMcpServer(app, { captureService, searchService, configService, db, entityService, wikiService, activityFeedService, emailDraftService, accessStatsQueue })
   }
 
   return app

--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -75,6 +75,11 @@ const documentPipelineQueue = new Queue('document-pipeline', { connection: redis
 // CS3.4/CS3.5 — ingest-process queue drives the batch-ingest pipeline for
 // uploaded files (CSVs, PDFs, images) from the web UI and sidecars.
 const ingestProcessQueue = new Queue('ingest-process', { connection: redisConnection })
+// P06 — access-stats queue fires after every search to update Hebbian co-access associations
+const accessStatsQueue = new Queue<{ captureIds: string[]; accessedAt: string }>(
+  'access-stats',
+  { connection: redisConnection },
+)
 
 // Services — instantiation order respects dependency graph
 const pipelineService = new PipelineService(capturePipelineQueue)
@@ -173,6 +178,7 @@ const app = createApp({
   sessionService,
   documentPipelineQueue,
   ingestProcessQueue,
+  accessStatsQueue,
   llmGateway,
   systemHealthService,
   wikiService,
@@ -205,6 +211,7 @@ const shutdown = async () => {
     skillQueue.close(),
     documentPipelineQueue.close(),
     ingestProcessQueue.close(),
+    accessStatsQueue.close(),
   ]
   if (wikiIngestQueue) queueClosePromises.push(wikiIngestQueue.close())
   if (wikiLintQueue) queueClosePromises.push(wikiLintQueue.close())

--- a/packages/core-api/src/mcp/server.ts
+++ b/packages/core-api/src/mcp/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import type { Hono } from 'hono'
+import type { Queue } from 'bullmq'
 import type { CaptureService } from '../services/capture.js'
 import type { SearchService } from '../services/search.js'
 import type { EntityService } from '../services/entity.js'
@@ -24,6 +25,8 @@ interface McpServerDeps {
   wikiService?: WikiService
   activityFeedService?: ActivityFeedService
   emailDraftService?: EmailDraftService
+  /** Access-stats BullMQ queue — fire-and-forget after search_brain tool completion (P06) */
+  accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>
 }
 
 /**
@@ -36,7 +39,7 @@ interface McpServerDeps {
  * This is the correct approach for Hono/edge environments and avoids shared state.
  */
 export function mountMcpServer(app: Hono, deps: McpServerDeps): void {
-  const { captureService, searchService, configService, db, entityService, wikiService, activityFeedService, emailDraftService } = deps
+  const { captureService, searchService, configService, db, entityService, wikiService, activityFeedService, emailDraftService, accessStatsQueue } = deps
 
   // Create the activity logger (shared across requests — it's stateless, just holds db ref)
   const activityLogger = new McpActivityLogger(db, activityFeedService)
@@ -60,7 +63,7 @@ export function mountMcpServer(app: Hono, deps: McpServerDeps): void {
       version: '0.1.0',
     })
 
-    registerMcpTools({ server, captureService, searchService, configService, db, entityService, wikiService, emailDraftService, activityLogger, clientId })
+    registerMcpTools({ server, captureService, searchService, configService, db, entityService, wikiService, emailDraftService, activityLogger, clientId, accessStatsQueue })
 
     // Register MCP resources
     server.registerResource(

--- a/packages/core-api/src/mcp/tools/index.ts
+++ b/packages/core-api/src/mcp/tools/index.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { Queue } from 'bullmq'
 import type { CaptureService } from '../../services/capture.js'
 import type { SearchService } from '../../services/search.js'
 import type { EntityService } from '../../services/entity.js'
@@ -39,6 +40,8 @@ interface RegisterToolsDeps {
   emailDraftService?: EmailDraftService
   activityLogger?: McpActivityLogger
   clientId?: string
+  /** Access-stats BullMQ queue — fire-and-forget after search_brain tool completion (P06) */
+  accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>
 }
 
 /**
@@ -56,7 +59,7 @@ function withLogging(
 }
 
 export function registerMcpTools(deps: RegisterToolsDeps): void {
-  const { server, captureService, searchService, configService, db, entityService, wikiService, emailDraftService, activityLogger, clientId } = deps
+  const { server, captureService, searchService, configService, db, entityService, wikiService, emailDraftService, activityLogger, clientId, accessStatsQueue } = deps
 
   // Tool 1: search_brain — semantic + FTS hybrid search
   server.tool(
@@ -64,7 +67,7 @@ export function registerMcpTools(deps: RegisterToolsDeps): void {
     'Search your captured knowledge using semantic and full-text search. Returns ranked results with match percentages.',
     searchBrainSchema.shape,
     withLogging('search_brain', async (input) => {
-      const result = await searchBrainTool(input as SearchBrainInput, searchService)
+      const result = await searchBrainTool(input as SearchBrainInput, searchService, accessStatsQueue)
       return { content: [{ type: 'text', text: result }] }
     }, activityLogger, clientId),
   )

--- a/packages/core-api/src/mcp/tools/search-brain.ts
+++ b/packages/core-api/src/mcp/tools/search-brain.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import type { Queue } from 'bullmq'
+import { logger } from '@open-brain/shared'
 import type { SearchService } from '../../services/search.js'
 import type { SearchResult } from '../../services/search.js'
 
@@ -58,7 +59,7 @@ export async function searchBrainTool(
     accessStatsQueue.add('access-stats', {
       captureIds,
       accessedAt: new Date().toISOString(),
-    }).catch(() => { /* fire-and-forget */ })
+    }).catch(err => logger.debug({ err }, '[search-brain] access-stats enqueue failed (fire-and-forget)'))
   }
 
   const results = response.results

--- a/packages/core-api/src/mcp/tools/search-brain.ts
+++ b/packages/core-api/src/mcp/tools/search-brain.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { Queue } from 'bullmq'
 import type { SearchService } from '../../services/search.js'
 import type { SearchResult } from '../../services/search.js'
 
@@ -36,7 +37,11 @@ function formatResult(index: number, { capture, score }: SearchResult): string[]
   return lines
 }
 
-export async function searchBrainTool(input: SearchBrainInput, searchService: SearchService): Promise<string> {
+export async function searchBrainTool(
+  input: SearchBrainInput,
+  searchService: SearchService,
+  accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>,
+): Promise<string> {
   const dateFrom = input.days
     ? new Date(Date.now() - input.days * 24 * 60 * 60 * 1000)
     : undefined
@@ -47,6 +52,14 @@ export async function searchBrainTool(input: SearchBrainInput, searchService: Se
     dateFrom,
     includeRelated: input.include_related,
   })
+
+  if (accessStatsQueue && response.results.length > 0) {
+    const captureIds = response.results.slice(0, 10).map(r => r.capture.id!)
+    accessStatsQueue.add('access-stats', {
+      captureIds,
+      accessedAt: new Date().toISOString(),
+    }).catch(() => { /* fire-and-forget */ })
+  }
 
   const results = response.results
 

--- a/packages/core-api/src/routes/search.ts
+++ b/packages/core-api/src/routes/search.ts
@@ -2,6 +2,7 @@ import type { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod'
 import type { Queue } from 'bullmq'
+import { logger } from '@open-brain/shared'
 import type { SearchService, SearchResponse } from '../services/search.js'
 import { searchSchema } from '../schemas/search.js'
 
@@ -61,7 +62,7 @@ export function registerSearchRoutes(
         accessStatsQueue.add('access-stats', {
           captureIds,
           accessedAt: new Date().toISOString(),
-        }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+        }).catch(err => logger.debug({ err }, '[search] access-stats enqueue failed (fire-and-forget)'))
       }
       return c.json({
         query: query.q,
@@ -77,7 +78,7 @@ export function registerSearchRoutes(
       accessStatsQueue.add('access-stats', {
         captureIds,
         accessedAt: new Date().toISOString(),
-      }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+      }).catch(err => logger.debug({ err }, '[search] access-stats enqueue failed (fire-and-forget)'))
     }
     return c.json({
       query: query.q,
@@ -111,7 +112,7 @@ export function registerSearchRoutes(
         accessStatsQueue.add('access-stats', {
           captureIds,
           accessedAt: new Date().toISOString(),
-        }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+        }).catch(err => logger.debug({ err }, '[search] access-stats enqueue failed (fire-and-forget)'))
       }
       return c.json({
         query: body.query,
@@ -131,7 +132,7 @@ export function registerSearchRoutes(
       accessStatsQueue.add('access-stats', {
         captureIds,
         accessedAt: new Date().toISOString(),
-      }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+      }).catch(err => logger.debug({ err }, '[search] access-stats enqueue failed (fire-and-forget)'))
     }
     return c.json({
       query: body.query,

--- a/packages/core-api/src/routes/search.ts
+++ b/packages/core-api/src/routes/search.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod'
+import type { Queue } from 'bullmq'
 import type { SearchService, SearchResponse } from '../services/search.js'
 import { searchSchema } from '../schemas/search.js'
 
@@ -31,7 +32,11 @@ const searchQuerySchema = z.object({
   capture_types: data.capture_types ?? data.capture_type,
 }))
 
-export function registerSearchRoutes(app: Hono, searchService: SearchService): void {
+export function registerSearchRoutes(
+  app: Hono,
+  searchService: SearchService,
+  accessStatsQueue?: Queue<{ captureIds: string[]; accessedAt: string }>,
+): void {
   // GET /api/v1/search?q=... — hybrid semantic + FTS search over captures
   app.get('/api/v1/search', zValidator('query', searchQuerySchema), async (c) => {
     const query = c.req.valid('query')
@@ -51,6 +56,13 @@ export function registerSearchRoutes(app: Hono, searchService: SearchService): v
 
     if (query.include_related) {
       const response: SearchResponse = await searchService.searchWithRelated(query.q, searchOptions)
+      if (accessStatsQueue && response.results.length > 0) {
+        const captureIds = response.results.slice(0, 10).map(r => r.capture.id!)
+        accessStatsQueue.add('access-stats', {
+          captureIds,
+          accessedAt: new Date().toISOString(),
+        }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+      }
       return c.json({
         query: query.q,
         total: response.results.length,
@@ -60,6 +72,13 @@ export function registerSearchRoutes(app: Hono, searchService: SearchService): v
     }
 
     const results = await searchService.search(query.q, searchOptions)
+    if (accessStatsQueue && results.length > 0) {
+      const captureIds = results.slice(0, 10).map(r => r.capture.id!)
+      accessStatsQueue.add('access-stats', {
+        captureIds,
+        accessedAt: new Date().toISOString(),
+      }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+    }
     return c.json({
       query: query.q,
       total: results.length,
@@ -87,6 +106,13 @@ export function registerSearchRoutes(app: Hono, searchService: SearchService): v
     if (body.include_related) {
       const response: SearchResponse = await searchService.searchWithRelated(body.query, searchOptions)
       const paginated = response.results.slice(body.offset, body.offset + body.limit)
+      if (accessStatsQueue && response.results.length > 0) {
+        const captureIds = response.results.slice(0, 10).map(r => r.capture.id!)
+        accessStatsQueue.add('access-stats', {
+          captureIds,
+          accessedAt: new Date().toISOString(),
+        }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+      }
       return c.json({
         query: body.query,
         total: response.results.length,
@@ -100,6 +126,13 @@ export function registerSearchRoutes(app: Hono, searchService: SearchService): v
     // Apply client-side offset for pagination (hybrid_search returns ordered results)
     const paginated = results.slice(body.offset, body.offset + body.limit)
 
+    if (accessStatsQueue && results.length > 0) {
+      const captureIds = results.slice(0, 10).map(r => r.capture.id!)
+      accessStatsQueue.add('access-stats', {
+        captureIds,
+        accessedAt: new Date().toISOString(),
+      }).catch(() => { /* fire-and-forget — search response never blocks on Redis */ })
+    }
     return c.json({
       query: body.query,
       total: results.length,

--- a/packages/workers/src/__tests__/integration/access-stats-e2e.test.ts
+++ b/packages/workers/src/__tests__/integration/access-stats-e2e.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Integration test: access-stats job — batch UPSERT + canonical pair ordering.
+ *
+ * Calls processAccessStatsJob() directly against real Postgres (docker-compose.test.yml).
+ * BullMQ plumbing is already E2E-tested by pipeline.test.ts — this test focuses
+ * on the batch-UPSERT correctness, canonical pair ordering, and second-call accumulation.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { eq, and, inArray } from 'drizzle-orm'
+import { captures, captureAssociations } from '@open-brain/shared'
+import { initTestDatabase, teardownTestDatabase, getTestDb } from './setup.js'
+import { cleanDatabase, createTestCapture } from './helpers.js'
+import { processAccessStatsJob } from '../../jobs/update-access-stats.js'
+
+beforeAll(async () => { await initTestDatabase() })
+afterAll(async () => { await teardownTestDatabase() })
+beforeEach(async () => { await cleanDatabase() })
+
+describe('access-stats integration', () => {
+  it('populates access_count and capture_associations with canonical ordering', async () => {
+    const db = getTestDb()
+    const c1 = await createTestCapture({ content: 'Access test A' })
+    const c2 = await createTestCapture({ content: 'Access test B' })
+    const captureIds = [c1.id as string, c2.id as string]
+    const accessedAt = new Date().toISOString()
+
+    await processAccessStatsJob({ captureIds, accessedAt }, db)
+
+    // access_count incremented for both
+    const rows = await db.select({ id: captures.id, access_count: captures.access_count })
+      .from(captures).where(inArray(captures.id, captureIds))
+    for (const r of rows) expect(r.access_count).toBeGreaterThanOrEqual(1)
+
+    // capture_associations: canonical (a < b) ordering
+    const [idA, idB] = captureIds[0] < captureIds[1]
+      ? [captureIds[0], captureIds[1]]
+      : [captureIds[1], captureIds[0]]
+    const [assoc] = await db.select().from(captureAssociations)
+      .where(and(
+        eq(captureAssociations.capture_id_a, idA),
+        eq(captureAssociations.capture_id_b, idB),
+      ))
+    expect(assoc).toBeDefined()
+    expect(assoc.co_access_count).toBe(1)
+    expect(Number(assoc.weight)).toBeCloseTo(1.0)
+
+    // Second call: co_access_count should increment, weight recomputed
+    await processAccessStatsJob({ captureIds, accessedAt: new Date().toISOString() }, db)
+    const [assoc2] = await db.select({ co_access_count: captureAssociations.co_access_count })
+      .from(captureAssociations)
+      .where(and(
+        eq(captureAssociations.capture_id_a, idA),
+        eq(captureAssociations.capture_id_b, idB),
+      ))
+    expect(assoc2.co_access_count).toBe(2)
+  })
+})

--- a/packages/workers/src/__tests__/update-access-stats.test.ts
+++ b/packages/workers/src/__tests__/update-access-stats.test.ts
@@ -37,18 +37,14 @@ const UUID_D = '00000000-0000-0000-0000-000000000004'
 // ============================================================
 
 function makeMockDb() {
-  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
-  const values = vi.fn().mockReturnValue({ onConflictDoUpdate })
   const where = vi.fn().mockResolvedValue(undefined)
   const set = vi.fn().mockReturnValue({ where })
 
   return {
     update: vi.fn().mockReturnValue({ set }),
-    insert: vi.fn().mockReturnValue({ values }),
+    execute: vi.fn().mockResolvedValue(undefined),
     _set: set,
     _where: where,
-    _values: values,
-    _onConflictDoUpdate: onConflictDoUpdate,
   }
 }
 
@@ -120,10 +116,10 @@ describe('upsertCoAccessAssociations', () => {
     const db = makeMockDb()
     const result = await upsertCoAccessAssociations([], TIMESTAMP, db as any)
     expect(result).toBe(0)
-    expect(db.insert).not.toHaveBeenCalled()
+    expect(db.execute).not.toHaveBeenCalled()
   })
 
-  it('calls insert for each pair', async () => {
+  it('executes exactly one batch statement for multiple pairs', async () => {
     const db = makeMockDb()
     const pairs: Array<[string, string]> = [
       [UUID_A, UUID_B],
@@ -133,37 +129,29 @@ describe('upsertCoAccessAssociations', () => {
     const result = await upsertCoAccessAssociations(pairs, TIMESTAMP, db as any)
 
     expect(result).toBe(2)
-    expect(db.insert).toHaveBeenCalledTimes(2)
+    // Batch UPSERT invariant: exactly 1 db.execute() regardless of pair count
+    expect(db.execute).toHaveBeenCalledTimes(1)
+    expect(db.execute).toHaveBeenCalledWith(expect.anything())
   })
 
-  it('provides onConflictDoUpdate for upsert behavior', async () => {
+  it('executes batch INSERT ... ON CONFLICT statement', async () => {
     const db = makeMockDb()
     const pairs: Array<[string, string]> = [[UUID_A, UUID_B]]
 
     await upsertCoAccessAssociations(pairs, TIMESTAMP, db as any)
 
-    expect(db._onConflictDoUpdate).toHaveBeenCalledTimes(1)
-    const conflictArg = db._onConflictDoUpdate.mock.calls[0][0]
-    // Should target the unique pair columns
-    expect(conflictArg.target).toBeDefined()
-    expect(conflictArg.set).toBeDefined()
-    // The set should update co_access_count, last_co_access, and weight
-    expect(conflictArg.set.co_access_count).toBeDefined()
-    expect(conflictArg.set.last_co_access).toBeDefined()
-    expect(conflictArg.set.weight).toBeDefined()
+    // Exactly 1 db.execute call — the batch UPSERT
+    expect(db.execute).toHaveBeenCalledTimes(1)
+    expect(db.execute).toHaveBeenCalledWith(expect.anything())
   })
 
-  it('inserts with initial weight of 1.0 and co_access_count of 1', async () => {
+  it('returns pair count on success', async () => {
     const db = makeMockDb()
     const pairs: Array<[string, string]> = [[UUID_A, UUID_B]]
 
-    await upsertCoAccessAssociations(pairs, TIMESTAMP, db as any)
+    const result = await upsertCoAccessAssociations(pairs, TIMESTAMP, db as any)
 
-    const insertedValues = db._values.mock.calls[0][0]
-    expect(insertedValues.capture_id_a).toBe(UUID_A)
-    expect(insertedValues.capture_id_b).toBe(UUID_B)
-    expect(insertedValues.co_access_count).toBe(1)
-    expect(insertedValues.weight).toBe(1.0)
+    expect(result).toBe(1)
   })
 })
 
@@ -180,7 +168,7 @@ describe('processAccessStatsJob', () => {
     const db = makeMockDb()
     await processAccessStatsJob({ captureIds: [], accessedAt: TIMESTAMP }, db as any)
     expect(db.update).not.toHaveBeenCalled()
-    expect(db.insert).not.toHaveBeenCalled()
+    expect(db.execute).not.toHaveBeenCalled()
   })
 
   it('updates access stats for single capture (no co-access)', async () => {
@@ -192,8 +180,8 @@ describe('processAccessStatsJob', () => {
 
     // Should update access_count
     expect(db.update).toHaveBeenCalledTimes(1)
-    // Should NOT insert associations (need >= 2 captures)
-    expect(db.insert).not.toHaveBeenCalled()
+    // Should NOT execute batch upsert (need >= 2 captures)
+    expect(db.execute).not.toHaveBeenCalled()
   })
 
   it('updates access stats AND creates co-access associations for 2+ captures', async () => {
@@ -205,8 +193,8 @@ describe('processAccessStatsJob', () => {
 
     // Access stats update
     expect(db.update).toHaveBeenCalledTimes(1)
-    // 3 pairs: A-B, A-C, B-C
-    expect(db.insert).toHaveBeenCalledTimes(3)
+    // Batch UPSERT invariant: exactly 1 db.execute() for all pairs combined
+    expect(db.execute).toHaveBeenCalledTimes(1)
   })
 
   it('limits co-access pairing to top 10 results', async () => {
@@ -223,14 +211,14 @@ describe('processAccessStatsJob', () => {
 
     // All 15 get access_count update
     expect(db.update).toHaveBeenCalledTimes(1)
-    // Only top 10 are paired: C(10, 2) = 45
-    expect(db.insert).toHaveBeenCalledTimes(45)
+    // Only top 10 are paired, but still exactly 1 batch execute regardless
+    expect(db.execute).toHaveBeenCalledTimes(1)
   })
 
   it('does not fail when co-access upsert throws', async () => {
     const db = makeMockDb()
-    // Make insert throw on first call
-    db._onConflictDoUpdate.mockRejectedValueOnce(new Error('DB constraint violation'))
+    // Make execute throw
+    db.execute.mockRejectedValueOnce(new Error('DB constraint violation'))
 
     // Should not throw — co-access is best-effort
     await expect(

--- a/packages/workers/src/jobs/update-access-stats.ts
+++ b/packages/workers/src/jobs/update-access-stats.ts
@@ -26,10 +26,14 @@ export function generateCanonicalPairs(ids: string[]): Array<[string, string]> {
 }
 
 /**
- * Upserts co-access associations for all pairs of capture IDs.
+ * Upserts co-access associations for all pairs of capture IDs using a single
+ * batch INSERT ... VALUES ... ON CONFLICT DO UPDATE statement.
+ *
  * On conflict (pair already exists): increments co_access_count, updates
  * last_co_access, and recalculates weight using Hebbian decay formula:
  *   weight = co_access_count * exp(-0.005 * hours_since_last_co_access)
+ *
+ * 45 serial INSERTs (C(10,2)) replaced with 1 batch statement.
  */
 export async function upsertCoAccessAssociations(
   pairs: Array<[string, string]>,
@@ -38,28 +42,27 @@ export async function upsertCoAccessAssociations(
 ): Promise<number> {
   if (pairs.length === 0) return 0
 
-  let upserted = 0
-  for (const [idA, idB] of pairs) {
-    await db
-      .insert(captureAssociations)
-      .values({
-        capture_id_a: idA,
-        capture_id_b: idB,
-        co_access_count: 1,
-        weight: 1.0,
-        last_co_access: new Date(accessedAt),
-      })
-      .onConflictDoUpdate({
-        target: [captureAssociations.capture_id_a, captureAssociations.capture_id_b],
-        set: {
-          co_access_count: sql`${captureAssociations.co_access_count} + 1`,
-          last_co_access: new Date(accessedAt),
-          weight: sql`(${captureAssociations.co_access_count} + 1) * exp(-0.005 * EXTRACT(EPOCH FROM (${new Date(accessedAt).toISOString()}::timestamptz - ${captureAssociations.last_co_access})) / 3600.0)`,
-        },
-      })
-    upserted++
-  }
-  return upserted
+  const accessedAtDate = new Date(accessedAt)
+  const valueFragments = pairs.map(([idA, idB]) =>
+    sql`(${idA}::uuid, ${idB}::uuid, 1, 1.0, ${accessedAtDate})`
+  )
+  const valuesClause = sql.join(valueFragments, sql`, `)
+
+  await db.execute(sql`
+    INSERT INTO capture_associations
+      (capture_id_a, capture_id_b, co_access_count, weight, last_co_access)
+    VALUES ${valuesClause}
+    ON CONFLICT (capture_id_a, capture_id_b) DO UPDATE SET
+      co_access_count = capture_associations.co_access_count + 1,
+      last_co_access  = EXCLUDED.last_co_access,
+      weight          = (capture_associations.co_access_count + 1)
+                        * exp(-0.005
+                          * EXTRACT(EPOCH FROM (
+                              EXCLUDED.last_co_access - capture_associations.last_co_access
+                            )) / 3600.0)
+  `)
+
+  return pairs.length
 }
 
 /**
@@ -209,4 +212,28 @@ export async function pruneStaleAssociations(
   }
 
   return { pruned, durationMs }
+}
+
+/**
+ * Creates and returns a BullMQ Worker for the 'prune-associations' queue.
+ * Runs pruneStaleAssociations() on each job trigger (typically weekly cron).
+ * The caller is responsible for calling worker.close() on process shutdown.
+ */
+export function createPruneAssociationsWorker(
+  connection: ConnectionOptions,
+  db: Database,
+): Worker<{ triggeredAt: string }> {
+  const worker = new Worker<{ triggeredAt: string }>(
+    'prune-associations',
+    async (_job) => {
+      await pruneStaleAssociations(db)
+    },
+    { connection, concurrency: 1 },
+  )
+
+  worker.on('failed', (job, err) => {
+    logger.warn({ jobId: job?.id, err: err.message }, 'prune-associations job failed')
+  })
+
+  return worker
 }

--- a/packages/workers/src/main.ts
+++ b/packages/workers/src/main.ts
@@ -15,7 +15,7 @@ import { createDocumentPipelineWorker } from './jobs/document-pipeline.js'
 import { createDailySweepWorker } from './jobs/daily-sweep.js'
 import { createPushoverWorker } from './jobs/pushover.js'
 import { createEmailWorker } from './jobs/email.js'
-import { createAccessStatsWorker } from './jobs/update-access-stats.js'
+import { createAccessStatsWorker, createPruneAssociationsWorker } from './jobs/update-access-stats.js'
 import { createBudgetCheckWorker } from './jobs/budget-check.js'
 import { createSkillExecutionWorker } from './jobs/skill-execution.js'
 import { createIngestRootWorker } from './jobs/ingest-root.js'
@@ -190,6 +190,7 @@ async function main() {
   workers.push(createPushoverWorker(connection, pushoverAppToken, pushoverUserKey))
   workers.push(createEmailWorker(connection))
   workers.push(createAccessStatsWorker(connection, db))
+  workers.push(createPruneAssociationsWorker(connection, db))
   // Budget-check uses LLM_SPEND_URL — distinct from the inference
   // OPENAI_BASE_URL since spend tracking may point at a different proxy.
   // Uses LLM_SPEND_API_KEY for auth, falling back to OPENAI_API_KEY.

--- a/packages/workers/src/main.ts
+++ b/packages/workers/src/main.ts
@@ -236,7 +236,7 @@ async function main() {
   logger.info({ count: workers.length }, 'All workers registered')
 
   // Scheduled jobs
-  await registerScheduledJobs(connection)
+  const scheduledQueues = await registerScheduledJobs(connection)
   logger.info('Scheduled jobs registered')
 
   // Graceful shutdown
@@ -246,7 +246,10 @@ async function main() {
     shuttingDown = true
     logger.info({ signal }, 'Shutting down workers...')
     await Promise.allSettled(workers.map(w => w.close()))
-    await Promise.allSettled(Object.values(queues).map(q => q.close()))
+    await Promise.allSettled([
+      ...Object.values(queues).map(q => q.close()),
+      ...Object.values(scheduledQueues).map(q => q.close()),
+    ])
     if (flowProducer) await flowProducer.close().catch(() => {})
     await dedupRedis.quit().catch(() => {})
     await composioMeterRedis.quit().catch(() => {})

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -11,6 +11,7 @@ export interface ScheduledQueues {
   dailySweep: Queue<DailySweepJobData>
   budgetCheck: Queue<BudgetCheckJobData>
   skillExecution: Queue<SkillExecutionJobData>
+  pruneAssociations: Queue<{ triggeredAt: string }>
 }
 
 /**
@@ -33,6 +34,7 @@ export interface ScheduledQueues {
  * - wiki-synthesis: 6:00 AM daily (cron: 0 6 * * *) — queues unintegrated captures for wiki-ingest
  * - container-health: every 15 min (cron: 0,15,30,45 * * * *) — /health checks on all containers
  * - storage-audit: 3:00 AM Sundays (cron: 0 3 * * 0) — Postgres, Redis, backup, wiki sizes
+ * - prune-associations: 3:30 AM Sundays (cron: 30 3 * * 0) — prunes stale low-weight Hebbian capture_associations (P06)
  * - secret-rotation: 10:00 AM 1st of month (cron: 0 10 1 * *) — checks API key ages via bws CLI, alerts if > 90 days
  * - capture-dedup-sweep: 4:00 AM Saturdays (cron: 0 4 * * 6) — flags near-duplicate captures (cosine > 0.95) for review
  *
@@ -418,5 +420,35 @@ export async function registerScheduledJobs(
 
   logger.info({ cron: emailClassifyCron }, '[scheduler] email-classify repeatable job registered')
 
-  return { dailySweep: dailySweepQueue, budgetCheck: budgetCheckQueue, skillExecution: skillExecutionQueue }
+  // --------------------------------------------------------
+  // Prune associations (3:30 AM Sundays)
+  // Staggered 30 min after storage-audit (0 3 * * 0) and 30 min before
+  // memory-consolidation (0 4 * * 0) — safe slot, no Sunday cron collision.
+  // --------------------------------------------------------
+  const pruneAssociationsCron = '30 3 * * 0'
+
+  const pruneAssociationsQueue = new Queue<{ triggeredAt: string }>(
+    'prune-associations',
+    {
+      connection,
+      defaultJobOptions: {
+        attempts: 1,
+        removeOnComplete: { count: 10 },
+        removeOnFail: { count: 10 },
+      },
+    },
+  )
+
+  await pruneAssociationsQueue.add(
+    'prune-associations',
+    { triggeredAt: new Date().toISOString() },
+    {
+      repeat: { pattern: pruneAssociationsCron },
+      jobId: 'prune-associations-recurring',
+    },
+  )
+
+  logger.info({ cron: pruneAssociationsCron }, '[scheduler] prune-associations repeatable job registered')
+
+  return { dailySweep: dailySweepQueue, budgetCheck: budgetCheckQueue, skillExecution: skillExecutionQueue, pruneAssociations: pruneAssociationsQueue }
 }


### PR DESCRIPTION
## Summary

Activates the dormant Hebbian co-access infrastructure (migrations 0011 + 0012, idle since 2026-04-09):

- **Producer wired in 5 search sites:** 4 HTTP sub-paths in `routes/search.ts` (GET/POST × include_related true/false) + MCP `search_brain` tool. Fire-and-forget `.catch(() => {})` — search/MCP response never blocks on Redis.
- **Batch UPSERT:** `upsertCoAccessAssociations` replaces 45 serial `db.insert()` calls with 1 `db.execute(sql\`INSERT ... VALUES ... ON CONFLICT ... DO UPDATE\`)`. Hebbian weight formula preserved (`count × exp(-0.005 × hours)`).
- **Weekly prune schedule:** `pruneStaleAssociations()` runs `30 3 * * 0` (03:30 Sundays — staggered after storage-audit at 03:00 and before memory-consolidation at 04:00). New dedicated `'prune-associations'` queue + worker, registered in `main.ts`.
- **Integration test:** `access-stats-e2e.test.ts` calls `processAccessStatsJob()` directly against real Postgres, asserts `access_count` increment, canonical pair ordering (`capture_id_a < capture_id_b`), and second-call accumulation.
- **`access-stats` queue** already exists in workers; core-api now instantiates its own `new Queue` with the same name string. Job payload type `{captureIds, accessedAt}` inlined in core-api (no cross-package import).

## Why

#109 (Theme 7 — Cognitive memory dormant). Tables, schema, and worker logic all shipped in prior phases but no producer existed — every search returned results and zero cognitive signal was captured. P06 turns on the signal: 4 weeks of data unblocks P24 (spreading activation quality tuning).

Closes #109.

## Scope boundaries

- **Cron collision:** card specified `0 3 * * 0` but that slot is `storage-audit`. Plan resolved to `30 3 * * 0` — still staggered before memory-consolidation at 04:00.
- **Not changed:** `SearchService` itself (no new method); `get_capture` MCP tool (single-capture fetches produce 0 pairs); association weight curve (defer until data exists).
- **Not changed:** `AccessStatsJobData` interface — existing `{captureIds, accessedAt}` preserved. Card's suggested `search_query` field not added (would require queue migration).

## Test plan

- [x] `pnpm --filter @open-brain/shared run build` — clean
- [x] `pnpm --filter @open-brain/core-api exec tsc --noEmit` — 0 errors
- [x] `pnpm --filter @open-brain/workers exec tsc --noEmit` — 0 errors
- [x] `pnpm --filter @open-brain/core-api run test` — 732 pass (unchanged)
- [x] `pnpm --filter @open-brain/workers run test` — 980 pass (unit test assertions updated in-place for batch UPSERT)
- [ ] Integration test `access-stats-e2e.test.ts` — TypeScript-checked; runtime exercise in CI against docker-compose.test.yml
- [ ] Homeserver deploy deferred (A70 batch window) — new `prune-associations` worker starts on next container restart; first cron fire is next Sunday 03:30

## Rollback

`git revert <merge sha>` on main — no schema change (tables already exist from migrations 0011/0012). Producer removal stops new jobs; existing association data preserved but stale. Prune schedule removal is one block in `scheduler.ts`. Safe without maintenance window.

## Artifacts

- Plan: \`IMPLEMENT_PHASE-P06.md\`
- Lab notebook: Entry 100

## Operator-approval note

Search hot path + scheduler cron slot + new worker registration → operator approval required at Gate 5 per ORCHESTRATOR.md matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)