### PR TITLE
P16: DR restore rehearsal script + cron + runbook + 9-case test

### DIFF
--- a/IMPLEMENT_PHASE-P16.md
+++ b/IMPLEMENT_PHASE-P16.md
@@ -1,0 +1,312 @@
+# IMPLEMENT_PHASE-P16 — Backup Restore Rehearsal
+
+**Phase:** P16  
+**Source card:** PHASED_PLAN.md § P16  
+**Effort estimate:** ~1 day  
+**Dependencies:** P04b ✅ (secrets redacted from backup payload), P08 ✅ (load-secrets.sh BWS reconciler complete)  
+**Status:** Ready — all dependencies merged; P08 unblocks the automation (no live secrets in backup tree).
+
+---
+
+## Scope Diff (Card vs. Current Reality)
+
+| Card assumption | Actual state | Action |
+|-----------------|--------------|--------|
+| "P04 (.env.secrets redacted)" | P04b ✅ — `scripts/test-backup-secrets-redaction.sh` guards it; backup.sh explicitly skips `.env.secrets` | No change needed |
+| "P08 delivered BWS reconciler" | P08 ✅ — `scripts/load-secrets.sh` fully implemented with `--dry-run`, `--verify-hash`, Pushover notify | Reference in runbook |
+| Card says "weekly cron entry on homeserver (Sunday 05:00, after memory-consolidation at 04:00)" | Cron slot audit: `0 5 * * 0` is **available** (wiki-lint is `0 5 * * 0` per CLAUDE.md scheduler table). **CONFLICT.** Must stagger — use `30 5 * * 0` (30 min after wiki-lint) | Shift cron to `30 5 * * 0` |
+| Card says "pulls latest backup from `/mnt/user/backup/openbrain/`" | `backup.sh` creates `${BACKUP_ROOT}/latest` symlink pointing to most recent daily — use that | Use `${BACKUP_ROOT}/latest` symlink |
+| No existing `scripts/restore-rehearsal.sh` | Correct — file does not exist | Create it |
+| Runbook directory | `docs/runbooks/` exists with 5 existing runbooks | Create `docs/runbooks/restore-rehearsal.md` following existing format |
+| Cron install pattern | `deploy/cron/unraid-ingest.cron` is the established pattern for host cron entries | Create `deploy/cron/unraid-restore-rehearsal.cron` |
+
+**Scope drift severity: LOW.** One cron slot conflict (shift 30 min). No structural change to deliverables.
+
+---
+
+## Work Items
+
+### WI-1: `scripts/restore-rehearsal.sh`
+
+**File:** `scripts/restore-rehearsal.sh` (new)
+
+Script must:
+1. Locate the backup: `${BACKUP_ROOT:-/mnt/user/backup/openbrain}/latest` symlink → resolve to an absolute daily dir
+2. Verify the dump file exists: `${BACKUP_DIR}/openbrain.pgdump`
+3. Read expected row counts from `manifest.json` (`tables` object) — this becomes the validation baseline
+4. Spin up an ephemeral Postgres container:
+   ```bash
+   docker run --rm -d \
+     --name open-brain-rehearsal-pg \
+     -e POSTGRES_PASSWORD=rehearsal \
+     -e POSTGRES_USER=openbrain \
+     -e POSTGRES_DB=openbrain \
+     pgvector/pgvector:pg16
+   ```
+   Use `pgvector/pgvector:pg16` to match production — pgvector extension must be present or `pg_restore` will fail on vector columns.
+5. Wait for Postgres to be ready (`pg_isready` poll, max 30s)
+6. Install pgvector extension: `docker exec ... psql -U openbrain -d openbrain -c "CREATE EXTENSION IF NOT EXISTS vector"`
+7. Run `pg_restore` via docker exec into the rehearsal container (copy dump in via `docker cp` then restore inside — avoids needing pg_restore on the Unraid host directly):
+   ```bash
+   docker cp "${BACKUP_DIR}/openbrain.pgdump" open-brain-rehearsal-pg:/tmp/restore.pgdump
+   docker exec open-brain-rehearsal-pg pg_restore \
+     -U openbrain -d openbrain \
+     --no-owner --no-privileges \
+     --exit-on-error \
+     /tmp/restore.pgdump
+   ```
+8. Validate row counts — for each table in `manifest.json`, query actual count and compare against manifest value with ±10% tolerance (to account for the backup being from yesterday). Hard-fail if any table is at 0 rows when manifest says > 0 (catastrophic blank restore).
+9. Tear down: `docker stop open-brain-rehearsal-pg` (--rm handles cleanup)
+10. Emit structured summary + exit code (0 = pass, 1 = fail)
+11. Send Pushover notification either way (pass = priority 0 / normal, fail = priority 1 / high):
+    - Source `scripts/lib/pushover-notify.sh` — already has `notify_pushover_mismatch`; add a second function `notify_pushover_rehearsal_result` or re-use with a message parameter
+    - Credentials from env: `PUSHOVER_APP_TOKEN` + `PUSHOVER_USER_KEY` (same as backup.sh env context)
+
+**Env overrides (test-harness friendly, same pattern as backup.sh):**
+- `BACKUP_ROOT` — default `/mnt/user/backup/openbrain`
+- `REHEARSAL_CONTAINER` — default `open-brain-rehearsal-pg`
+- `PUSHOVER_API_URL` — default `https://api.pushover.net/1/messages.json` (mock-able for tests)
+- `ROW_COUNT_TOLERANCE` — default `0.10` (10%)
+
+**Exit codes:**
+- `0` — restore successful, all row counts within tolerance
+- `1` — restore failed (pg_restore error OR row count validation failed)
+- `2` — precondition failure (no backup found, manifest missing, container couldn't start)
+
+**Memory ceiling:** Script is pure bash + docker exec. No Node process. Compliant with 1.5 GB rule.
+
+---
+
+### WI-2: `scripts/lib/pushover-notify.sh` — add rehearsal notification function
+
+**File:** `scripts/lib/pushover-notify.sh` (edit)
+
+Add `notify_pushover_rehearsal` function below the existing `notify_pushover_mismatch`:
+
+```bash
+# notify_pushover_rehearsal <status> <summary_message>
+#   status: "pass" (priority 0) or "fail" (priority 1)
+#   Sends a Pushover notification for restore rehearsal results.
+notify_pushover_rehearsal() {
+  local status="$1"
+  local message="${2:-Open Brain: restore rehearsal ${status}}"
+  local title="Open Brain: DR rehearsal ${status}"
+  local priority=0
+  [[ "$status" == "fail" ]] && priority=1
+  local url="${PUSHOVER_API_URL:-https://api.pushover.net/1/messages.json}"
+  local token="${PUSHOVER_APP_TOKEN:-${PUSHOVER_TOKEN:-}}"
+  local user="${PUSHOVER_USER_KEY:-${PUSHOVER_USER:-}}"
+  if [[ -z "$token" || -z "$user" ]]; then
+    echo "WARN: Pushover credentials missing — rehearsal alert skipped" >&2
+    return 0
+  fi
+  curl -sf --max-time 10 -X POST "$url" \
+    -d "token=${token}" \
+    -d "user=${user}" \
+    -d "title=${title}" \
+    -d "message=${message}" \
+    -d "priority=${priority}" >/dev/null 2>&1 || \
+    echo "WARN: Pushover POST failed (curl exit $?)" >&2
+  return 0
+}
+```
+
+---
+
+### WI-3: `deploy/cron/unraid-restore-rehearsal.cron`
+
+**File:** `deploy/cron/unraid-restore-rehearsal.cron` (new)
+
+Following the exact format of `deploy/cron/unraid-ingest.cron`:
+
+```
+# Open Brain — Restore rehearsal cron entry (Unraid host)
+#
+# INSTALL (post-merge, once):
+#   1. SSH to homeserver as `claude` (has passwordless sudo for cron operations).
+#   2. Append this line to the Unraid system crontab:
+#        sudo tee -a /boot/config/plugins/dynamix/custom.cron \
+#          < deploy/cron/unraid-restore-rehearsal.cron
+#   3. Reload cron:
+#        sudo /usr/local/sbin/update_cron
+#   4. Verify:
+#        crontab -l | grep restore-rehearsal
+#
+# SCHEDULE: Sunday 05:30 — after wiki-lint (0 5 * * 0) and before the
+#   production week starts. Staggered per P16 cron-slot audit: 0 5 * * 0
+#   is taken by wiki-lint; 30 5 * * 0 is the next available Sunday slot.
+#
+# ROLLBACK:
+#   Remove this line from /boot/config/plugins/dynamix/custom.cron and
+#   run update_cron again. Script can remain in repo — it makes no writes
+#   unless explicitly invoked.
+#
+# LOGS: /var/log/open-brain-restore-rehearsal.log
+#   Rotate manually with: sudo : > /var/log/open-brain-restore-rehearsal.log
+
+30 5 * * 0 cd /mnt/user/appdata/open-brain && bash scripts/restore-rehearsal.sh >> /var/log/open-brain-restore-rehearsal.log 2>&1
+```
+
+---
+
+### WI-4: `docs/runbooks/restore-rehearsal.md`
+
+**File:** `docs/runbooks/restore-rehearsal.md` (new)
+
+Content structure (following `docs/runbooks/capture-flow-alert.md` format):
+
+```markdown
+# Runbook: DR Restore Rehearsal Failure
+
+**Alert:** Pushover notification from `restore-rehearsal.sh`
+**Schedule:** Sunday 05:30 (Unraid host cron)
+**Script:** `scripts/restore-rehearsal.sh`
+**Log:** `/var/log/open-brain-restore-rehearsal.log` on homeserver
+
+---
+
+## What the rehearsal does
+
+1. Locates the most recent daily backup (`/mnt/user/backup/openbrain/latest` symlink)
+2. Reads expected row counts from `manifest.json`
+3. Spins up an ephemeral `pgvector/pgvector:pg16` container
+4. Runs `pg_restore` against the dump
+5. Validates actual row counts vs. manifest values (±10% tolerance)
+6. Tears down the ephemeral container
+7. Sends Pushover notification (pass or fail)
+
+---
+
+## Alert conditions
+
+| Exit code | Meaning |
+|-----------|---------|
+| 0 | Restore successful, row counts within tolerance |
+| 1 | Restore failed — pg_restore error OR row count mismatch |
+| 2 | Precondition failure — no backup found, manifest missing, container failed to start |
+
+---
+
+## Diagnosis
+
+### Check the log first
+[commands to read the rehearsal log, inspect manifest.json, etc.]
+
+### Restore failure (exit 1)
+- pg_restore error → check for schema drift (new migration not in dump; run from earlier dump)
+- Row count zero when manifest says >N → blank restore; pg_restore may have silently exited 0 despite errors; re-run with `-v` flag
+
+### Precondition failure (exit 2)
+- No backup file → backup.sh cron may have failed; check `/tmp/open-brain-backup.log`
+- Container start failure → Docker daemon issue on homeserver
+
+---
+
+## Manual restore (actual DR)
+
+[Step-by-step commands for a real disaster recovery scenario using the backup + load-secrets.sh]
+
+---
+
+## Testing the failure path manually
+[Instructions for corrupting a backup to verify the alert fires]
+```
+
+---
+
+### WI-5: `scripts/test-restore-rehearsal.sh` — regression test
+
+**File:** `scripts/test-restore-rehearsal.sh` (new)
+
+Similar structure to `scripts/test-backup-secrets-redaction.sh`: uses env overrides to test without real Docker.
+
+Test coverage:
+1. **Happy path** (mock mode): supply a fake manifest.json + a path to a known-good dump; verify exit 0 and that the Pushover mock received a "pass" call
+2. **Missing backup** (BACKUP_ROOT points to empty dir): verify exit 2
+3. **Missing manifest.json**: verify exit 2
+4. **Corrupted dump** (truncated file): verify exit 1 and Pushover mock received "fail"
+5. **Row count tolerance check**: create manifest with table X = 100 rows; restore produces 95 (within 10%) → pass; 80 (outside) → fail
+
+**Note:** Tests that actually spin Docker containers (WI-1 step 3-9) are exercised manually per the acceptance criteria. This test script covers the bash logic and Pushover notification path using `PUSHOVER_API_URL` mock override + a local `nc` listener or Python http.server.
+
+---
+
+## Acceptance Criteria (from card + cron slot drift fix)
+
+| # | Criterion | How to verify |
+|---|-----------|---------------|
+| AC-1 | Rehearsal script passes manually against a real backup on homeserver | `bash scripts/restore-rehearsal.sh` exits 0; Pushover "pass" notification received |
+| AC-2 | Cron job installed on homeserver (Sunday 05:30, not 05:00 — stagger fix) | `crontab -l \| grep restore-rehearsal` shows `30 5 * * 0` line |
+| AC-3 | Pushover notification delivered on pass | AC-1 verification includes checking phone |
+| AC-4 | Failure test: intentionally corrupt a backup, verify rehearsal exits 1 + Pushover "fail" fires | `truncate -s 1k /mnt/user/backup/openbrain/latest/openbrain.pgdump && bash scripts/restore-rehearsal.sh`; script exits 1, restore phone notification = "fail" |
+| AC-5 | `scripts/test-restore-rehearsal.sh` passes locally | `bash scripts/test-restore-rehearsal.sh` exits 0 |
+| AC-6 | Runbook exists and covers manual DR steps | `docs/runbooks/restore-rehearsal.md` present; operator reviews |
+| AC-7 | No two cron jobs on same minute (P07 rule) | `grep '5 \* \* 0\|30 5 \* \* 0' deploy/cron/*.cron` — no collisions |
+
+---
+
+## Rollback Plan
+
+Per card: remove cron entry from homeserver; script remains in repo.
+
+```bash
+# On homeserver
+sudo sed -i '/restore-rehearsal/d' /boot/config/plugins/dynamix/custom.cron
+sudo /usr/local/sbin/update_cron
+# Verify
+crontab -l | grep restore-rehearsal  # should return nothing
+```
+
+The ephemeral rehearsal container (`open-brain-rehearsal-pg`) is `--rm` — no persistent state to clean up.
+
+---
+
+## Dependencies on Prior Work
+
+| Dependency | PR | Relevance |
+|------------|-----|-----------|
+| P04b — secrets redacted from backup | #129 | `backup.sh` excludes `.env.secrets`; rehearsal script can run against backup tree safely |
+| P08 — load-secrets.sh BWS reconciler | #134 | Runbook references `load-secrets.sh` as the restore step for secrets; complete implementation means runbook instructions are accurate |
+| `scripts/lib/pushover-notify.sh` | Phase 3/P03 era | Library already exists; WI-2 extends it |
+| `deploy/cron/unraid-ingest.cron` | Phase 4 | Pattern reference for WI-3 |
+
+---
+
+## Files Touched
+
+| File | Action |
+|------|--------|
+| `scripts/restore-rehearsal.sh` | **CREATE** |
+| `scripts/lib/pushover-notify.sh` | **EDIT** — add `notify_pushover_rehearsal` function |
+| `deploy/cron/unraid-restore-rehearsal.cron` | **CREATE** |
+| `docs/runbooks/restore-rehearsal.md` | **CREATE** |
+| `scripts/test-restore-rehearsal.sh` | **CREATE** |
+
+No application code changes. No Drizzle migrations. No `package.json` changes. No CI changes (test script is bash, not vitest).
+
+---
+
+## Effort Breakdown
+
+| Item | Estimate |
+|------|----------|
+| WI-1: restore-rehearsal.sh | 3–4 h |
+| WI-2: pushover-notify.sh extension | 30 min |
+| WI-3: cron file | 30 min |
+| WI-4: runbook | 1 h |
+| WI-5: test script | 1–1.5 h |
+| Manual homeserver validation (AC-1 through AC-4) | 1 h |
+| **Total** | **~7–8.5 h (~1 day)** |
+
+Estimate matches card. No scope expansion.
+
+---
+
+## Notes for Implementer
+
+- **`pgvector/pgvector:pg16` is mandatory** — using `postgres:16` will fail on vector column restore because the pgvector extension won't be present.
+- **`pg_restore --exit-on-error`** is the right flag to surface silent schema errors. Without it, `pg_restore` can exit 0 even when it drops objects due to permission errors.
+- **Row count tolerance** must be ±10%, not exact match. The backup was taken at 03:00; by 05:30 Sunday there can be new captures from voice/Slack. Exact match would produce false failures.
+- **`docker cp` + `docker exec` pg_restore** is cleaner than mounting the host backup volume into the rehearsal container — it avoids bind-mount permission issues on Unraid.
+- **Cron slot confirmed:** `30 5 * * 0` is clear in the P07 slot registry. The card's `0 5 * * 0` would collide with wiki-lint. Do NOT use `0 5 * * 0`.
+- **Test script should NOT require actual Docker** — mock the container operations via `REHEARSAL_DRY_RUN=true` env var that short-circuits the docker run/exec/stop calls with a synthetic success result. This lets the bash logic + Pushover path be exercised in CI if desired.

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -7761,3 +7761,81 @@ Card said `packages/shared/src/services/prompt-builder.ts`. Actual pattern:
 - **#116 partial** — P14b (call-site migration) remains open.
 
 ---
+
+## Entry 112 — P14b: Prompt injection call-site migration to SafePromptBuilder — 2026-04-19
+
+**Tags:** [security] [prompt-injection] [workers] [api] [mcp]
+**Environment:** Laptop (development), branch `feat/phase-P14b-prompt-injection-migration`
+**Status:** IN PROGRESS
+
+### Objective
+
+Migrate all 6 confirmed prompt-injection call sites (synthesize.ts, daily-sweep-skill.ts, weekly-brief.ts, memory-consolidation.ts, daily-connections.ts, email-compose.ts) and 3 MCP tool return sites (search-brain.ts, get-capture.ts, list-captures.ts) to use `SafePromptBuilder` from P14a. Add adversarial integration test for synthesize. Update SECURITY.md residual risks. Also fold A73/#131: 6 deferred proactive skills needing `static minimum_autonomy` gates.
+
+### Hypothesis
+
+- All 9 production files pass user-controlled content through SafePromptBuilder before reaching LLM or MCP client.
+- Adversarial integration test: injection payload in a capture does NOT appear unsanitized in the prompt sent to LLMGatewayService.completeByTask.
+- `tsc --noEmit` clean on core-api and workers.
+- Existing test suites pass.
+
+### Rollback plan
+
+Git-tracked changes only. `git revert` the call-site commits. SafePromptBuilder (P14a) retained. No schema change, no config, no homeserver deploy.
+
+### email-compose design note
+
+`email-compose.ts` uses `runAgent()` with Anthropic tool-call loop, not a template-based LLM call. The injection surface is inside the `search_brain` tool's `execute()` function where DB rows are formatted as a return string. Applying `sanitizeInline` to each `r.content` before the 300-char slice inside the tool executor is the correct intervention point.
+
+---
+
+## Entry 114 — P16: DR restore rehearsal
+
+**Tags:** [deploy] [docker] [database] [decision]
+**Date:** 2026-04-19
+**Branch:** `feat/phase-P16-dr-restore-rehearsal`
+**Environment:** Laptop (worktree agent-a4e35656)
+
+### Objective
+
+Implement the weekly DR restore rehearsal automation: a bash script that locates the most recent backup, spins up an ephemeral `pgvector/pgvector:pg16` container, runs `pg_restore`, validates row counts against `manifest.json`, tears down, and sends Pushover notification. Also create a regression test, cron file, and runbook.
+
+### Hypothesis
+
+- `scripts/restore-rehearsal.sh` exits 0 against a real backup with all row counts within ±10% tolerance.
+- `scripts/test-restore-rehearsal.sh` exits 0 in dry-run mode on the laptop without a real backup or Docker.
+- Cron slot `30 5 * * 0` is unoccupied (P07 audit confirmed `0 5 * * 0` = wiki-lint; `30 5 * * 0` is clear).
+- No two cron jobs share the same Sunday minute (AC-7).
+- `scripts/lib/pushover-notify.sh` extended with `notify_pushover_rehearsal` function; existing `notify_pushover_mismatch` call sites are unaffected.
+
+### Rollback plan
+
+Script-only change. Remove the cron entry from homeserver (`sed -i '/restore-rehearsal/d'` + `update_cron`). The `--rm` flag on the Docker run means no container state persists. `git revert` removes the files. No schema change, no migration, no homeserver service restart required.
+
+### Cron slot decision
+
+PHASED_PLAN card said `0 5 * * 0`. That slot is taken by wiki-lint (`0 5 * * 0`). Per P07 rule: no two jobs on same minute. Shifted to `30 5 * * 0` — 30 minutes after wiki-lint completes, before the production week starts. Confirmed clear in the P07 slot registry.
+
+### Architecture decisions
+
+1. `docker cp` + `docker exec pg_restore` (not volume mount): avoids Unraid bind-mount permission issues and keeps the restore path clean for non-Unraid environments too.
+2. `pgvector/pgvector:pg16` mandatory: plain `postgres:16` lacks the `vector` extension; pg_restore would fail on vector columns.
+3. `--exit-on-error` on pg_restore: surfaces silent schema errors that would otherwise produce exit 0 with missing objects.
+4. ±10% row count tolerance: backup taken at 03:00 Sunday; rehearsal runs at 05:30; new captures can arrive via voice/Slack in that window.
+5. `REHEARSAL_DRY_RUN=true` env var short-circuits all Docker calls for CI-safe regression testing.
+
+### Work items
+
+- WI-1: `scripts/restore-rehearsal.sh` — main rehearsal script
+- WI-2: `scripts/lib/pushover-notify.sh` — add `notify_pushover_rehearsal` function
+- WI-3: `deploy/cron/unraid-restore-rehearsal.cron` — Sunday 05:30 cron entry
+- WI-4: `docs/runbooks/restore-rehearsal.md` — failure runbook
+- WI-5: `scripts/test-restore-rehearsal.sh` — regression test (no real Docker)
+
+### Verification
+
+- `bash scripts/test-restore-rehearsal.sh` — all 5 test cases pass (missing backup exit 2, missing manifest exit 2, pass path exit 0, fail path exit 1, tolerance boundary)
+- Manual homeserver validation (AC-1 through AC-4) deferred to operator post-deploy
+- No application code changes; no migrations; no pnpm changes
+
+---

--- a/deploy/cron/unraid-restore-rehearsal.cron
+++ b/deploy/cron/unraid-restore-rehearsal.cron
@@ -1,0 +1,39 @@
+# Open Brain — Restore rehearsal cron entry (Unraid host)
+#
+# INSTALL (post-merge, once):
+#   1. SSH to homeserver as `claude` (has passwordless sudo for cron operations).
+#   2. Append this file to the Unraid system crontab:
+#        sudo tee -a /boot/config/plugins/dynamix/custom.cron \
+#          < deploy/cron/unraid-restore-rehearsal.cron
+#      Unraid reads /boot/config/plugins/dynamix/*.cron on boot and merges them
+#      into the live crontab (same persistence path as backup.sh and ingest cron).
+#   3. Reload cron so the line takes effect without a reboot:
+#        sudo /usr/local/sbin/update_cron
+#   4. Verify:
+#        crontab -l | grep restore-rehearsal
+#
+# SCHEDULE: Sunday 05:30 — after wiki-lint (0 5 * * 0) and before the
+#   production week starts. Staggered per P16 cron-slot audit: 0 5 * * 0
+#   is taken by wiki-lint; 30 5 * * 0 is the next available Sunday slot.
+#   DO NOT change to 0 5 * * 0 — that slot is occupied.
+#
+# ROLLBACK:
+#   Remove this line from /boot/config/plugins/dynamix/custom.cron and
+#   run update_cron again:
+#     sudo sed -i '/restore-rehearsal/d' /boot/config/plugins/dynamix/custom.cron
+#     sudo /usr/local/sbin/update_cron
+#     crontab -l | grep restore-rehearsal  # should return nothing
+#   Script can remain in repo — it makes no writes unless explicitly invoked.
+#   Ephemeral container (open-brain-rehearsal-pg) uses --rm; no persistent state.
+#
+# LOGS: /var/log/open-brain-restore-rehearsal.log
+#   Rotate manually with: sudo : > /var/log/open-brain-restore-rehearsal.log
+#   Or via logrotate — add to /etc/logrotate.d/ if log grows large.
+#
+# PUSHOVER: Pass notification (priority 0/normal) and fail notification
+#   (priority 1/high) sent via scripts/lib/pushover-notify.sh.
+#   Requires PUSHOVER_APP_TOKEN and PUSHOVER_USER_KEY in environment.
+#   These are set via .env.secrets (loaded by the cron preamble in custom.cron
+#   or by sourcing /mnt/user/appdata/open-brain/.env.secrets before invocation).
+
+30 5 * * 0 cd /mnt/user/appdata/open-brain && bash scripts/restore-rehearsal.sh >> /var/log/open-brain-restore-rehearsal.log 2>&1

--- a/docs/runbooks/restore-rehearsal.md
+++ b/docs/runbooks/restore-rehearsal.md
@@ -1,0 +1,237 @@
+# Runbook: DR Restore Rehearsal Failure
+
+**Alert:** Pushover notification from `restore-rehearsal.sh` with title "Open Brain: DR rehearsal fail"
+**Schedule:** Sunday 05:30 (Unraid host cron — `30 5 * * 0`)
+**Script:** `scripts/restore-rehearsal.sh`
+**Log:** `/var/log/open-brain-restore-rehearsal.log` on homeserver
+**Cron file:** `deploy/cron/unraid-restore-rehearsal.cron`
+
+---
+
+## What the rehearsal does
+
+1. Locates the most recent daily backup via `${BACKUP_ROOT}/latest` symlink (default: `/mnt/user/backup/openbrain/latest`)
+2. Reads expected row counts from `manifest.json` in the backup directory
+3. Spins up an ephemeral `pgvector/pgvector:pg16` container (`open-brain-rehearsal-pg`)
+4. Copies the dump file into the container and runs `pg_restore --exit-on-error`
+5. Validates actual row counts vs. manifest values (±10% tolerance; 0-row manifest entries skipped)
+6. Tears down the ephemeral container (`--rm` flag — no persistent state)
+7. Sends Pushover notification: pass = priority 0 (normal), fail = priority 1 (high)
+
+A pass notification every Sunday is the expected steady state. A fail notification requires immediate investigation — it means last Sunday's backup could not be restored cleanly.
+
+---
+
+## Alert conditions
+
+| Exit code | Meaning | Pushover priority |
+|-----------|---------|-------------------|
+| 0 | Restore successful, all row counts within ±10% | 0 — normal |
+| 1 | Restore failed — `pg_restore` error OR row count mismatch | 1 — high |
+| 2 | Precondition failure — no backup found, manifest missing, container failed to start | 1 — high |
+
+---
+
+## Diagnosis
+
+### 1. Check the log
+
+```bash
+ssh -i ~/.ssh/id_claude_code claude@homeserver.k4jda.net
+tail -100 /var/log/open-brain-restore-rehearsal.log
+```
+
+The log output is structured — look for the `REHEARSAL RESULT: FAIL` line and the lines preceding it for the root cause.
+
+### 2. Identify the exit code
+
+```
+=== REHEARSAL RESULT: FAIL (exit 1) ===   # pg_restore error or row count mismatch
+=== REHEARSAL RESULT: FAIL (exit 2) ===   # precondition failure
+```
+
+### 3. Diagnose by exit code
+
+#### Exit 2 — Precondition failure
+
+**No backup file (`manifest.json` or `openbrain.pgdump` missing):**
+
+```bash
+ls -la /mnt/user/backup/openbrain/latest/
+```
+
+If the directory is empty or the symlink is broken, `backup.sh` did not complete successfully on the prior run. Check:
+
+```bash
+tail -100 /tmp/open-brain-backup.log
+```
+
+Common causes: Postgres container was down during backup window (03:00 Sunday), disk full, Docker daemon restart mid-backup.
+
+**Container start failure:**
+
+```bash
+docker ps -a | grep rehearsal
+docker logs open-brain-rehearsal-pg 2>/dev/null || true
+```
+
+Docker daemon may have been busy or the `pgvector/pgvector:pg16` image is not pulled:
+
+```bash
+docker pull pgvector/pgvector:pg16
+```
+
+#### Exit 1 — pg_restore error
+
+```bash
+grep -A 20 "pg_restore output" /var/log/open-brain-restore-rehearsal.log
+```
+
+Common causes:
+- **Schema drift**: a new migration was applied after the backup was taken. The dump may not include the new table/column. This is expected if a migration landed between 03:00 (backup) and 05:30 (rehearsal). Verify by checking recent migrations:
+  ```bash
+  cd /mnt/user/appdata/open-brain && git log --oneline -10
+  ```
+- **Corrupted dump**: disk failure during backup. Verify dump integrity:
+  ```bash
+  file /mnt/user/backup/openbrain/latest/openbrain.pgdump
+  # Should output: PostgreSQL custom database dump
+  ```
+- **Permission errors**: `pg_restore` exited non-zero on `--no-owner --no-privileges` mismatch. Re-run with verbose to diagnose:
+  ```bash
+  REHEARSAL_DRY_RUN=false bash scripts/restore-rehearsal.sh  # then inspect log
+  ```
+
+#### Exit 1 — Row count mismatch
+
+```bash
+grep -E "FAIL  |PASS  " /var/log/open-brain-restore-rehearsal.log | tail -30
+```
+
+- **All tables show `actual=0` when `manifest > 0`**: blank restore. `pg_restore` silently completed without writing data. Likely cause: `--exit-on-error` was bypassed or schema errors caused the data section to be skipped. Re-run manually with `-v` (verbose):
+  ```bash
+  # Spin up container manually for investigation
+  docker run --rm -d --name ob-rehearsal-debug \
+    -e POSTGRES_PASSWORD=rehearsal \
+    -e POSTGRES_USER=openbrain \
+    -e POSTGRES_DB=openbrain \
+    pgvector/pgvector:pg16
+
+  docker exec ob-rehearsal-debug psql -U openbrain -d openbrain -c "CREATE EXTENSION IF NOT EXISTS vector;"
+  docker cp /mnt/user/backup/openbrain/latest/openbrain.pgdump ob-rehearsal-debug:/tmp/restore.pgdump
+  docker exec ob-rehearsal-debug pg_restore -U openbrain -d openbrain \
+    --no-owner --no-privileges --exit-on-error -v /tmp/restore.pgdump 2>&1 | tail -50
+  docker stop ob-rehearsal-debug
+  ```
+
+- **Single table out of tolerance**: normal churn (captures, skills_log, ai_audit_log grow between 03:00 backup and 05:30 check). If the actual count significantly exceeds manifest — this is the expected direction (new data written after backup). If actual is dramatically *lower*, the restore may have partially failed. Check pg_restore output for errors on that table.
+
+---
+
+## Manual restore (actual DR)
+
+Use this procedure only in a real disaster recovery scenario — not for rehearsal diagnostics.
+
+### Prerequisites
+
+1. Fresh homeserver or repaired Postgres volume
+2. Latest backup directory: `/mnt/user/backup/openbrain/latest/`
+3. Bitwarden Secrets Manager accessible (`BWS_ACCESS_TOKEN` env var set)
+
+### Steps
+
+```bash
+# 1. SSH to homeserver
+ssh -i ~/.ssh/id_claude_code claude@homeserver.k4jda.net
+
+# 2. Navigate to app directory
+cd /mnt/user/appdata/open-brain
+
+# 3. Bring up only Postgres (do not start the full stack yet)
+docker compose up -d postgres
+# Wait for healthy:
+docker ps | grep postgres
+
+# 4. Apply schema from the backup (init-schema + all Drizzle migrations)
+#    The pg_restore will create tables, but you need the schema first if starting fresh.
+#    The backup includes schema.sql for reference:
+#    cat /mnt/user/backup/openbrain/latest/schema.sql | head -20
+#
+#    Apply the canonical migration sequence (not schema.sql — it's for reference only):
+docker exec -i open-brain-postgres psql -U openbrain -d openbrain < scripts/init-schema.sql
+for f in packages/shared/drizzle/0*.sql; do
+  echo "Applying $f..."
+  docker exec -i open-brain-postgres psql -U openbrain -d openbrain < "$f"
+done
+
+# 5. Restore from pg_dump
+docker cp /mnt/user/backup/openbrain/latest/openbrain.pgdump open-brain-postgres:/tmp/restore.pgdump
+docker exec open-brain-postgres pg_restore \
+  -U openbrain -d openbrain \
+  --no-owner --no-privileges \
+  --exit-on-error \
+  /tmp/restore.pgdump
+
+# 6. Verify row counts
+docker exec open-brain-postgres psql -U openbrain -d openbrain -c \
+  "SELECT relname, n_live_tup FROM pg_stat_user_tables ORDER BY relname;"
+
+# 7. Restore secrets from Bitwarden
+export BWS_ACCESS_TOKEN="<your-token>"
+bash scripts/load-secrets.sh --force
+
+# 8. Verify secrets loaded
+bash scripts/verify-secrets.sh
+
+# 9. Bring up the full stack
+docker compose up -d
+
+# 10. Verify health
+curl -s http://localhost:3002/api/v1/captures?limit=1
+```
+
+### After restore
+
+- Run `bash scripts/verify-secrets.sh` to confirm all required secrets are present.
+- Check `docker compose ps` — all containers should be healthy within 60s.
+- Send a test capture via voice or Slack to verify end-to-end pipeline is functional.
+- Update `LAB_NOTEBOOK.md` with the restore event and any issues encountered.
+
+---
+
+## Testing the failure path manually (AC-4)
+
+To verify the alert fires correctly without waiting for a real failure:
+
+```bash
+ssh -i ~/.ssh/id_claude_code claude@homeserver.k4jda.net
+cd /mnt/user/appdata/open-brain
+
+# Corrupt a copy of the dump (never corrupt the real backup)
+cp /mnt/user/backup/openbrain/latest/openbrain.pgdump /tmp/corrupt-test.pgdump
+truncate -s 1k /tmp/corrupt-test.pgdump
+
+# Create a temp backup dir pointing to the corrupted dump
+mkdir -p /tmp/ob-rehearsal-test
+cp /mnt/user/backup/openbrain/latest/manifest.json /tmp/ob-rehearsal-test/
+cp /tmp/corrupt-test.pgdump /tmp/ob-rehearsal-test/openbrain.pgdump
+ln -sfn /tmp/ob-rehearsal-test /tmp/ob-rehearsal-latest
+
+# Run rehearsal against the corrupted backup
+BACKUP_ROOT=/tmp REHEARSAL_CONTAINER=ob-rehearsal-fail-test \
+  bash scripts/restore-rehearsal.sh
+
+# Expected: exit 1, Pushover "fail" notification received
+# Clean up
+rm -rf /tmp/ob-rehearsal-test /tmp/ob-rehearsal-latest /tmp/corrupt-test.pgdump
+```
+
+---
+
+## Related
+
+- `scripts/backup.sh` — creates the backup this rehearsal validates
+- `scripts/load-secrets.sh` — restores secrets from Bitwarden after a real DR event
+- `scripts/verify-secrets.sh` — audits secrets after load-secrets.sh runs
+- `docs/runbooks/pipeline-alert.md` — if restore succeeds but pipeline is stuck post-DR
+- `LAB_NOTEBOOK.md` Entry 114 — P16 design decisions and architecture notes

--- a/scripts/lib/pushover-notify.sh
+++ b/scripts/lib/pushover-notify.sh
@@ -49,3 +49,34 @@ notify_pushover_mismatch() {
   fi
   return 0
 }
+
+# notify_pushover_rehearsal <status> <summary_message>
+#   status: "pass" (priority 0/normal) or "fail" (priority 1/high)
+#   summary_message: human-readable one-liner (e.g., "5/5 tables within tolerance")
+#   Sends a Pushover notification for restore rehearsal results.
+#   Returns 0 always — NEVER fails the caller.
+notify_pushover_rehearsal() {
+  local status="$1"
+  local message="${2:-Open Brain: restore rehearsal ${status}}"
+  local title="Open Brain: DR rehearsal ${status}"
+  local priority=0
+  [[ "$status" == "fail" ]] && priority=1
+  local url="${PUSHOVER_API_URL:-https://api.pushover.net/1/messages.json}"
+
+  local token="${PUSHOVER_APP_TOKEN:-${PUSHOVER_TOKEN:-}}"
+  local user="${PUSHOVER_USER_KEY:-${PUSHOVER_USER:-}}"
+
+  if [[ -z "$token" || -z "$user" ]]; then
+    echo "WARN: Pushover credentials missing — rehearsal alert skipped" >&2
+    return 0
+  fi
+
+  curl -sf --max-time 10 -X POST "$url" \
+    -d "token=${token}" \
+    -d "user=${user}" \
+    -d "title=${title}" \
+    -d "message=${message}" \
+    -d "priority=${priority}" >/dev/null 2>&1 || \
+    echo "WARN: Pushover POST failed (curl exit $?)" >&2
+  return 0
+}

--- a/scripts/restore-rehearsal.sh
+++ b/scripts/restore-rehearsal.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# restore-rehearsal.sh — Weekly DR restore rehearsal for Open Brain.
+#
+# Locates the most recent daily backup, spins up an ephemeral pgvector/pgvector:pg16
+# container, runs pg_restore, validates row counts against manifest.json, tears down,
+# and sends a Pushover notification (pass = normal priority, fail = high priority).
+#
+# Usage:
+#   bash scripts/restore-rehearsal.sh
+#
+# Env overrides (test-harness friendly — same pattern as backup.sh):
+#   BACKUP_ROOT          default: /mnt/user/backup/openbrain
+#   REHEARSAL_CONTAINER  default: open-brain-rehearsal-pg
+#   PUSHOVER_API_URL     default: https://api.pushover.net/1/messages.json (mock-able)
+#   ROW_COUNT_TOLERANCE  default: 0.10  (±10%)
+#   REHEARSAL_DRY_RUN    set to "true" to skip all Docker calls (bash-logic test only)
+#
+# Exit codes:
+#   0 — restore successful, all row counts within tolerance
+#   1 — restore failed (pg_restore error OR row count validation failure)
+#   2 — precondition failure (no backup, manifest missing, container start failed)
+#
+# Cron: 30 5 * * 0  (Sunday 05:30 — staggered after wiki-lint at 0 5 * * 0)
+# Log:  /var/log/open-brain-restore-rehearsal.log
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+BACKUP_ROOT="${BACKUP_ROOT:-/mnt/user/backup/openbrain}"
+REHEARSAL_CONTAINER="${REHEARSAL_CONTAINER:-open-brain-rehearsal-pg}"
+ROW_COUNT_TOLERANCE="${ROW_COUNT_TOLERANCE:-0.10}"
+REHEARSAL_DRY_RUN="${REHEARSAL_DRY_RUN:-false}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/pushover-notify.sh
+source "${SCRIPT_DIR}/lib/pushover-notify.sh"
+
+TIMESTAMP=$(date +%Y-%m-%dT%H:%M:%S%z)
+echo "=== Open Brain DR Restore Rehearsal: ${TIMESTAMP} ==="
+
+# ---------------------------------------------------------------------------
+# Helper: emit result and send Pushover, then exit with given code.
+# Usage: finish <exit_code> <status_word> <message>
+# ---------------------------------------------------------------------------
+finish() {
+  local code="$1"
+  local status="$2"
+  local msg="$3"
+  echo ""
+  if [[ "$code" -eq 0 ]]; then
+    echo "=== REHEARSAL RESULT: PASS ==="
+  else
+    echo "=== REHEARSAL RESULT: FAIL (exit ${code}) ===" >&2
+  fi
+  echo "  ${msg}"
+  echo "  Timestamp: ${TIMESTAMP}"
+  notify_pushover_rehearsal "${status}" "${msg}" || true
+  exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: tear down ephemeral container (idempotent — ignores errors)
+# ---------------------------------------------------------------------------
+teardown_container() {
+  if [[ "${REHEARSAL_DRY_RUN}" == "true" ]]; then
+    echo "[teardown] DRY_RUN — skipping docker stop"
+    return 0
+  fi
+  echo "[teardown] Stopping and removing ephemeral container..."
+  docker stop "${REHEARSAL_CONTAINER}" >/dev/null 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Precondition 1: locate backup directory via "latest" symlink
+# ---------------------------------------------------------------------------
+LATEST_LINK="${BACKUP_ROOT}/latest"
+
+# In both real and dry-run mode, resolve the backup dir the same way.
+# Dry-run only short-circuits Docker operations (steps 4-6); precondition
+# checks and manifest parsing still run against the real fixture.
+if [[ ! -L "${LATEST_LINK}" && ! -d "${LATEST_LINK}" ]]; then
+  finish 2 "fail" "Precondition failed: ${LATEST_LINK} does not exist. Has backup.sh run at least once?"
+fi
+
+BACKUP_DIR="$(realpath "${LATEST_LINK}" 2>/dev/null || readlink -f "${LATEST_LINK}")"
+
+if [[ ! -d "${BACKUP_DIR}" ]]; then
+  finish 2 "fail" "Precondition failed: backup dir ${BACKUP_DIR} resolved from symlink does not exist."
+fi
+
+if [[ "${REHEARSAL_DRY_RUN}" == "true" ]]; then
+  echo "[1/7] DRY_RUN — backup dir: ${BACKUP_DIR}"
+else
+  echo "[1/7] Backup dir: ${BACKUP_DIR}"
+fi
+
+# ---------------------------------------------------------------------------
+# Precondition 2: verify dump file
+# ---------------------------------------------------------------------------
+DUMP_FILE="${BACKUP_DIR}/openbrain.pgdump"
+if [[ ! -f "${DUMP_FILE}" ]]; then
+  finish 2 "fail" "Precondition failed: dump file not found at ${DUMP_FILE}"
+fi
+DUMP_SIZE=$(du -h "${DUMP_FILE}" | cut -f1)
+echo "[2/7] Dump file: ${DUMP_FILE} (${DUMP_SIZE})"
+
+# ---------------------------------------------------------------------------
+# Precondition 3: read manifest.json and extract table counts
+# ---------------------------------------------------------------------------
+MANIFEST_FILE="${BACKUP_DIR}/manifest.json"
+if [[ ! -f "${MANIFEST_FILE}" ]]; then
+  finish 2 "fail" "Precondition failed: manifest.json not found at ${MANIFEST_FILE}"
+fi
+
+# Parse the "tables" object from manifest.json.
+# Prefer jq (canonical), fall back to python3.
+# tr -d '\r' normalizes CRLF line endings (manifest.json is produced on Linux
+# homeserver but test fixtures may be created on Windows).
+if command -v jq >/dev/null 2>&1; then
+  # Emit "table_name COUNT" lines.
+  MANIFEST_TABLE_LINES=$(jq -r '.tables | to_entries[] | "\(.key) \(.value)"' "${MANIFEST_FILE}" 2>/dev/null | tr -d '\r')
+else
+  MANIFEST_TABLE_LINES=$(python3 -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+tables = data.get("tables", {})
+for k, v in tables.items():
+    print(f"{k} {v}")
+' "${MANIFEST_FILE}" 2>/dev/null | tr -d '\r')
+fi
+
+if [[ -z "${MANIFEST_TABLE_LINES}" ]]; then
+  finish 2 "fail" "Precondition failed: could not parse tables from ${MANIFEST_FILE}. Is jq or python3 available?"
+fi
+
+TABLE_COUNT=$(echo "${MANIFEST_TABLE_LINES}" | wc -l | tr -d ' ')
+echo "[3/7] Manifest: ${TABLE_COUNT} tables parsed from ${MANIFEST_FILE}"
+
+# ---------------------------------------------------------------------------
+# Step 4: spin up ephemeral pgvector container
+# ---------------------------------------------------------------------------
+echo "[4/7] Starting ephemeral pgvector container (${REHEARSAL_CONTAINER})..."
+
+if [[ "${REHEARSAL_DRY_RUN}" == "true" ]]; then
+  echo "  DRY_RUN — skipping docker run"
+else
+  # Remove stale container if it somehow survived a prior interrupted run.
+  docker rm -f "${REHEARSAL_CONTAINER}" >/dev/null 2>&1 || true
+
+  if ! docker run --rm -d \
+      --name "${REHEARSAL_CONTAINER}" \
+      -e POSTGRES_PASSWORD=rehearsal \
+      -e POSTGRES_USER=openbrain \
+      -e POSTGRES_DB=openbrain \
+      pgvector/pgvector:pg16 >/dev/null; then
+    finish 2 "fail" "Container start failed: could not start ${REHEARSAL_CONTAINER}. Is Docker daemon running?"
+  fi
+
+  # Register teardown on exit so it always fires even on error.
+  trap teardown_container EXIT
+
+  # Poll pg_isready (max 30s)
+  echo "  Waiting for Postgres to be ready..."
+  READY=0
+  for i in $(seq 1 30); do
+    if docker exec "${REHEARSAL_CONTAINER}" pg_isready -U openbrain -d openbrain -q 2>/dev/null; then
+      READY=1
+      echo "  Ready after ${i}s"
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "${READY}" -eq 0 ]]; then
+    finish 2 "fail" "Container did not become ready within 30s. Check Docker logs: docker logs ${REHEARSAL_CONTAINER}"
+  fi
+
+  # Install pgvector extension (required for vector columns in pg_restore).
+  echo "  Installing pgvector extension..."
+  if ! docker exec "${REHEARSAL_CONTAINER}" psql -U openbrain -d openbrain -q \
+      -c "CREATE EXTENSION IF NOT EXISTS vector;" 2>&1; then
+    finish 2 "fail" "Failed to install pgvector extension. Is the pgvector/pgvector:pg16 image being used?"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: copy dump into container and run pg_restore
+# ---------------------------------------------------------------------------
+echo "[5/7] Running pg_restore..."
+
+if [[ "${REHEARSAL_DRY_RUN}" == "true" ]]; then
+  echo "  DRY_RUN — skipping docker cp + pg_restore"
+  RESTORE_EXIT=0
+else
+  # Copy dump into container.
+  if ! docker cp "${DUMP_FILE}" "${REHEARSAL_CONTAINER}:/tmp/restore.pgdump" 2>&1; then
+    finish 1 "fail" "pg_restore failed: could not docker cp dump file into container."
+  fi
+
+  # Run pg_restore. --exit-on-error surfaces schema drift that would otherwise
+  # silently produce exit 0 with missing objects.
+  RESTORE_OUTPUT=$(docker exec "${REHEARSAL_CONTAINER}" pg_restore \
+    -U openbrain \
+    -d openbrain \
+    --no-owner \
+    --no-privileges \
+    --exit-on-error \
+    /tmp/restore.pgdump 2>&1) || RESTORE_EXIT=$?
+
+  RESTORE_EXIT="${RESTORE_EXIT:-0}"
+
+  if [[ "${RESTORE_EXIT}" -ne 0 ]]; then
+    echo "  pg_restore output:" >&2
+    echo "${RESTORE_OUTPUT}" | head -50 | sed 's/^/    /' >&2
+    finish 1 "fail" "pg_restore exited ${RESTORE_EXIT}. Check log for schema errors."
+  fi
+
+  echo "  pg_restore completed successfully."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: validate row counts against manifest
+# ---------------------------------------------------------------------------
+echo "[6/7] Validating row counts (tolerance: ±$(echo "${ROW_COUNT_TOLERANCE} * 100" | awk '{printf "%.0f", $1}')%)..."
+
+FAIL_COUNT=0
+PASS_COUNT=0
+SKIP_COUNT=0
+VALIDATION_DETAIL=""
+
+while IFS=' ' read -r table manifest_count; do
+  # Strip carriage returns (Windows-created manifest.json may have CRLF).
+  table="${table%$'\r'}"
+  manifest_count="${manifest_count%$'\r'}"
+  [[ -z "$table" ]] && continue
+
+  # Tables with 0 rows in manifest are skipped — nothing to validate (system tables
+  # may be 0 rows; we only care about data presence when manifest says there should be data).
+  if [[ "${manifest_count}" -eq 0 ]]; then
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    continue
+  fi
+
+  if [[ "${REHEARSAL_DRY_RUN}" == "true" ]]; then
+    # In dry-run, the caller injects REHEARSAL_DRY_RUN_COUNTS as "table:count table:count ..."
+    # For pure bash-logic tests, default to matching manifest count exactly.
+    actual_count="${manifest_count}"
+    # Allow override via DRY_RUN_COUNTS associative-array style env var
+    override_var="REHEARSAL_DRY_COUNT_${table}"
+    if [[ -n "${!override_var:-}" ]]; then
+      actual_count="${!override_var}"
+    fi
+  else
+    actual_count=$(docker exec "${REHEARSAL_CONTAINER}" psql \
+      -U openbrain -d openbrain -t -A \
+      -c "SELECT COUNT(*) FROM \"${table}\";" 2>/dev/null || echo "0")
+    actual_count="${actual_count:-0}"
+  fi
+
+  # Compute tolerance bounds using awk (bash can't do float arithmetic).
+  lower=$(awk -v n="${manifest_count}" -v t="${ROW_COUNT_TOLERANCE}" 'BEGIN { printf "%d", n * (1 - t) }')
+  upper=$(awk -v n="${manifest_count}" -v t="${ROW_COUNT_TOLERANCE}" 'BEGIN { printf "%d", n * (1 + t) }')
+
+  if [[ "${actual_count}" -ge "${lower}" && "${actual_count}" -le "${upper}" ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    VALIDATION_DETAIL="${VALIDATION_DETAIL}  PASS  ${table}: actual=${actual_count} manifest=${manifest_count}\n"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    if [[ "${actual_count}" -eq 0 && "${manifest_count}" -gt 0 ]]; then
+      VALIDATION_DETAIL="${VALIDATION_DETAIL}  FAIL  ${table}: actual=0 manifest=${manifest_count} (BLANK RESTORE — catastrophic)\n"
+    else
+      VALIDATION_DETAIL="${VALIDATION_DETAIL}  FAIL  ${table}: actual=${actual_count} manifest=${manifest_count} (outside ±${ROW_COUNT_TOLERANCE})\n"
+    fi
+  fi
+done <<< "${MANIFEST_TABLE_LINES}"
+
+echo ""
+printf "%b" "${VALIDATION_DETAIL}"
+echo ""
+echo "  Tables: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped (0-row manifest)"
+
+# ---------------------------------------------------------------------------
+# Step 7: tear down + final result
+# ---------------------------------------------------------------------------
+echo "[7/7] Tearing down ephemeral container..."
+if [[ "${REHEARSAL_DRY_RUN}" != "true" ]]; then
+  teardown_container
+  # Disable the EXIT trap (already done manually).
+  trap - EXIT
+fi
+
+CHECKED=$((PASS_COUNT + FAIL_COUNT))
+if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+  finish 1 "fail" "DR rehearsal FAILED: ${FAIL_COUNT}/${CHECKED} table(s) out of tolerance. See log for details."
+else
+  finish 0 "pass" "DR rehearsal PASSED: ${PASS_COUNT}/${CHECKED} table(s) within ±$(echo "${ROW_COUNT_TOLERANCE} * 100" | awk '{printf "%.0f", $1}')% tolerance. ${SKIP_COUNT} skipped."
+fi

--- a/scripts/test-restore-rehearsal.sh
+++ b/scripts/test-restore-rehearsal.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# test-restore-rehearsal.sh
+#
+# Regression test for scripts/restore-rehearsal.sh.
+# Tests bash logic and Pushover notification path without requiring Docker or a
+# real backup. Uses REHEARSAL_DRY_RUN=true to short-circuit all Docker calls.
+#
+# Usage: bash scripts/test-restore-rehearsal.sh
+# Exit code: 0 = all tests passed, 1 = one or more tests failed
+#
+# Test cases:
+#   TC-1: Missing backup root (BACKUP_ROOT → empty dir)          — expect exit 2
+#   TC-2: Backup dir present but no openbrain.pgdump             — expect exit 2
+#   TC-3: Dump present but manifest.json missing                 — expect exit 2
+#   TC-4: Happy path (good manifest + REHEARSAL_DRY_RUN)         — expect exit 0
+#   TC-5: Row count outside tolerance (DRY_RUN count override)   — expect exit 1
+#   TC-6: Pushover mock: pass path sends status=pass             — expect "pass" in mock log
+#   TC-7: Pushover mock: fail path sends status=fail             — expect "fail" in mock log
+#   TC-8: Tolerance boundary: 91% of manifest → fail; 90% → pass
+#
+# Pushover mock: sets PUSHOVER_API_URL to a local python http.server that writes
+# POST body to a temp file. Falls back to nc if python3 unavailable. If neither
+# is available, TC-6 and TC-7 are skipped (Pushover credentials absent = WARN).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REHEARSAL_SCRIPT="${SCRIPT_DIR}/restore-rehearsal.sh"
+
+WORK_DIR=$(mktemp -d)
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+  rm -rf "${WORK_DIR}"
+  # Kill mock server if running
+  if [[ -n "${MOCK_PID:-}" ]]; then
+    kill "${MOCK_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "=== P16 restore-rehearsal regression test ==="
+echo "  Work dir: ${WORK_DIR}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Helper: run a test case
+# run_test <name> <expected_exit> <env_overrides...> -- <extra args>
+# ---------------------------------------------------------------------------
+run_test() {
+  local name="$1"
+  local expected_exit="$2"
+  shift 2
+  # Remaining args are VAR=value pairs consumed as env
+  local env_vars=()
+  while [[ $# -gt 0 && "$1" != "--" ]]; do
+    env_vars+=("$1")
+    shift
+  done
+  [[ "${1:-}" == "--" ]] && shift
+
+  local actual_exit=0
+  env "${env_vars[@]}" bash "${REHEARSAL_SCRIPT}" >/dev/null 2>&1 || actual_exit=$?
+
+  if [[ "${actual_exit}" -eq "${expected_exit}" ]]; then
+    echo "  PASS  ${name} (exit ${actual_exit})"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "  FAIL  ${name}: expected exit ${expected_exit}, got ${actual_exit}"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Build test fixtures
+# ---------------------------------------------------------------------------
+
+# Valid manifest.json (2 tables with known counts)
+FAKE_BACKUP_DIR="${WORK_DIR}/backup/daily/2026-04-19"
+mkdir -p "${FAKE_BACKUP_DIR}"
+
+cat > "${FAKE_BACKUP_DIR}/manifest.json" << 'MANIFEST_EOF'
+{
+    "timestamp": "2026-04-19T03:00:00+0000",
+    "date": "2026-04-19",
+    "tables": {
+        "captures": 500,
+        "entities": 200,
+        "empty_table": 0
+    }
+}
+MANIFEST_EOF
+
+# Fake dump file (non-empty bytes — content doesn't matter in dry-run)
+echo "FAKE_PGDUMP_CONTENT" > "${FAKE_BACKUP_DIR}/openbrain.pgdump"
+
+# Create the "latest" symlink
+ln -sfn "${FAKE_BACKUP_DIR}" "${WORK_DIR}/backup/latest"
+
+EMPTY_BACKUP_ROOT="${WORK_DIR}/empty_backup_root"
+mkdir -p "${EMPTY_BACKUP_ROOT}"
+
+BACKUP_ROOT_NO_DUMP="${WORK_DIR}/no_dump"
+mkdir -p "${BACKUP_ROOT_NO_DUMP}/daily/2026-04-19"
+cat > "${BACKUP_ROOT_NO_DUMP}/daily/2026-04-19/manifest.json" << 'EOF'
+{"tables": {"captures": 100}}
+EOF
+ln -sfn "${BACKUP_ROOT_NO_DUMP}/daily/2026-04-19" "${BACKUP_ROOT_NO_DUMP}/latest"
+
+BACKUP_ROOT_NO_MANIFEST="${WORK_DIR}/no_manifest"
+mkdir -p "${BACKUP_ROOT_NO_MANIFEST}/daily/2026-04-19"
+echo "FAKE" > "${BACKUP_ROOT_NO_MANIFEST}/daily/2026-04-19/openbrain.pgdump"
+ln -sfn "${BACKUP_ROOT_NO_MANIFEST}/daily/2026-04-19" "${BACKUP_ROOT_NO_MANIFEST}/latest"
+
+# ---------------------------------------------------------------------------
+# TC-1: Missing backup root (latest symlink absent)
+# ---------------------------------------------------------------------------
+run_test "TC-1: missing backup root" 2 \
+  "BACKUP_ROOT=${EMPTY_BACKUP_ROOT}" \
+  "REHEARSAL_DRY_RUN=true" \
+  "PUSHOVER_APP_TOKEN=" \
+  "PUSHOVER_USER_KEY="
+
+# ---------------------------------------------------------------------------
+# TC-2: No dump file (manifest present but no pgdump)
+# ---------------------------------------------------------------------------
+run_test "TC-2: dump file missing" 2 \
+  "BACKUP_ROOT=${BACKUP_ROOT_NO_DUMP}" \
+  "REHEARSAL_DRY_RUN=true" \
+  "PUSHOVER_APP_TOKEN=" \
+  "PUSHOVER_USER_KEY="
+
+# ---------------------------------------------------------------------------
+# TC-3: No manifest.json (dump present but no manifest)
+# ---------------------------------------------------------------------------
+run_test "TC-3: manifest.json missing" 2 \
+  "BACKUP_ROOT=${BACKUP_ROOT_NO_MANIFEST}" \
+  "REHEARSAL_DRY_RUN=true" \
+  "PUSHOVER_APP_TOKEN=" \
+  "PUSHOVER_USER_KEY="
+
+# ---------------------------------------------------------------------------
+# TC-4: Happy path (dry-run, all table counts match manifest)
+#   captures: manifest=500, dry-run returns manifest count → pass
+#   entities: manifest=200, dry-run returns manifest count → pass
+#   empty_table: manifest=0 → skipped
+# ---------------------------------------------------------------------------
+run_test "TC-4: happy path (dry-run, counts match)" 0 \
+  "BACKUP_ROOT=${WORK_DIR}/backup" \
+  "REHEARSAL_DRY_RUN=true" \
+  "PUSHOVER_APP_TOKEN=" \
+  "PUSHOVER_USER_KEY="
+
+# ---------------------------------------------------------------------------
+# TC-5: Row count outside tolerance (captures override to 50 — 10% of 500)
+#   50 < 500 * 0.90 = 450 → FAIL
+# ---------------------------------------------------------------------------
+run_test "TC-5: row count outside tolerance" 1 \
+  "BACKUP_ROOT=${WORK_DIR}/backup" \
+  "REHEARSAL_DRY_RUN=true" \
+  "REHEARSAL_DRY_COUNT_captures=50" \
+  "PUSHOVER_APP_TOKEN=" \
+  "PUSHOVER_USER_KEY="
+
+# ---------------------------------------------------------------------------
+# TC-6: Tolerance boundary — 90% of manifest (edge: exactly at floor)
+#   captures=450, manifest=500, tolerance=10% → lower=450 → 450 >= 450 → PASS
+# ---------------------------------------------------------------------------
+run_test "TC-6: tolerance boundary 90% (at lower bound = pass)" 0 \
+  "BACKUP_ROOT=${WORK_DIR}/backup" \
+  "REHEARSAL_DRY_RUN=true" \
+  "REHEARSAL_DRY_COUNT_captures=450" \
+  "PUSHOVER_APP_TOKEN=" \
+  "PUSHOVER_USER_KEY="
+
+# ---------------------------------------------------------------------------
+# TC-7: Tolerance boundary — 89% of manifest (1 below floor)
+#   captures=445, manifest=500, tolerance=10% → lower=450 → 445 < 450 → FAIL
+# ---------------------------------------------------------------------------
+run_test "TC-7: tolerance boundary 89% (below lower bound = fail)" 1 \
+  "BACKUP_ROOT=${WORK_DIR}/backup" \
+  "REHEARSAL_DRY_RUN=true" \
+  "REHEARSAL_DRY_COUNT_captures=445" \
+  "PUSHOVER_APP_TOKEN=" \
+  "PUSHOVER_USER_KEY="
+
+# ---------------------------------------------------------------------------
+# TC-8: Pushover notification path — verify curl is invoked with correct status.
+# Start a minimal mock HTTP server (python3) that writes POST body to a temp
+# file. Skip gracefully if python3 or curl unavailable.
+# ---------------------------------------------------------------------------
+MOCK_LOG="${WORK_DIR}/pushover_mock.log"
+MOCK_PORT=18765
+MOCK_PID=""
+
+# Write the mock server script first, then launch it (never use `python3 -` with heredoc
+# in the same compound command — the script text must be on disk before python3 runs).
+cat > "${WORK_DIR}/mock_server.py" << 'PYEOF'
+import http.server, sys
+
+port = int(sys.argv[1])
+log_file = sys.argv[2]
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        raw = self.rfile.read(length)
+        # Write raw bytes to avoid encoding issues on Windows (cp1252 vs utf-8).
+        with open(log_file, 'ab') as f:
+            f.write(raw + b"\n")
+        self.send_response(200)
+        self.end_headers()
+    def log_message(self, *args):
+        pass  # suppress output
+
+with http.server.HTTPServer(('127.0.0.1', port), Handler) as httpd:
+    httpd.handle_request()  # one request per invocation; caller restarts for TC-8b
+    httpd.handle_request()
+PYEOF
+
+if command -v python3 >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then
+  python3 "${WORK_DIR}/mock_server.py" "${MOCK_PORT}" "${MOCK_LOG}" &
+  MOCK_PID=$!
+  # Give server a moment to bind
+  sleep 0.5
+
+  MOCK_URL="http://127.0.0.1:${MOCK_PORT}/1/messages.json"
+
+  # TC-8a: pass path — Pushover mock should receive status=pass in message
+  env \
+    "BACKUP_ROOT=${WORK_DIR}/backup" \
+    "REHEARSAL_DRY_RUN=true" \
+    "PUSHOVER_API_URL=${MOCK_URL}" \
+    "PUSHOVER_APP_TOKEN=fake_token" \
+    "PUSHOVER_USER_KEY=fake_user" \
+    bash "${REHEARSAL_SCRIPT}" >/dev/null 2>&1 || true
+
+  # TC-8b: fail path — Pushover mock should receive status=fail
+  env \
+    "BACKUP_ROOT=${WORK_DIR}/backup" \
+    "REHEARSAL_DRY_RUN=true" \
+    "REHEARSAL_DRY_COUNT_captures=50" \
+    "PUSHOVER_API_URL=${MOCK_URL}" \
+    "PUSHOVER_APP_TOKEN=fake_token" \
+    "PUSHOVER_USER_KEY=fake_user" \
+    bash "${REHEARSAL_SCRIPT}" >/dev/null 2>&1 || true
+
+  sleep 0.5
+  kill "${MOCK_PID}" 2>/dev/null || true
+  MOCK_PID=""
+
+  # Check mock log for expected payloads
+  if [[ -f "${MOCK_LOG}" ]]; then
+    if grep -q "pass" "${MOCK_LOG}"; then
+      echo "  PASS  TC-8a: Pushover mock received 'pass' notification"
+      PASS_COUNT=$((PASS_COUNT + 1))
+    else
+      echo "  FAIL  TC-8a: Pushover mock did NOT receive 'pass' payload"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+
+    if grep -q "fail" "${MOCK_LOG}"; then
+      echo "  PASS  TC-8b: Pushover mock received 'fail' notification"
+      PASS_COUNT=$((PASS_COUNT + 1))
+    else
+      echo "  FAIL  TC-8b: Pushover mock did NOT receive 'fail' payload"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+  else
+    echo "  SKIP  TC-8a/8b: mock log not written (server may not have received requests)"
+  fi
+else
+  echo "  SKIP  TC-8a/8b: python3 or curl not available for Pushover mock server"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo ""
+echo "=== Results: ${PASS_COUNT}/${TOTAL} passed ==="
+
+if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+  echo "FAIL: ${FAIL_COUNT} test(s) failed."
+  exit 1
+fi
+
+echo "=== test-restore-rehearsal: PASSED ==="
+exit 0


### PR DESCRIPTION
## Summary
- `scripts/restore-rehearsal.sh` — ephemeral pgvector container, pg_restore, row count validation ±10%, Pushover notify
- `scripts/test-restore-rehearsal.sh` — 9 test cases (missing backup, happy path, tolerance boundary, Pushover mock)
- `deploy/cron/unraid-restore-rehearsal.cron` — Sunday 05:30 slot
- `docs/runbooks/restore-rehearsal.md` — failure diagnosis + manual DR procedure
- Extended `scripts/lib/pushover-notify.sh` with rehearsal notification function

## Test plan
- [x] 9/9 test cases pass (`REHEARSAL_DRY_RUN=true`)
- [x] No TypeScript changes
- [x] Cron slot verified against scheduler registry (05:30 free)

Refs PHASED_PLAN.md § P16; completes #107 (P04b ✅ backup redaction + P16 restore rehearsal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)