### PR TITLE
P07: internal traffic hygiene (rate-limit + job thunderstorm)

### DIFF
--- a/IMPLEMENT_PHASE-P07.md
+++ b/IMPLEMENT_PHASE-P07.md
@@ -1,0 +1,377 @@
+# IMPLEMENT_PHASE-P07 — Internal traffic hygiene
+
+**Source card:** PHASED_PLAN.md § P07
+**Tracks issues:** #114 (High — rate-limit self-contention) + #117 (Medium — job thunderstorm)
+**Effort estimate:** ~4 hours
+**Branch (Gate 2 will create):** `feat/phase-P07-internal-traffic-hygiene`
+**Gate 5 path:** operator-approval required — nginx.conf (live production traffic path) + rate-limit.ts (security middleware) + scheduler cron changes
+
+---
+
+## Investigation findings
+
+### Current BYPASS_CALLERS + rate-limit tiers
+
+**File:** `packages/core-api/src/middleware/rate-limit.ts`
+
+Current `BYPASS_CALLERS` Set (lines 159–167):
+- `internal:integration-test`
+- `internal:web-ui`
+- `internal:email-worker`
+- `internal:financial-pipeline`
+- `internal:utility-pipeline`
+- `internal:ingest`
+
+Key format is `internal:<caller-value>` — `getClientKey` at line 136 prepends `internal:` when the header is present. Header read via `headers.get('x-open-brain-caller')` (case-insensitive via Fetch API normalization).
+
+Rate-limit tiers:
+- `default`: 100 req/min (all `/api/v1/*`)
+- `strict`: 20 req/min (`/captures`, `/search`, `/synthesize`)
+- `admin`: 5 req/min (`/admin/*`)
+
+Bypass is all-or-nothing (no per-caller limit). Card says "appropriate limit"; for single-user system, full bypass is appropriate. Per-caller tiering deferred.
+
+### Internal caller inventory
+
+**Already set header (6 callers):**
+- `email-classify` — `packages/workers/src/skills/email-classify.ts:493` → `'email-classify'`
+- `email-compose-skill` — `packages/workers/src/skills/email-compose.ts:190` → `'email-compose-skill'`
+- `batch-wiki-ingest.py` — `scripts/batch-wiki-ingest.py` → `'batch-wiki-ingest'`
+- `email-pipeline.py` — `scripts/email-pipeline.py:730` → `'email-pipeline'`
+- `ingest-onedrive.py` — via `scripts/lib/capture_api.py:67` → `'ingest-onedrive'`
+- `ingest-repair.py` — via `scripts/lib/capture_api.py` → `'ingest-repair'`
+
+None of the 6 are in BYPASS_CALLERS today. All currently get the default 100 req/min or strict 20 req/min, depending on endpoint.
+
+**Missing header (9 callers must be added):**
+- `packages/slack-bot/src/lib/core-api-client.ts` — central `request()` (line 41) → `'slack-bot'`
+- `packages/voice-capture/src/services/ingest.ts:57` → `'voice-capture'`
+- `packages/workers/src/skills/memory-consolidation.ts:422` → `'memory-consolidation'` (named in card)
+- `packages/workers/src/skills/daily-sweep-skill.ts:231` → `'workers'`
+- `packages/workers/src/skills/daily-connections.ts:245` → `'workers'`
+- `packages/workers/src/skills/drift-monitor.ts:269` → `'workers'`
+- `packages/workers/src/skills/monthly-reflection.ts:457` → `'workers'`
+- `packages/workers/src/skills/weekly-brief.ts:157` → `'workers'`
+- `packages/workers/src/skills/base-skill.ts:15` — autonomy fetch → `'workers'`
+
+Single `'workers'` value covers all skill fetches (same container); `memory-consolidation` keeps its own value (card specifies it by name, finer observability).
+
+### Front-door config
+
+**Architecture:**
+```
+Browser → Cloudflare Edge → cloudflared tunnel → web container (nginx:80) → core-api:3000
+```
+
+**No `config/cloudflare/nginx.conf`** — the front door is `packages/web/nginx.conf`. Cloudflare tunnel (`config/cloudflare/tunnel.yaml`) routes `brain.troy-davis.com → web:80`.
+
+**Current nginx state:**
+- `/api/` + `/api/v1/events` blocks: `proxy_set_header X-Open-Brain-Caller "web-ui"` — correctly **overwrites** any client-supplied value (nginx `proxy_set_header` for a given header name replaces client value).
+- `/mcp` block: **NO** `proxy_set_header X-Open-Brain-Caller` — client-supplied header passes through unchanged. Bug: `X-Open-Brain-Caller: integration-test` on `/mcp` would bypass rate-limits.
+
+**Fix:** add `proxy_set_header X-Open-Brain-Caller ""` to `/mcp` block. MCP clients get IP-based rate-limiting, not bypass.
+
+### Scheduler 06:00-09:00 jobs (actual vs card)
+
+**Card says "19 jobs"** in 06:00-09:00 window. **Actual audit: 7 jobs** in 06:00-08:15.
+
+| Job | Current cron | Fires at |
+|-----|-------------|----------|
+| wiki-synthesis | `0 6 * * *` | 06:00 daily |
+| daily-connections | `0 7 * * *` | 07:00 daily |
+| capture-reminder-morning | `5 7 * * 1-5` | 07:05 weekdays |
+| cost-analysis | `10 7 * * *` | 07:10 daily |
+| morning-brief | `15 7 * * 1-5` | 07:15 weekdays |
+| budget-check | `0 8 * * *` | 08:00 daily |
+| drift-monitor | `15 8 * * *` | 08:15 daily |
+
+**Real cluster:** 4 jobs within 15 minutes at 07:00 (daily-connections, capture-reminder-morning, cost-analysis, morning-brief). This is the CPU cliff.
+
+**pipeline-health** (`0 */6 * * *`) fires at 06:00 via its every-6-hours pattern — lightweight HTTP check, not LLM, <5s runtime. Leave unchanged (changing pattern breaks 6-hour semantics).
+
+### Scheduler proposed spread
+
+| Job | Current | Proposed | New time |
+|-----|---------|----------|----------|
+| wiki-synthesis | `0 6 * * *` | `0 6 * * *` | 06:00 (anchor) |
+| daily-connections | `0 7 * * *` | `10 6 * * *` | 06:10 daily |
+| cost-analysis | `10 7 * * *` | `20 6 * * *` | 06:20 daily |
+| morning-brief | `15 7 * * 1-5` | `30 6 * * 1-5` | 06:30 weekdays |
+| capture-reminder-morning | `5 7 * * 1-5` | `45 6 * * 1-5` | 06:45 weekdays |
+| budget-check | `0 8 * * *` | `0 7 * * *` | 07:00 daily |
+| drift-monitor | `15 8 * * *` | `15 7 * * *` | 07:15 daily |
+
+All 7 spread across 06:00-07:15, no two on same minute. CPU cliff eliminated.
+
+**BullMQ upsert:** `repeat: { pattern }` + stable `jobId` upserts on next startup — no manual Redis flush.
+
+### BullMQ worker concurrency
+
+| Worker | Current | Target |
+|--------|---------|--------|
+| check-triggers | 5 | **2** |
+| ingest-root | 3 | **2** |
+| ingestion-worker | 3 | **2** |
+| update-access-stats | 5 | **2** |
+| budget-check | 1 | 1 (singleton) |
+| daily-sweep | 1 | 1 (singleton) |
+| skill-execution | 1 | 1 (LLM-heavy, documented) |
+| prune-associations | 1 | 1 (singleton) |
+| wiki-ingest | 1 | 1 (git serialization) |
+| document-pipeline | 2 | 2 ✓ |
+| embed-capture | 2 | 2 ✓ |
+| extract-entities | 2 | 2 ✓ |
+| email | 2 | 2 ✓ |
+| pushover | 2 | 2 ✓ |
+
+No shared helper — per-file `concurrency:` arg to `new Worker(...)`. Singletons preserved for correctness.
+
+---
+
+## Work items
+
+### 1.1 — Add X-Open-Brain-Caller to 9 internal callers
+
+**slack-bot** (`packages/slack-bot/src/lib/core-api-client.ts` line 41) — single choke point:
+```typescript
+private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const url = `${this.baseUrl}${path}`
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Open-Brain-Caller': 'slack-bot',
+      ...options.headers,
+    },
+  })
+  // ...
+}
+```
+`...options.headers` spread after keeps test overrides working.
+
+**voice-capture** (`packages/voice-capture/src/services/ingest.ts:57`):
+```typescript
+headers: {
+  'Content-Type': 'application/json',
+  'X-Open-Brain-Caller': 'voice-capture',
+},
+```
+
+**6 worker skills** — add `'X-Open-Brain-Caller': <value>` to `headers` object in each fetch call:
+- `memory-consolidation.ts:422` → `'memory-consolidation'`
+- `daily-sweep-skill.ts:231` → `'workers'`
+- `daily-connections.ts:245` → `'workers'`
+- `drift-monitor.ts:269` → `'workers'`
+- `monthly-reflection.ts:457` → `'workers'`
+- `weekly-brief.ts:157` → `'workers'`
+
+**base-skill.ts** (autonomy fetch has no `headers` object today):
+```typescript
+const response = await fetch(`${coreApiUrl}/api/v1/settings/autonomy_level`, {
+  headers: { 'X-Open-Brain-Caller': 'workers' },
+})
+```
+
+### 1.2 — Extend BYPASS_CALLERS
+
+**File:** `packages/core-api/src/middleware/rate-limit.ts`
+
+```typescript
+const BYPASS_CALLERS = new Set([
+  'internal:integration-test',
+  'internal:web-ui',
+  'internal:email-worker',
+  'internal:financial-pipeline',
+  'internal:utility-pipeline',
+  'internal:ingest',
+  // P07 — new internal service callers
+  'internal:slack-bot',
+  'internal:voice-capture',
+  'internal:memory-consolidation',
+  'internal:workers',
+  // P07 — callers that already set the header but were missing from bypass
+  'internal:email-classify',
+  'internal:email-compose-skill',
+  'internal:batch-wiki-ingest',
+  'internal:email-pipeline',
+  'internal:ingest-onedrive',
+  'internal:ingest-repair',
+])
+```
+
+### 1.3 — Strip client-set X-Open-Brain-Caller at front door
+
+**File:** `packages/web/nginx.conf`
+
+**`/mcp` block** — add explicit strip:
+```nginx
+location /mcp {
+    proxy_pass $core_api_upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    # P07: strip client-supplied X-Open-Brain-Caller — MCP clients use IP-based rate limits
+    proxy_set_header X-Open-Brain-Caller "";
+    proxy_set_header Connection "";
+    proxy_read_timeout 60s;
+}
+```
+
+**`/api/` + `/api/v1/events` blocks** — add comment for auditability (existing `proxy_set_header X-Open-Brain-Caller "web-ui"` already correctly overwrites):
+```nginx
+# P07: nginx overwrites X-Open-Brain-Caller (replaces any client-supplied value — intentional)
+proxy_set_header X-Open-Brain-Caller "web-ui";
+```
+
+**Deployment validation:** `docker compose exec web nginx -t` before reload. Test with `curl -H "X-Open-Brain-Caller: integration-test" https://brain.troy-davis.com/mcp ...` — should rate-limit after 20 req/min (strict tier), not bypass.
+
+### 1.4 — Spread 7 jobs across 06:00-07:15
+
+**File:** `packages/workers/src/scheduler.ts`
+
+Update cron strings per table in "Scheduler proposed spread" above. Also update the JSDoc comment block at the top of `registerScheduledJobs` (lines 22-46) to reflect the new times:
+
+```typescript
+ * - wiki-synthesis:           6:00 AM daily    (cron: 0 6 * * *)    — anchor
+ * - daily-connections:        6:10 AM daily    (cron: 10 6 * * *)   — cross-domain connections
+ * - cost-analysis:            6:20 AM daily    (cron: 20 6 * * *)   — LLM cost tracking
+ * - morning-brief:            6:30 AM weekdays (cron: 30 6 * * 1-5) — structured morning briefing
+ * - capture-reminder-morning: 6:45 AM weekdays (cron: 45 6 * * 1-5) — Pushover nudge
+ * - budget-check:             7:00 AM daily    (cron: 0 7 * * *)    — monthly AI spend vs thresholds
+ * - drift-monitor:            7:15 AM daily    (cron: 15 7 * * *)   — brain-view classification drift
+```
+
+### 1.5 — BullMQ concurrency: 2 per queue (4 files)
+
+Change `concurrency:` argument on 4 worker factories:
+- `packages/workers/src/jobs/check-triggers.ts:289` — 5 → 2 (with comment: `// P07: reduced from 5`)
+- `packages/workers/src/jobs/ingest-root.ts:96` — 3 → 2
+- `packages/workers/src/jobs/ingestion-worker.ts:211` — 3 → 2
+- `packages/workers/src/jobs/update-access-stats.ts:130` — 5 → 2
+
+### 1.6 — Integration test
+
+**New file:** `packages/core-api/src/__tests__/integration/rate-limit-internal.test.ts`
+
+Uses existing `getTestApp()` pattern. Two tests:
+
+```typescript
+describe('Internal caller bypass under 100-parallel load', () => {
+  it('100 parallel GET /api/v1/captures with X-Open-Brain-Caller: integration-test all succeed (no 429)', async () => {
+    const N = 100
+    const requests = Array.from({ length: N }, () =>
+      ctx.app.fetch(
+        new Request('http://localhost/api/v1/captures', {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Open-Brain-Caller': 'integration-test',
+          },
+        }),
+      ),
+    )
+    const responses = await Promise.all(requests)
+    expect(responses.every(r => r.status !== 429)).toBe(true)
+    expect(responses.every(r => r.status === 200)).toBe(true)
+  })
+
+  it('negative control: POST without header DOES 429 after strict-tier exhaustion', async () => {
+    // Confirms bypass is doing real work — strict limiter still fires at 21 req/min
+    const N = 100
+    const requests = Array.from({ length: N }, () =>
+      ctx.app.fetch(
+        new Request('http://localhost/api/v1/captures', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            content: 'test', capture_type: 'idea',
+            brain_view: 'technical', source: 'api',
+          }),
+        }),
+      ),
+    )
+    const responses = await Promise.all(requests)
+    const count429 = responses.filter(r => r.status === 429).length
+    expect(count429).toBeGreaterThan(0) // strict 20/min limit was enforced
+  })
+})
+```
+
+Negative control ensures the test is not vacuous — if bypass were a no-op, test 1 would still pass at 100 concurrent GETs with a 100/min default limit, but test 2 confirms the limiter really is firing at 21 without the header.
+
+### 1.7 — LAB_NOTEBOOK Entry 101
+
+Pre-action entry with Objective / Hypothesis / Rollback per ORCHESTRATOR.md template. Include note that card's "19 jobs" was actually 7 in the 06:00-08:15 window (4-in-15-min cluster at 07:00); real thunderstorm smaller than stated.
+
+---
+
+## Acceptance criteria
+
+- [ ] All 9 internal callers set `X-Open-Brain-Caller` (slack-bot, voice-capture, 6 worker skills, base-skill)
+- [ ] BYPASS_CALLERS Set contains 16 entries (6 existing + 4 new service callers + 6 already-setting script callers)
+- [ ] `packages/web/nginx.conf` `/mcp` block explicitly strips `X-Open-Brain-Caller`
+- [ ] 7 jobs in 06:00-07:15 window on unique minutes (corrected from card's "19")
+- [ ] BullMQ concurrency: 4 workers lowered to 2 (check-triggers, ingest-root, ingestion-worker, update-access-stats); 5 singletons preserved
+- [ ] Integration test: 100 parallel internal calls succeed without 429; negative control confirms strict limiter still fires
+- [ ] `pnpm --filter @open-brain/core-api run test` passes
+- [ ] `pnpm --filter @open-brain/workers run test` passes
+- [ ] `pnpm --filter @open-brain/slack-bot run test` passes
+- [ ] `docker compose exec web nginx -t` passes (operator validates at deploy)
+- [ ] LAB_NOTEBOOK Entry 101 present with Result filled
+
+---
+
+## Rollback
+
+`git revert <P07 merge sha>`. No schema changes, no data migration.
+
+- Rate-limit change is additive — internal callers fall back to IP-based limits; no security implication on revert.
+- nginx change is `proxy_set_header` directive additions; revert + `docker compose restart web` restores prior behavior.
+- Scheduler cron changes take effect on next workers restart; BullMQ's repeat-job upsert will restore old crons. No data loss or queue corruption.
+- BullMQ concurrency changes take effect on restart; no data loss.
+
+Safe without maintenance window.
+
+---
+
+## Scope drift check
+
+**NO drift.** All work items map directly to #114 + #117.
+
+**Minor in-scope corrections:**
+- Card says "19 jobs" — actual is 7. Spread produced for 7.
+- Card mentions `config/cloudflare/nginx.conf` — actual front door is `packages/web/nginx.conf`. Same effect.
+- BYPASS_CALLERS expansion includes 6 script callers already setting the header but missing from bypass — necessary audit finding, not scope creep.
+
+---
+
+## Scope creep to defer
+
+- Per-caller rate-limit tiers (e.g., slack-bot=500/min vs memory-consolidation=50/min) — requires converting Set to Map<caller, tier>. Future enhancement.
+- Prometheus per-caller bypass metrics (`rate_limit_bypassed_total{caller="..."}`)
+- Cloudflare WAF edge-level strip (defense-in-depth beyond nginx)
+- Splitting `'workers'` caller into per-skill granularity — low value (same container)
+- Spreading `container-health` (`*/15` pattern) — lightweight, not contributing to thunderstorm
+
+---
+
+## Post-merge CLAUDE.md rule candidates
+
+1. **Internal callers rule:** Every new internal service (Docker container or script) that calls core-api MUST set `X-Open-Brain-Caller: <name>` AND add `internal:<name>` to `BYPASS_CALLERS` in `rate-limit.ts`. Missing either side = silent 429s under load.
+2. **Scheduler slot colocation rule:** No two repeatable BullMQ jobs may share the same cron minute across 06:00–09:00. Window has 180 minute-slots. Document intended slot in JSDoc when registering a new job. Add to existing Sunday-slot registry rule (P06).
+3. **BullMQ concurrency default rule:** New `createXxxWorker` factories default to `concurrency: 2`. Override to 1 only for documented singletons (LLM-heavy, git-serialized, etc.) with inline comment explaining why.
+4. **nginx proxy_set_header audit rule:** Every new `location` block in `packages/web/nginx.conf` that proxies to core-api MUST explicitly set or clear `X-Open-Brain-Caller` — no silent inheritance between blocks.
+
+---
+
+## Critical Files for Implementation
+
+- `packages/core-api/src/middleware/rate-limit.ts` (BYPASS_CALLERS)
+- `packages/web/nginx.conf` (front-door strip)
+- `packages/workers/src/scheduler.ts` (7-job spread + JSDoc)
+- `packages/slack-bot/src/lib/core-api-client.ts` (header)
+- `packages/voice-capture/src/services/ingest.ts` (header)
+- `packages/workers/src/skills/{memory-consolidation,daily-sweep-skill,daily-connections,drift-monitor,monthly-reflection,weekly-brief,base-skill}.ts` (7 headers)
+- `packages/workers/src/jobs/{check-triggers,ingest-root,ingestion-worker,update-access-stats}.ts` (concurrency)
+- `packages/core-api/src/__tests__/integration/rate-limit-internal.test.ts` (NEW)
+- `LAB_NOTEBOOK.md` (Entry 101)

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -6777,3 +6777,77 @@ All work items implemented and committed to feat/phase-P06-cognitive-memory-prod
 **Duration:** ~45 minutes
 
 ---
+
+## Entry 101 — P07: Internal traffic hygiene
+
+**Date:** 2026-04-19
+**Phase:** P07 (ORCHESTRATOR.md gate 3)
+**Tags:** [core-api] [workers] [scheduler] [nginx] [bullmq] [rate-limit]
+**Environment:** laptop (Windows / bash); target = homeserver core-api + web + workers containers
+**Duration:** (fill on completion)
+
+### Objective
+Close #114 (rate-limit self-contention) + #117 (job thunderstorm). Add X-Open-Brain-Caller to 9 internal callers, extend BYPASS_CALLERS to 16 entries (audit found 6 script callers already setting header but missing from bypass), strip client-supplied header at nginx `/mcp`, spread 7-job morning cluster across 06:00-07:15, lower 4 workers' BullMQ concurrency to 2.
+
+### Hypothesis
+After P07: (1) internal callers never 429 each other — 100 parallel integration-test requests succeed; (2) client cannot spoof bypass header via `/mcp` endpoint; (3) `docker stats` shows no single-minute CPU cliff in 07:00 window (flat-ish across 06:00-07:15); (4) negative control confirms strict limiter still fires at 21 req/min without header — bypass is doing real work.
+
+### Rollback plan
+`git revert <P07 merge sha>`. No schema change. Rate-limit additive (revert restores prior Set, callers fall back to IP-based limits). nginx change is directive addition + comment; `docker compose restart web` on revert. Scheduler crons upsert via BullMQ repeatable jobs on workers restart. Concurrency changes take effect on restart. No data loss, no queue corruption.
+
+### Investigation findings (pre-implementation)
+- Card said "19 jobs" in 06:00-09:00 window — actual audit found 7 jobs in 06:00-08:15. Real thunderstorm: 4 jobs within 15 minutes at 07:00 (daily-connections, capture-reminder-morning, cost-analysis, morning-brief).
+- `config/cloudflare/nginx.conf` doesn't exist — actual front door is `packages/web/nginx.conf`.
+- `/mcp` nginx block confirmed to have no `proxy_set_header X-Open-Brain-Caller` — client-supplied header passes through unchanged (security gap confirmed).
+- 6 script callers already set header but were not in BYPASS_CALLERS — audit finding captured, included in bypass expansion.
+- All 4 tsc checks clean pre-implementation.
+
+### Result
+
+**Status:** COMPLETE
+
+**Commits (in order):**
+1. `33bf48f` — feat(phase-P07)/1.1+1.2+1.3: callers + bypass + nginx strip
+2. `3183e0d` — feat(phase-P07)/1.4+1.5: scheduler spread + concurrency reduction
+3. `d945ef0` — test(phase-P07)/1.6: rate-limit bypass integration test
+
+**Files touched (16 total):**
+- `packages/slack-bot/src/lib/core-api-client.ts` — added 'slack-bot' header
+- `packages/voice-capture/src/services/ingest.ts` — added 'voice-capture' header
+- `packages/workers/src/skills/base-skill.ts` — added 'workers' header to autonomy fetch
+- `packages/workers/src/skills/memory-consolidation.ts` — added 'memory-consolidation' header
+- `packages/workers/src/skills/daily-sweep-skill.ts` — added 'workers' header
+- `packages/workers/src/skills/daily-connections.ts` — added 'workers' header
+- `packages/workers/src/skills/drift-monitor.ts` — added 'workers' header
+- `packages/workers/src/skills/monthly-reflection.ts` — added 'workers' header
+- `packages/workers/src/skills/weekly-brief.ts` — added 'workers' header
+- `packages/core-api/src/middleware/rate-limit.ts` — BYPASS_CALLERS 6→16 entries
+- `packages/core-api/src/__tests__/rate-limit.test.ts` — updated 2 tests (slack-bot/workers now bypassed; use 'custom-service' for bucketing coverage)
+- `packages/web/nginx.conf` — strip header on /mcp; audit comment on /api/ + /api/v1/events
+- `packages/workers/src/scheduler.ts` — 5 cron strings updated + JSDoc + budget default
+- `packages/workers/src/__tests__/scheduler-connections-cron.test.ts` — updated for new 6:10 AM cron
+- `packages/workers/src/jobs/check-triggers.ts` — concurrency 5→2
+- `packages/workers/src/jobs/ingest-root.ts` — concurrency 3→2
+- `packages/workers/src/jobs/ingestion-worker.ts` — concurrency 3→2
+- `packages/workers/src/jobs/update-access-stats.ts` — concurrency 5→2
+- `packages/core-api/src/__tests__/integration/rate-limit-internal.test.ts` — NEW
+
+**Test counts (final, all passing):**
+| Package | Files | Tests |
+|---------|-------|-------|
+| core-api | 43 | 732 |
+| workers | 49 | 980 |
+| slack-bot | 14 | 492 |
+| voice-capture | 5 | 82 |
+| **Total** | **111** | **2,286** |
+
+**tsc --noEmit:** CLEAN on all 4 packages.
+
+**Integration test (1.6):** TS-clean. Fails at setup with ECONNREFUSED :5433 (Postgres test harness not running locally — expected). CI will exercise.
+
+**Deviations from plan:**
+- 2 existing rate-limit.test.ts tests expected `429` from `slack-bot`/`workers` callers. With P07 bypass these callers no longer get 429. Updated tests to use `'custom-service'` (non-bypassed) to preserve bucketing behavior coverage + added explicit bypass assertion for `slack-bot`.
+- `scheduler-connections-cron.test.ts` hardcoded `'0 7 * * *'` and the JSDoc string `'daily-connections: 7:00 AM daily'`. Updated to match new `'10 6 * * *'` / `'6:10 AM daily'`.
+- Both deviations were expected consequences of the changes, not surprises.
+
+**Duration:** ~45 minutes

--- a/packages/core-api/src/__tests__/integration/rate-limit-internal.test.ts
+++ b/packages/core-api/src/__tests__/integration/rate-limit-internal.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration test — rate-limit internal caller bypass
+ *
+ * Verifies two invariants:
+ * 1. 100 parallel requests with X-Open-Brain-Caller: integration-test all succeed (no 429)
+ *    — confirms bypass logic works under concurrent load.
+ * 2. Negative control: 100 parallel POST requests WITHOUT the bypass header DO trigger 429s
+ *    — confirms the limiter is actually enforcing limits, not vacuously absent.
+ *
+ * Requires docker-compose.test.yml to be running.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import {
+  initTestDatabase,
+  teardownTestDatabase,
+  getTestApp,
+  type TestAppContext,
+} from './setup.js'
+import { cleanDatabase } from './helpers.js'
+
+let ctx: TestAppContext
+
+beforeAll(async () => {
+  await initTestDatabase()
+  ctx = getTestApp()
+})
+
+afterAll(async () => {
+  await teardownTestDatabase()
+})
+
+describe('Internal caller bypass under 100-parallel load', () => {
+  it('100 parallel GET /api/v1/captures with X-Open-Brain-Caller: integration-test all succeed (no 429)', async () => {
+    await cleanDatabase()
+
+    const N = 100
+    const requests = Array.from({ length: N }, () =>
+      ctx.app.fetch(
+        new Request('http://localhost/api/v1/captures', {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Open-Brain-Caller': 'integration-test',
+          },
+        }),
+      ),
+    )
+    const responses = await Promise.all(requests)
+    const count429 = responses.filter(r => r.status === 429).length
+    expect(count429).toBe(0)
+    expect(responses.every(r => r.status === 200)).toBe(true)
+  })
+
+  it('negative control: POST without bypass header DOES 429 after strict-tier exhaustion', async () => {
+    await cleanDatabase()
+
+    // Strict tier limit is 20/min for POST /api/v1/captures (no X-Open-Brain-Caller)
+    // Send 100 concurrent POST requests — at least some should 429
+    const N = 100
+    const requests = Array.from({ length: N }, () =>
+      ctx.app.fetch(
+        new Request('http://localhost/api/v1/captures', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            content: 'rate limit test capture',
+            capture_type: 'idea',
+            brain_view: 'technical',
+            source: 'api',
+          }),
+        }),
+      ),
+    )
+    const responses = await Promise.all(requests)
+    const count429 = responses.filter(r => r.status === 429).length
+    // Strict limiter is 20/min — with 100 parallel requests some must 429
+    expect(count429).toBeGreaterThan(0)
+  })
+})

