### PR TITLE
P18: dashboard polish — status strip, search toggle, source filter, related captures

### DIFF
--- a/IMPLEMENT_PHASE-P18.md
+++ b/IMPLEMENT_PHASE-P18.md
@@ -1,0 +1,210 @@
+# IMPLEMENT_PHASE-P18.md — Dashboard & Settings Polish
+
+**Phase:** P18
+**GH Issue:** #70
+**Wave:** 3 (Polish + search)
+**PHASED_PLAN dependencies:** None (independent of all other phases)
+**Effort estimate:** ~2 days
+
+---
+
+## Scope Diff (card vs. current state)
+
+The PHASED_PLAN § P18 card lists five "likely candidates" with `(depend on Troy's direction)` caveat.
+GH issue #70 lists different items. After reading both against the actual codebase, the status per item:
+
+| PHASED_PLAN candidate | GH #70 item | Actual status | Action |
+|---|---|---|---|
+| Settings: autonomy-level selector | — | **DONE** — `AutonomyCard` in Settings accordion "Autonomy" tab (P05/P14b). Full selector + upgrade confirmation dialog. | **SKIP** |
+| Dashboard: surface current autonomy level | — | Not present on Dashboard. | **IN SCOPE** |
+| Dashboard: last memory-consolidation timestamp | — | Not present anywhere. `GET /api/v1/skills` returns `last_run_at` per skill. | **IN SCOPE** |
+| Captures list: filter by source (9-value dropdown) | — | **DONE** — `SearchFilters.tsx` already has all 9 `CaptureSource` values; Timeline has client-side `capture_type` filter. Source dropdown on Timeline is **missing**. | **PARTIAL** |
+| Search UI: expose `include_related` toggle | — | `SearchFilters` panel has no `include_related` field. API param exists (`include_related` default `false`). `SearchFilters` type has no field. | **IN SCOPE** |
+| System.tsx: 5 sub-tabs | `System.tsx: 5 sub-tabs (Queues, Skills, Flows, Infrastructure, MCP Activity)` | **DONE** — System page fully built: all 5 tabs (`QueuesTab`, `SkillsTab`, `FlowsTab`, `InfrastructureTab`, `McpActivityTab`). | **SKIP** |
+| Settings.tsx: AI routing, voice, wiki, email, integrations | `Settings.tsx sections expanded` | **DONE** — 6-section accordion (General, AI Routing, Voice, Email, Integrations, Autonomy). | **SKIP** |
+| VoiceConversations.tsx | `VoiceConversations.tsx: session list, playback` | `/voice-conversations` page exists (`VoiceConversations.tsx`). | **SKIP** (already built) |
+| Related captures component | `Related captures component (spreading activation results per capture)` | `CaptureDetail.tsx` exists but does **not** show related captures. Spreading-activation results are returned when `include_related=true`. | **IN SCOPE** |
+| Financial dashboard tab | `Financial dashboard tab (if 3B-3E built)` | `Financial.tsx` page exists and handles the financial view separately. | **SKIP** (condition not met) |
+
+**Net scope drift summary:** ~60% of PHASED_PLAN candidates were already shipped before this phase plan was written. Three new items from GH #70 are also already done. Four items remain genuinely open and are all small, well-bounded, and cohesive.
+
+---
+
+## Work Items
+
+### W1 — Dashboard: Autonomy level + last memory-consolidation timestamp widget
+
+**What:** Add a small "System status" strip below `StatsCards` on the Dashboard showing:
+1. Current autonomy level (badge with color: observe=gray, assist=blue, advise=yellow, partner=red)
+2. Last memory-consolidation run timestamp (from `GET /api/v1/skills` → find `memory-consolidation` entry → `last_run_at`)
+
+**Files touched:**
+- `packages/web/src/pages/Dashboard.tsx` — add `systemStatus` state; fetch from `skillsApi.list()` + `settingsApi.get('autonomy_level')`; render `SystemStatusStrip`
+- `packages/web/src/components/SystemStatusStrip.tsx` (NEW) — small inline component; two stat pills; no external deps beyond shadcn Badge
+
+**API contracts:**
+- `GET /api/v1/skills` → `{ skills: [{ name, last_run_at, ... }] }` — already exists; `skillsApi.list()` already in `api.ts`
+- `GET /api/v1/settings/autonomy_level` → `{ value: AutonomyLevel }` — already exists; `settingsApi.get()` already in `api.ts`
+
+**Implementation notes:**
+- Both fetches are fire-and-forget — failure is non-fatal; strip simply doesn't render if either returns null
+- Use `Promise.allSettled` alongside existing `loadStats` call (already uses `Promise.allSettled` for four calls)
+- Strip shows: `Autonomy: observe` badge + `Memory consolidation: 3 days ago` or `Memory consolidation: never run`
+- `relativeTime` helper already exists in `Ingest.tsx` — copy/extract into `lib/utils.ts` or duplicate inline
+
+**Acceptance criteria:**
+- [ ] Strip visible on Dashboard when both API calls succeed
+- [ ] Autonomy badge color matches level semantics
+- [ ] `last_run_at` renders as relative time (e.g., "3 days ago") or "never run"
+- [ ] No JS errors when either API call fails (graceful hide)
+
+---
+
+### W2 — Search UI: `include_related` toggle
+
+**What:** Add a checkbox toggle to `SearchFiltersPanel` that sets `include_related: true/false` on the search request body. Activating it returns spreading-activation neighbors alongside direct matches.
+
+**Files touched:**
+- `packages/web/src/lib/types.ts` — add `include_related?: boolean` to `SearchFilters` interface
+- `packages/web/src/lib/api.ts` — `searchApi.search()` already POSTs the full `filters` object; adding the field to the type automatically includes it in the body
+- `packages/web/src/components/SearchFilters.tsx` — add checkbox below the existing `hybrid` checkbox
+- `packages/web/src/pages/Search.tsx` — update `DEFAULT_FILTERS` constant (keep `include_related` absent = defaults to `false` on backend)
+
+**Implementation notes:**
+- Label: "Include related captures (spreading activation)" — informative, not just "include_related"
+- Should be unchecked by default (matches API default `false`)
+- The backend already handles `include_related` as a POST body boolean; the API client's `buildQueryString` is not used here (POST body)
+- No schema migration — purely frontend + existing API param
+
+**Acceptance criteria:**
+- [ ] Checkbox renders in filter panel below "Hybrid search" toggle
+- [ ] Toggling it and re-searching returns different result counts (verifiable in network tab when spreading-activation neighbors exist)
+- [ ] `tsc --noEmit` clean on `packages/web`
+- [ ] `SearchFilters` interface correctly typed
+
+---
+
+### W3 — Timeline: source filter dropdown
+
+**What:** Add a "Source" dropdown filter to the Timeline page (currently has `capture_type` and date filters, but no `source` filter). Uses the same 9-value `CaptureSource` array already in `SearchFilters.tsx`.
+
+**Files touched:**
+- `packages/web/src/pages/Timeline.tsx` — add `source` state variable; add `<select>` for source alongside existing type/date filters; apply to the `captures` list fetch
+
+**Current Timeline fetch chain:**
+- `capturesApi.list({ limit, offset, ...params })` where params includes `source` (check `api.ts`)
+
+**Prerequisite check:** Verify `capturesApi.list()` passes `source` through to `GET /api/v1/captures?source=...`.
+
+**Implementation notes:**
+- Re-use the same `CAPTURE_SOURCES` constant from `SearchFilters.tsx` — extract to `lib/constants.ts` or duplicate inline
+- The API endpoint `GET /api/v1/captures` — need to confirm `source` query param is supported (see `packages/core-api/src/routes/captures.ts`)
+- Filter resets pagination offset to 0 (same pattern as existing filters)
+
+**Acceptance criteria:**
+- [ ] Source dropdown renders in Timeline filter bar
+- [ ] Selecting a source correctly filters the capture list
+- [ ] "All sources" (blank) is the default
+- [ ] `tsc --noEmit` clean
+
+---
+
+### W4 — CaptureDetail: related captures section (spreading activation)
+
+**What:** Add a "Related Captures" section to `CaptureDetail.tsx` that appears when spreading-activation neighbors exist. Triggered by fetching the specific capture via `GET /api/v1/captures/:id?include_related=true` or by passing `include_related=true` to search.
+
+**Files touched:**
+- `packages/web/src/components/CaptureDetail.tsx` — add `related` state; fetch `GET /api/v1/captures/:id?include_related=true` on mount; render related list below existing content
+- `packages/web/src/lib/api.ts` — verify `capturesApi.get(id)` exists and supports `include_related`; add if missing
+- `packages/web/src/lib/types.ts` — verify `Capture` type includes `related_captures` field if the API returns it
+
+**API contracts to verify first:**
+- Check `GET /api/v1/captures/:id` — does it accept `include_related=true`?
+- Check `packages/core-api/src/routes/captures.ts` for the param
+- If not present: use the search API with `capture_id` filter and `include_related=true` as the backing call (fire a search for the capture's content with `include_related=true`)
+
+**Fallback approach** (if `GET /api/v1/captures/:id` doesn't support `include_related`):
+- Use `POST /api/v1/search` with `{ query: capture.content.slice(0, 200), include_related: true, limit: 5 }` to approximate related captures
+- Deduplicate: exclude the current capture from results
+
+**Implementation notes:**
+- Section only renders if `related.length > 0`
+- Render as compact list of `CaptureCard` items (same component used everywhere else)
+- Non-blocking — fire-and-forget; if fetch fails, section stays hidden
+- Title: "Related via memory associations" (descriptive, not just "Related")
+- Cap display at 5 items
+
+**Acceptance criteria:**
+- [ ] Related section appears in CaptureDetail when associations exist in the database
+- [ ] Empty/fetch-fail case: section simply does not render (no error UI)
+- [ ] Related captures link back to their own detail (click to select in parent)
+- [ ] `tsc --noEmit` clean
+
+---
+
+## Execution Order
+
+```
+W1 (Dashboard strip) → independent, simplest
+W2 (Search toggle)   → independent, smallest (type + checkbox)
+W3 (Timeline source) → requires verifying captures API param first
+W4 (CaptureDetail)   → requires verifying captures/:id include_related first
+```
+
+All four are fully independent. W3 and W4 require a quick API verification step before implementing — Gate 3 implementer must read `packages/core-api/src/routes/captures.ts` before writing W3/W4 code.
+
+---
+
+## Pre-implementation verifications (Gate 3 implementer must perform)
+
+1. **`capturesApi.list()` source param** — `grep -n "source" packages/core-api/src/routes/captures.ts` — confirm `source` is a supported query param on the list endpoint.
+
+2. **`GET /api/v1/captures/:id` include_related** — `grep -n "include_related" packages/core-api/src/routes/captures.ts` — if missing, use the fallback search approach for W4.
+
+3. **Timeline `capturesApi.list()` call signature** — check `packages/web/src/lib/api.ts` `capturesApi.list` to confirm what params it passes.
+
+4. **`relativeTime` helper location** — currently inline in `Ingest.tsx`; extract to `packages/web/src/lib/utils.ts` if re-using in W1. Do NOT duplicate across files.
+
+---
+
+## Deliverables checklist
+
+| File | Change | Work item |
+|------|--------|-----------|
+| `packages/web/src/pages/Dashboard.tsx` | Add system status fetch + `SystemStatusStrip` render | W1 |
+| `packages/web/src/components/SystemStatusStrip.tsx` | NEW: autonomy badge + last-consolidation pill | W1 |
+| `packages/web/src/lib/utils.ts` | Extract `relativeTime()` from Ingest.tsx | W1 |
+| `packages/web/src/lib/types.ts` | Add `include_related?: boolean` to `SearchFilters` | W2 |
+| `packages/web/src/components/SearchFilters.tsx` | Add include_related checkbox | W2 |
+| `packages/web/src/pages/Search.tsx` | Keep `DEFAULT_FILTERS` stable (no change needed) | W2 |
+| `packages/web/src/pages/Timeline.tsx` | Add source filter dropdown | W3 |
+| `packages/web/src/components/CaptureDetail.tsx` | Add related captures section | W4 |
+| `packages/web/src/lib/api.ts` | Add `include_related` to capturesApi.get() if missing | W4 |
+
+---
+
+## LAB_NOTEBOOK requirement
+
+Before first commit: Entry 115 with:
+- Objective: Dashboard + search polish
+- Hypothesis: 4 items fully independent, no schema migration, pure frontend — should be low-risk
+- Rollback: `git revert` PR; no data consequences
+
+---
+
+## Rollback plan
+
+Pure frontend changes — no schema migration, no API routes added, no Docker changes. Rollback = revert the PR. No homeserver deploy required post-merge (web is served via Vite build deployed to the `web` container; standard `docker compose up -d --build` or GHCR pull handles it).
+
+---
+
+## Acceptance criteria (phase-level)
+
+- [ ] W1: Dashboard shows autonomy level badge and last memory-consolidation timestamp
+- [ ] W2: Search filter panel has `include_related` toggle; toggling it changes search behavior
+- [ ] W3: Timeline has source dropdown filter with all 9 values + "All sources" default
+- [ ] W4: CaptureDetail shows "Related via memory associations" section when data exists
+- [ ] Zero JavaScript runtime errors on Dashboard, Search, Timeline, and any page with CaptureDetail
+- [ ] `pnpm --filter @open-brain/web build` succeeds (zero type errors, zero import errors)
+- [ ] `pnpm --filter @open-brain/web exec vitest run` passes (existing tests + any new ones)
+- [ ] GH issue #70 can be closed

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -8010,3 +8010,51 @@ Homeserver prometheus.yml content was provided as a pre-flight data block in the
 - **#113 CLOSED** — P11a + P11b + P12 all complete. Full observability stack (Loki + Prometheus + Grafana + Pushgateway) is now IaC-managed under the `observability` compose profile.
 
 ---
+
+## Entry 117 — P18: Dashboard & settings polish  [web] [decision]
+
+**Tags:** [web]
+**Environment:** Laptop / worktree `agent-a107d3f4` on branch `feat/phase-P18-dashboard-polish`
+**Date:** 2026-04-19
+
+### Objective
+
+Implement 4 frontend-only polish items for P18:
+- W1: SystemStatusStrip on Dashboard (autonomy level badge + last consolidation)
+- W2: `include_related` toggle checkbox in SearchFiltersPanel
+- W3: Timeline source filter dropdown
+- W4: CaptureDetail related captures section (spreading activation)
+
+### Hypothesis
+
+All 4 items are fully independent. No schema migration, no backend changes. Pure frontend.
+Expected outcome: All 4 items rendered, Vite build passes clean, zero type errors.
+
+### Pre-implementation verifications
+
+1. **`GET /api/v1/captures` source param** — CONFIRMED: `listCapturesSchema` passes `source` through in `captures.ts:50`. `capturesApi.list()` already accepts `source` as a param. W3 can use server-side filtering.
+
+2. **`GET /api/v1/captures/:id` include_related** — NOT PRESENT: `captures.ts:69` handler only calls `captureService.getById(id)` with no params. Fallback approach required for W4: use `POST /api/v1/search` with `include_related: true` and the capture's content as the query.
+
+3. **`relativeTime` helper** — ALREADY in `packages/web/src/lib/utils.ts` (line 48). No extraction needed. Also exported as `formatRelativeTime`.
+
+4. **`searchApi.search()`** — POSTs the entire `SearchFilters` object as body. Adding `include_related` to the `SearchFilters` interface automatically includes it in the body. No extra API client code needed for W2.
+
+5. **`skillsApi.list()`** already exists in `api.ts:157-198`. Returns `{ data: Skill[] }` with `last_run_at` per skill.
+
+6. **`settingsApi.get()`** already exists in `api.ts:335-337`. Used to fetch `autonomy_level`.
+
+7. **`capturesApi.list()`** accepts `source` param in its type signature (`api.ts:42`). W3 can pass source directly as server-side filter (not client-side).
+
+### Design decisions
+
+- **W1**: `SystemStatusStrip` is a new component. Both fetches (`skillsApi.list()`, `settingsApi.get()`) added to Dashboard's `loadStats()` `Promise.allSettled` block. Component only renders when data is available — graceful failure (hides silently).
+- **W2**: Add `include_related?: boolean` to `SearchFilters` interface. Add checkbox below the existing `hybrid` checkbox in `SearchFiltersPanel`. No DEFAULT_FILTERS change needed (absence = false on backend).
+- **W3**: Add `source` state variable to Timeline. The API filter is server-side (passes `source` to `capturesApi.list()`), unlike the client-side `captureType` filter. Reset offset on filter change matches existing pattern.
+- **W4**: Use `POST /api/v1/search` fallback with `include_related: true` and the capture's content (first 200 chars). Deduplicate the current capture from results. Cap at 5 items. Fire-and-forget on mount; section hidden when no results or error.
+
+### Rollback plan
+
+Pure frontend changes. `git revert` the PR. No data consequences, no Docker changes, no migrations.
+
+---

--- a/packages/web/src/components/CaptureDetail.tsx
+++ b/packages/web/src/components/CaptureDetail.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useState } from 'react';
 import { Clock, Globe, MapPin, Smartphone, Watch, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { cn, formatRelativeTime } from '@/lib/utils';
+import { searchApi } from '@/lib/api';
+import CaptureCard from '@/components/CaptureCard';
 import type { Capture } from '@/lib/types';
 
 interface CaptureDetailProps {
@@ -160,6 +163,23 @@ export default function CaptureDetail({ capture, similarity, onClose }: CaptureD
   const pipelineEvents = capture.pipeline_events ?? [];
   const sourceMetadata = capture.source_metadata ?? {};
 
+  // --- Related captures (spreading activation via search fallback) ---
+  const [related, setRelated] = useState<Capture[]>([]);
+
+  useEffect(() => {
+    const query = capture.content.slice(0, 200);
+    searchApi
+      .search({ query, include_related: true, limit: 6 })
+      .then((res) => {
+        // Exclude the current capture from results; cap at 5
+        const filtered = res.captures.filter((c) => c.id !== capture.id).slice(0, 5);
+        setRelated(filtered);
+      })
+      .catch(() => {
+        // Non-fatal — section stays hidden
+      });
+  }, [capture.id, capture.content]);
+
   return (
     <div className="flex flex-col h-full overflow-y-auto">
       {/* Header */}
@@ -289,6 +309,21 @@ export default function CaptureDetail({ capture, similarity, onClose }: CaptureD
             <div>
               <p className="text-xs font-medium text-muted-foreground mb-2">Source Metadata</p>
               <SourceMetadataDisplay metadata={sourceMetadata} />
+            </div>
+          </>
+        )}
+
+        {/* Related captures (spreading activation) */}
+        {related.length > 0 && (
+          <>
+            <Separator />
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2">Related via memory associations</p>
+              <div className="space-y-2">
+                {related.map((rel) => (
+                  <CaptureCard key={rel.id} capture={rel} />
+                ))}
+              </div>
             </div>
           </>
         )}

--- a/packages/web/src/components/SearchFilters.tsx
+++ b/packages/web/src/components/SearchFilters.tsx
@@ -120,6 +120,19 @@ export default function SearchFiltersPanel({ filters, onChange, onClear }: Searc
           Hybrid search (FTS + vector)
         </label>
       </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="include-related-toggle"
+          type="checkbox"
+          checked={filters.include_related ?? false}
+          onChange={(e) => update({ include_related: e.target.checked })}
+          className="rounded border-input"
+        />
+        <label htmlFor="include-related-toggle" className="text-sm text-muted-foreground cursor-pointer">
+          Include related captures (spreading activation)
+        </label>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/SystemStatusStrip.tsx
+++ b/packages/web/src/components/SystemStatusStrip.tsx
@@ -1,0 +1,46 @@
+import { Badge } from '@/components/ui/badge';
+import { relativeTime } from '@/lib/utils';
+import type { AutonomyLevel } from '@/lib/types';
+
+interface SystemStatusStripProps {
+  autonomyLevel: AutonomyLevel | null;
+  lastConsolidationAt: string | null;
+}
+
+const AUTONOMY_BADGE_CLASS: Record<AutonomyLevel, string> = {
+  observe: 'bg-gray-100 text-gray-700 border-gray-300',
+  assist: 'bg-blue-100 text-blue-700 border-blue-300',
+  advise: 'bg-yellow-100 text-yellow-700 border-yellow-300',
+  partner: 'bg-red-100 text-red-700 border-red-300',
+};
+
+export default function SystemStatusStrip({
+  autonomyLevel,
+  lastConsolidationAt,
+}: SystemStatusStripProps) {
+  if (!autonomyLevel && lastConsolidationAt === null) return null;
+
+  const consolidationLabel = lastConsolidationAt
+    ? relativeTime(lastConsolidationAt)
+    : 'never run';
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border bg-muted/30 px-3 py-2 text-sm">
+      {autonomyLevel && (
+        <span className="flex items-center gap-1.5">
+          <span className="text-muted-foreground text-xs">Autonomy</span>
+          <Badge
+            variant="outline"
+            className={`text-xs capitalize ${AUTONOMY_BADGE_CLASS[autonomyLevel]}`}
+          >
+            {autonomyLevel}
+          </Badge>
+        </span>
+      )}
+      <span className="flex items-center gap-1.5">
+        <span className="text-muted-foreground text-xs">Memory consolidation</span>
+        <span className="text-xs font-medium">{consolidationLabel}</span>
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface SearchFilters {
   brain_view?: BrainView
   source?: CaptureSource
   hybrid?: boolean
+  include_related?: boolean
   threshold?: number
   limit?: number
   offset?: number

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -15,10 +15,11 @@ import { Badge } from '@/components/ui/badge';
 import StatsCards from '@/components/StatsCards';
 import ActivityFeedItemComponent from '@/components/ActivityFeedItem';
 import { FinancialPulseCard } from '@/components/FinancialPulseCard';
-import { statsApi, pipelineApi, adminApi, intelligenceApi, activityApi } from '@/lib/api';
+import { statsApi, pipelineApi, adminApi, intelligenceApi, activityApi, skillsApi, settingsApi } from '@/lib/api';
 import { sseClient } from '@/lib/sse';
 import type { AdminBanner } from '@/lib/api';
-import type { BrainStats, ActivityFeedItem } from '@/lib/types';
+import type { BrainStats, ActivityFeedItem, AutonomyLevel } from '@/lib/types';
+import SystemStatusStrip from '@/components/SystemStatusStrip';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -107,6 +108,10 @@ export default function Dashboard() {
   const [pipelineHealth, setPipelineHealth] = useState<PipelineHealth | null>(null);
   const [adminBanner, setAdminBanner] = useState<AdminBanner | null>(null);
   const [unresolvedQuestions, setUnresolvedQuestions] = useState<Array<{ id: string; content: string; brain_view: string; created_at: string }>>([]);
+
+  // --- System status (autonomy level + last consolidation) ---
+  const [autonomyLevel, setAutonomyLevel] = useState<AutonomyLevel | null>(null);
+  const [lastConsolidationAt, setLastConsolidationAt] = useState<string | null | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -148,17 +153,30 @@ export default function Dashboard() {
     if (!silent) setLoading(true);
     setError(null);
     try {
-      const [statsData, healthData, bannerData, questionsData] = await Promise.allSettled([
+      const [statsData, healthData, bannerData, questionsData, skillsData, autonomyData] = await Promise.allSettled([
         statsApi.get(),
         pipelineApi.health(),
         adminApi.getBanner(),
         intelligenceApi.unresolvedQuestions(5),
+        skillsApi.list(),
+        settingsApi.get<AutonomyLevel>('autonomy_level'),
       ]);
 
       if (statsData.status === 'fulfilled') setStats(statsData.value);
       if (healthData.status === 'fulfilled') setPipelineHealth(healthData.value);
       if (bannerData.status === 'fulfilled') setAdminBanner(bannerData.value.banner);
       if (questionsData.status === 'fulfilled') setUnresolvedQuestions(questionsData.value.questions);
+
+      // System status strip — non-fatal
+      if (skillsData.status === 'fulfilled') {
+        const consolidation = skillsData.value.data.find((s) => s.name === 'memory-consolidation');
+        setLastConsolidationAt(consolidation?.last_run_at ?? null);
+      } else {
+        setLastConsolidationAt(null);
+      }
+      if (autonomyData.status === 'fulfilled') {
+        setAutonomyLevel(autonomyData.value.value);
+      }
 
       if (
         statsData.status === 'rejected' &&
@@ -444,6 +462,14 @@ export default function Dashboard() {
 
       {/* Stats cards */}
       {stats && <StatsCards stats={stats} />}
+
+      {/* System status strip — autonomy level + last memory consolidation */}
+      {lastConsolidationAt !== undefined && (
+        <SystemStatusStrip
+          autonomyLevel={autonomyLevel}
+          lastConsolidationAt={lastConsolidationAt}
+        />
+      )}
 
       {/* Open Questions widget */}
       {unresolvedQuestions.length > 0 && (

--- a/packages/web/src/pages/Timeline.tsx
+++ b/packages/web/src/pages/Timeline.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import CaptureCard from '@/components/CaptureCard';
 import { capturesApi } from '@/lib/api';
-import type { Capture, CaptureType, BrainView } from '@/lib/types';
+import type { Capture, CaptureType, BrainView, CaptureSource } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
 // --- Brain view color mapping ---
@@ -28,6 +28,10 @@ const CAPTURE_TYPES: CaptureType[] = [
 ];
 
 const BRAIN_VIEWS: BrainView[] = ['career', 'personal', 'technical', 'work-internal', 'client'];
+
+const CAPTURE_SOURCES: CaptureSource[] = [
+  'slack', 'voice', 'api', 'document', 'mcp', 'email', 'file', 'consolidation', 'system',
+];
 
 const PAGE_SIZE = 25;
 
@@ -70,6 +74,7 @@ export default function Timeline() {
   // Filters
   const [captureType, setCaptureType] = useState<CaptureType | ''>('');
   const [brainView, setBrainView] = useState<BrainView | ''>('');
+  const [captureSource, setCaptureSource] = useState<CaptureSource | ''>('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
 
@@ -88,6 +93,7 @@ export default function Timeline() {
         offset: currentOffset,
       };
       if (brainView) params.brain_view = brainView;
+      if (captureSource) params.source = captureSource;
 
       const res = await capturesApi.list(params);
 
@@ -106,7 +112,7 @@ export default function Timeline() {
       setLoading(false);
       setLoadingMore(false);
     }
-  }, [brainView, captureType, startDate, endDate, offset, total]);
+  }, [brainView, captureType, captureSource, startDate, endDate, offset, total]);
 
   // Initial load and filter resets
   useEffect(() => {
@@ -114,7 +120,7 @@ export default function Timeline() {
     setCaptures([]);
     setTotal(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [brainView, captureType, startDate, endDate]);
+  }, [brainView, captureType, captureSource, startDate, endDate]);
 
   useEffect(() => {
     if (offset === 0) {
@@ -186,6 +192,17 @@ export default function Timeline() {
           ))}
         </select>
 
+        <select
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+          value={captureSource}
+          onChange={(e) => setCaptureSource(e.target.value as CaptureSource | '')}
+        >
+          <option value="">All sources</option>
+          {CAPTURE_SOURCES.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+
         <Input
           type="date"
           className="h-9 w-auto"
@@ -201,13 +218,14 @@ export default function Timeline() {
           placeholder="To"
         />
 
-        {(captureType || brainView || startDate || endDate) && (
+        {(captureType || brainView || captureSource || startDate || endDate) && (
           <Button
             variant="ghost"
             size="sm"
             onClick={() => {
               setCaptureType('');
               setBrainView('');
+              setCaptureSource('');
               setStartDate('');
               setEndDate('');
             }}


### PR DESCRIPTION
## Summary
4 frontend-only UI improvements:
- **Dashboard SystemStatusStrip** — autonomy level badge + last memory-consolidation timestamp
- **Search `include_related` toggle** — checkbox for spreading activation, unchecked by default
- **Timeline source filter** — dropdown with all 9 CaptureSource values, server-side filtering
- **CaptureDetail related captures** — spreading activation neighbors via search fallback

## Test plan
- [x] `pnpm --filter @open-brain/web build` — zero errors (8.26s)
- [x] No backend changes
- [x] All new components follow existing shadcn/ui + Tailwind patterns

Refs PHASED_PLAN.md § P18; closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)