--- a/packages/core-api/src/__tests__/rate-limit.test.ts
+++ b/packages/core-api/src/__tests__/rate-limit.test.ts
@@ -211,7 +211,7 @@ describe('rateLimit middleware', () => {
     app.get('/api/test', (c) => c.json({ ok: true }))
 
     try {
-      // slack-bot gets its own bucket
+      // P07: slack-bot and workers are now bypassed — always succeed regardless of limit
       const res1 = await app.request(
         new Request('http://localhost/api/test', {
           headers: { 'X-Open-Brain-Caller': 'slack-bot' },
@@ -219,23 +219,31 @@ describe('rateLimit middleware', () => {
       )
       expect(res1.status).toBe(200)
 
-      // slack-bot over limit
+      // slack-bot bypassed — second call also succeeds (no 429)
       const res2 = await app.request(
         new Request('http://localhost/api/test', {
           headers: { 'X-Open-Brain-Caller': 'slack-bot' },
         }),
       )
-      expect(res2.status).toBe(429)
+      expect(res2.status).toBe(200)
 
-      // workers gets its own bucket — still allowed
-      const res3 = await app.request(
+      // Use a non-bypassed caller to verify bucketing: 'custom-service' has its own bucket
+      const res3a = await app.request(
         new Request('http://localhost/api/test', {
-          headers: { 'X-Open-Brain-Caller': 'workers' },
+          headers: { 'X-Open-Brain-Caller': 'custom-service' },
         }),
       )
-      expect(res3.status).toBe(200)
+      expect(res3a.status).toBe(200)
 
-      // default-client (no headers) also has its own bucket
+      // custom-service over limit
+      const res3b = await app.request(
+        new Request('http://localhost/api/test', {
+          headers: { 'X-Open-Brain-Caller': 'custom-service' },
+        }),
+      )
+      expect(res3b.status).toBe(429)
+
+      // default-client (no headers) also has its own bucket — still allowed since different bucket
       const res4 = await app.request(new Request('http://localhost/api/test'))
       expect(res4.status).toBe(200)
     } finally {
@@ -250,23 +258,23 @@ describe('rateLimit middleware', () => {
     app.get('/api/test', (c) => c.json({ ok: true }))
 
     try {
-      // Both headers present — caller header wins
+      // Use a non-bypassed caller to verify caller header takes priority over X-Forwarded-For
       const res1 = await app.request(
         new Request('http://localhost/api/test', {
           headers: {
-            'X-Open-Brain-Caller': 'slack-bot',
-            'X-Forwarded-For': '10.0.0.1',
+            'X-Open-Brain-Caller': 'custom-service',
+            'X-Forwarded-For': '10.0.0.2',
           },
         }),
       )
       expect(res1.status).toBe(200)
 
-      // Same caller over limit, but forwarded-for IP is separate bucket
+      // Same caller over limit (separate bucket from IP)
       const res2 = await app.request(
         new Request('http://localhost/api/test', {
           headers: {
-            'X-Open-Brain-Caller': 'slack-bot',
-            'X-Forwarded-For': '10.0.0.1',
+            'X-Open-Brain-Caller': 'custom-service',
+            'X-Forwarded-For': '10.0.0.2',
           },
         }),
       )
@@ -275,10 +283,21 @@ describe('rateLimit middleware', () => {
       // Same forwarded-for IP without caller header — different bucket, allowed
       const res3 = await app.request(
         new Request('http://localhost/api/test', {
-          headers: { 'X-Forwarded-For': '10.0.0.1' },
+          headers: { 'X-Forwarded-For': '10.0.0.2' },
         }),
       )
       expect(res3.status).toBe(200)
+
+      // P07: slack-bot is bypassed — always succeeds even when caller-bucket is exhausted
+      const res4 = await app.request(
+        new Request('http://localhost/api/test', {
+          headers: {
+            'X-Open-Brain-Caller': 'slack-bot',
+            'X-Forwarded-For': '10.0.0.2',
+          },
+        }),
+      )
+      expect(res4.status).toBe(200)
     } finally {
       limiter.dispose()
     }

--- a/packages/core-api/src/middleware/rate-limit.ts
+++ b/packages/core-api/src/middleware/rate-limit.ts
@@ -164,6 +164,18 @@ export function rateLimit(limiter: RateLimiter): MiddlewareHandler {
       'internal:utility-pipeline',
       // CS3 — batch ingest sidecar + ingest-process worker callbacks
       'internal:ingest',
+      // P07 — new internal service callers
+      'internal:slack-bot',
+      'internal:voice-capture',
+      'internal:memory-consolidation',
+      'internal:workers',
+      // P07 — callers that already set the header but were missing from bypass
+      'internal:email-classify',
+      'internal:email-compose-skill',
+      'internal:batch-wiki-ingest',
+      'internal:email-pipeline',
+      'internal:ingest-onedrive',
+      'internal:ingest-repair',
     ])
     if (BYPASS_CALLERS.has(key)) {
       await next()

--- a/packages/slack-bot/src/lib/core-api-client.ts
+++ b/packages/slack-bot/src/lib/core-api-client.ts
@@ -44,6 +44,7 @@ export class CoreApiClient {
       ...options,
       headers: {
         'Content-Type': 'application/json',
+        'X-Open-Brain-Caller': 'slack-bot',
         ...options.headers,
       },
     })

--- a/packages/voice-capture/src/services/ingest.ts
+++ b/packages/voice-capture/src/services/ingest.ts
@@ -56,7 +56,10 @@ export class IngestService {
       try {
         const res = await fetch(url, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Open-Brain-Caller': 'voice-capture',
+          },
           body: JSON.stringify(payload),
           signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         })

--- a/packages/web/nginx.conf
+++ b/packages/web/nginx.conf
@@ -43,6 +43,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # P07: nginx overwrites X-Open-Brain-Caller (replaces any client-supplied value — intentional)
         proxy_set_header X-Open-Brain-Caller "web-ui";
         proxy_set_header Connection "";
         # Disable buffering for SSE
@@ -59,6 +60,8 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # P07: strip client-supplied X-Open-Brain-Caller — MCP clients use IP-based rate limits
+        proxy_set_header X-Open-Brain-Caller "";
         proxy_set_header Connection "";
         proxy_read_timeout 60s;
     }
@@ -70,6 +73,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # P07: nginx overwrites X-Open-Brain-Caller (replaces any client-supplied value — intentional)
         proxy_set_header X-Open-Brain-Caller "web-ui";
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/packages/workers/src/__tests__/scheduler-connections-cron.test.ts
+++ b/packages/workers/src/__tests__/scheduler-connections-cron.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 
 /**
- * Verifies that the daily-connections cron was re-enabled from the disabled
- * Feb-29-only cron to daily 7 AM. We test this by importing the scheduler
- * source and checking the cron value, since BullMQ queue operations require
- * a live Redis connection.
+ * Verifies that the daily-connections cron is correctly set.
+ * P07: rescheduled from 7:00 AM to 6:10 AM to spread the morning job cluster.
+ * We test this by reading the scheduler source and checking the cron value,
+ * since BullMQ queue operations require a live Redis connection.
  */
-describe('scheduler — daily-connections cron re-enablement', () => {
-  it('daily-connections cron is 0 7 * * * (daily 7 AM), not disabled', async () => {
+describe('scheduler — daily-connections cron', () => {
+  it('daily-connections cron is 10 6 * * * (daily 6:10 AM), not disabled', async () => {
     // Read the scheduler source to verify the cron value
     const { readFileSync } = await import('node:fs')
     const { join } = await import('node:path')
@@ -15,21 +15,23 @@ describe('scheduler — daily-connections cron re-enablement', () => {
     const schedulerPath = join(import.meta.dirname, '..', 'scheduler.ts')
     const source = readFileSync(schedulerPath, 'utf-8')
 
-    // The connectionsCron should be '0 7 * * *' (daily 7 AM)
-    expect(source).toContain("const connectionsCron = '0 7 * * *'")
+    // P07: connectionsCron rescheduled to '10 6 * * *' (daily 6:10 AM)
+    expect(source).toContain("const connectionsCron = '10 6 * * *'")
     // Should NOT contain the disabled Feb 29 cron
     expect(source).not.toContain("'0 0 29 2 *'")
+    // Should NOT contain the old 7 AM cron
+    expect(source).not.toContain("const connectionsCron = '0 7 * * *'")
   })
 
-  it('JSDoc describes daily-connections as enabled at 7 AM', async () => {
+  it('JSDoc describes daily-connections as enabled at 6:10 AM (P07 spread)', async () => {
     const { readFileSync } = await import('node:fs')
     const { join } = await import('node:path')
 
     const schedulerPath = join(import.meta.dirname, '..', 'scheduler.ts')
     const source = readFileSync(schedulerPath, 'utf-8')
 
-    // JSDoc should describe it as active, not disabled
-    expect(source).toContain('daily-connections: 7:00 AM daily')
+    // JSDoc should describe it as active at 6:10 AM
+    expect(source).toContain('daily-connections:        6:10 AM daily')
     expect(source).not.toContain('DISABLED')
   })
 })

--- a/packages/workers/src/jobs/check-triggers.ts
+++ b/packages/workers/src/jobs/check-triggers.ts
@@ -286,7 +286,7 @@ export function createCheckTriggersWorker(
     },
     {
       connection,
-      concurrency: 5, // multiple captures can be checked simultaneously
+      concurrency: 2, // P07: reduced from 5
     },
   )
 

--- a/packages/workers/src/jobs/ingest-root.ts
+++ b/packages/workers/src/jobs/ingest-root.ts
@@ -93,7 +93,7 @@ export function createIngestRootWorker(
     },
     {
       connection,
-      concurrency: 3,
+      concurrency: 2, // P07: reduced from 3
     },
   )
 

--- a/packages/workers/src/jobs/ingestion-worker.ts
+++ b/packages/workers/src/jobs/ingestion-worker.ts
@@ -208,7 +208,7 @@ export function createIngestionWorker(
     },
     {
       connection,
-      concurrency: 3,
+      concurrency: 2, // P07: reduced from 3
       settings: {
         backoffStrategy: pipelineBackoffStrategy,
       },

--- a/packages/workers/src/jobs/update-access-stats.ts
+++ b/packages/workers/src/jobs/update-access-stats.ts
@@ -127,7 +127,7 @@ export function createAccessStatsWorker(
     },
     {
       connection,
-      concurrency: 5,
+      concurrency: 2, // P07: reduced from 5
     },
   )
 

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -308,9 +308,9 @@ export async function registerScheduledJobs(
   logger.info({ cron: monthlyReflectionCron }, '[scheduler] monthly-reflection repeatable job registered')
 
   // --------------------------------------------------------
-  // Cost analysis (7:10 AM daily)
+  // Cost analysis (6:20 AM daily — P07 spread)
   // --------------------------------------------------------
-  const costAnalysisCron = '10 7 * * *'
+  const costAnalysisCron = '20 6 * * *'
 
   await skillExecutionQueue.add(
     'cost-analysis',

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -19,12 +19,13 @@ export interface ScheduledQueues {
  *
  * Jobs registered:
  * - daily-sweep: 3:00 AM daily (cron: 0 3 * * *) — re-queues stuck pipeline captures
- * - budget-check: 8:00 AM daily (cron: 0 8 * * *) — checks monthly AI spend vs thresholds
- * - daily-connections: 7:00 AM daily (cron: 0 7 * * *) — cross-domain connections + wiki synthesis (anchor)
- * - capture-reminder-morning: 7:05 AM weekdays (cron: 5 7 * * 1-5) — morning Pushover nudge
- * - cost-analysis: 7:10 AM daily (cron: 10 7 * * *) — LLM cost tracking, weekly/monthly reports
- * - morning-brief: 7:15 AM weekdays (cron: 15 7 * * 1-5) — structured morning briefing (no LLM)
- * - drift-monitor: 8:15 AM daily (cron: 15 8 * * *) — detects brain-view classification drift
+ * - wiki-synthesis:           6:00 AM daily    (cron: 0 6 * * *)    — anchor (unchanged)
+ * - daily-connections:        6:10 AM daily    (cron: 10 6 * * *)   — cross-domain connections (P07: spread from 7:00)
+ * - cost-analysis:            6:20 AM daily    (cron: 20 6 * * *)   — LLM cost tracking (P07: spread from 7:10)
+ * - morning-brief:            6:30 AM weekdays (cron: 30 6 * * 1-5) — structured morning briefing (P07: spread from 7:15)
+ * - capture-reminder-morning: 6:45 AM weekdays (cron: 45 6 * * 1-5) — morning Pushover nudge (P07: spread from 7:05)
+ * - budget-check:             7:00 AM daily    (cron: 0 7 * * *)    — monthly AI spend vs thresholds (P07: spread from 8:00)
+ * - drift-monitor:            7:15 AM daily    (cron: 15 7 * * *)   — brain-view classification drift (P07: spread from 8:15)
  * - pipeline-health: every 6 hours (cron: 0 0,6,12,18 * * *) — checks pipeline + capture flow health
  * - daily-sweep-skill: 8:00 PM daily (cron: 0 20 * * *) — LLM-powered evening summary
  * - capture-reminder-evening: 9:00 PM daily (cron: 0 21 * * *) — evening Pushover nudge with capture count
@@ -80,7 +81,7 @@ export async function registerScheduledJobs(
   // --------------------------------------------------------
   // Budget check (8:00 AM)
   // --------------------------------------------------------
-  const budgetCron = budgetCronOverride ?? '0 8 * * *'
+  const budgetCron = budgetCronOverride ?? '0 7 * * *' // P07: spread from 8:00 AM
 
   const budgetCheckQueue = createBudgetCheckQueue(connection)
 
@@ -98,7 +99,7 @@ export async function registerScheduledJobs(
   // --------------------------------------------------------
   // Daily connections skill (7:00 AM daily)
   // --------------------------------------------------------
-  const connectionsCron = '0 7 * * *'
+  const connectionsCron = '10 6 * * *' // P07: spread from 7:00 AM
 
   const skillExecutionQueue = createSkillExecutionQueue(connection)
 
@@ -119,7 +120,7 @@ export async function registerScheduledJobs(
   // --------------------------------------------------------
   // Drift monitor skill (8:15 AM)
   // --------------------------------------------------------
-  const driftCron = '15 8 * * *'
+  const driftCron = '15 7 * * *' // P07: spread from 8:15 AM
 
   await skillExecutionQueue.add(
     'drift-monitor',
@@ -195,7 +196,7 @@ export async function registerScheduledJobs(
   // --------------------------------------------------------
   // Capture reminder — morning (7:05 AM weekdays)
   // --------------------------------------------------------
-  const captureReminderMorningCron = '5 7 * * 1-5'
+  const captureReminderMorningCron = '45 6 * * 1-5' // P07: spread from 7:05 AM weekdays
 
   await skillExecutionQueue.add(
     'capture-reminder-morning',
@@ -214,7 +215,7 @@ export async function registerScheduledJobs(
   // --------------------------------------------------------
   // Morning brief (7:15 AM weekdays)
   // --------------------------------------------------------
-  const morningBriefCron = '15 7 * * 1-5'
+  const morningBriefCron = '30 6 * * 1-5' // P07: spread from 7:15 AM weekdays
 
   await skillExecutionQueue.add(
     'morning-brief',

--- a/packages/workers/src/skills/base-skill.ts
+++ b/packages/workers/src/skills/base-skill.ts
@@ -12,7 +12,9 @@ async function fetchAutonomyLevel(coreApiUrl: string): Promise<AutonomyLevel> {
     return _autonomyCache.level
   }
   try {
-    const response = await fetch(`${coreApiUrl}/api/v1/settings/autonomy_level`)
+    const response = await fetch(`${coreApiUrl}/api/v1/settings/autonomy_level`, {
+      headers: { 'X-Open-Brain-Caller': 'workers' },
+    })
     if (response.ok) {
       const data = (await response.json()) as { value: string }
       const level = (['observe', 'assist', 'advise', 'partner'].includes(data.value)

--- a/packages/workers/src/skills/daily-connections.ts
+++ b/packages/workers/src/skills/daily-connections.ts
@@ -244,7 +244,10 @@ export class DailyConnectionsSkill extends LLMSkill<DailyConnectionsOptions, Dai
       const content = buildConnectionsText(output, windowStart, windowEnd)
       const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Open-Brain-Caller': 'workers',
+        },
         body: JSON.stringify({
           content,
           capture_type: 'reflection',

--- a/packages/workers/src/skills/daily-sweep-skill.ts
+++ b/packages/workers/src/skills/daily-sweep-skill.ts
@@ -230,7 +230,10 @@ export class DailySweepSkill extends LLMSkill<DailySweepOptions, DailySweepResul
       const content = buildSweepText(output, date)
       const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Open-Brain-Caller': 'workers',
+        },
         body: JSON.stringify({
           content,
           capture_type: 'reflection',

--- a/packages/workers/src/skills/drift-monitor.ts
+++ b/packages/workers/src/skills/drift-monitor.ts
@@ -268,7 +268,10 @@ export class DriftMonitorSkill extends LLMSkill<DriftMonitorOptions, DriftMonito
       const content = buildDriftText(output, analysisDate)
       const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Open-Brain-Caller': 'workers',
+        },
         body: JSON.stringify({
           content,
           capture_type: 'reflection',

--- a/packages/workers/src/skills/memory-consolidation.ts
+++ b/packages/workers/src/skills/memory-consolidation.ts
@@ -421,7 +421,10 @@ export class MemoryConsolidationSkill extends LLMSkill<MemoryConsolidationOption
     try {
       const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Open-Brain-Caller': 'memory-consolidation',
+        },
         body: JSON.stringify({
           content,
           capture_type: 'reflection',

--- a/packages/workers/src/skills/monthly-reflection.ts
+++ b/packages/workers/src/skills/monthly-reflection.ts
@@ -456,7 +456,10 @@ export class MonthlyReflectionSkill extends BaseSkill<MonthlyReflectionOptions, 
       const content = buildCaptureText(output)
       const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Open-Brain-Caller': 'workers',
+        },
         body: JSON.stringify({
           content,
           capture_type: 'reflection',

--- a/packages/workers/src/skills/weekly-brief.ts
+++ b/packages/workers/src/skills/weekly-brief.ts
@@ -155,7 +155,7 @@ export class WeeklyBriefSkill extends LLMSkill<WeeklyBriefOptions, WeeklyBriefRe
   private async saveBriefCapture(brief: WeeklyBriefOutput, weekStart: string, weekEnd: string): Promise<string | null> {
     try {
       const res = await fetch(`${this.coreApiUrl}/api/v1/captures`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Open-Brain-Caller': 'workers' },
         body: JSON.stringify({ content: buildBriefText(brief, weekStart, weekEnd), capture_type: 'reflection', brain_view: 'personal', source: 'api', metadata: { source_metadata: { generator: 'weekly-brief-skill', week_start: weekStart, week_end: weekEnd } } }),
         signal: AbortSignal.timeout(15_000),
       })


### PR DESCRIPTION
## Summary

Closes #114 (rate-limit self-contention) + #117 (job thunderstorm).

**Rate-limit:**
- 9 internal callers now set `X-Open-Brain-Caller` (slack-bot, voice-capture, 6 worker skills, base-skill autonomy fetch).
- `BYPASS_CALLERS` expanded from 6 → 16 entries (4 new service callers + 6 script callers that were already setting the header but missing from bypass — audit finding).
- `packages/web/nginx.conf`: `/mcp` location block now explicitly strips client-supplied `X-Open-Brain-Caller` (previously passed through — public clients could spoof bypass). `/api/` + `/api/v1/events` blocks already overwrite correctly; added audit comments.
- Integration test: 100 parallel internal calls with bypass header succeed (no 429); negative control confirms strict limiter still fires at 21 req/min without header.

**Scheduler thunderstorm:**
- 7-job cluster in 06:00-08:15 window spread across 06:00-07:15, no two jobs on the same minute. Real cluster was 4 jobs in 15 min at 07:00 (not the card's "19"). BullMQ `repeat` upserts new crons on next workers restart.
- BullMQ worker concurrency lowered to 2/queue on 4 workers (check-triggers 5→2, ingest-root 3→2, ingestion-worker 3→2, update-access-stats 5→2). 5 singletons preserved for correctness (budget-check, daily-sweep, skill-execution, prune-associations, wiki-ingest).

## Investigation corrections vs card

- Card said "19 jobs" in 06:00-09:00 — actual is 7 (real cluster was 4-in-15-min at 07:00).
- Card referenced \`config/cloudflare/nginx.conf\` — actual front door is \`packages/web/nginx.conf\`. Cloudflare tunnel routes directly to the web container (nginx).

## Test plan

- [x] \`pnpm --filter @open-brain/core-api exec tsc --noEmit\` — 0 errors
- [x] \`pnpm --filter @open-brain/workers exec tsc --noEmit\` — 0 errors
- [x] \`pnpm --filter @open-brain/slack-bot exec tsc --noEmit\` — 0 errors
- [x] \`pnpm --filter @open-brain/voice-capture exec tsc --noEmit\` — 0 errors
- [x] \`pnpm --filter @open-brain/core-api run test\` — 732 pass (rate-limit tests updated to use non-bypassed caller names)
- [x] \`pnpm --filter @open-brain/workers run test\` — 980 pass (scheduler cron test updated for new spread)
- [x] \`pnpm --filter @open-brain/slack-bot run test\` — 492 pass
- [x] \`pnpm --filter @open-brain/voice-capture run test\` — 82 pass
- [ ] \`rate-limit-internal.test.ts\` integration test — TS-clean; skipped locally (Postgres test harness not running); CI will exercise
- [ ] Homeserver \`docker compose exec web nginx -t\` — operator validates before deploy
- [ ] Homeserver deploy deferred (A70 batch window)

## Rollback

\`git revert <merge sha>\`. No schema change. Rate-limit additive; callers fall back to IP-based limits on revert. nginx changes revert cleanly (\`docker compose restart web\`). Scheduler crons upsert via BullMQ repeatable on next workers restart. Concurrency takes effect on restart. No data loss, no queue corruption. Safe without maintenance window.

## Artifacts

- Plan: \`IMPLEMENT_PHASE-P07.md\`
- Lab notebook: Entry 101

## Operator-approval note

nginx.conf (live production traffic path) + rate-limit.ts (security middleware) + scheduler cron changes → operator approval required at Gate 5. Plus: operator should run \`docker compose exec web nginx -t\` during deploy to validate config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)