### PR TITLE
P21: financial advisor newsletter pipeline — T0 parse + T2 synthesis

### DIFF
--- a/IMPLEMENT_PHASE-P21.md
+++ b/IMPLEMENT_PHASE-P21.md
@@ -1,0 +1,351 @@
+# IMPLEMENT_PHASE-P21 — Financial Advisor Newsletter Assessment (#66)
+
+**Phase:** P21  
+**Wave:** 4 (Arc 3 Batch Source Pipelines)  
+**PR scope:** New Python script + config file + cron entry  
+**GitHub issue:** #66  
+**Generated:** 2026-04-19 (Gate 1 — phase-planner)  
+**Prior phases required:** None (Wave 4 is independent of A–D after P02/P03 landed)
+
+---
+
+## Scope Diff vs. PHASED_PLAN.md Card
+
+The P21 card in PHASED_PLAN.md is a 4-bullet sketch. Gate 1 investigation reveals the following clarifications and one scope adjustment:
+
+| Card item | Status |
+|-----------|--------|
+| "Newsletter ingestion hook (email with known advisor senders triggers pipeline)" | **NEEDS GROUNDING** — email-pipeline.py classifies newsletters into the `Newsletters & Marketing` category but does NOT currently fetch full body text or fire a downstream hook. P21 must read full email bodies via the Graph/Gmail API, not just subject+preview. |
+| "Advisor-voice extraction (quoted vs. opinion vs. market data)" | **IN-SCOPE** — T0 section parsing + T2 Claude CLI synthesis for full analysis. |
+| "'What changed vs. prior newsletter' diff capture" | **IN-SCOPE** — SQLite stores prior run; diff is computed in Python (T0), surfaced in synthesis prompt. |
+| "Action items: specific recommendations with deadlines" | **IN-SCOPE** — structured extraction in synthesis prompt; output capture tagged `observation` / `brain_view: personal`. |
+| "Last 5 newsletters processed; operator validates quality" | **ACCEPTANCE CRITERION** — preserved. |
+
+**Scope addition (grounded in existing code):**
+- Email body fetching via the Hotmail Graph API already exists in `email-pipeline.py`'s `HotmailBackend`. P21 will reuse that class rather than duplicate the MSAL token flow.
+- The `lib/capture_api.py` shared helper is the correct POST path (same pattern as `financial-pipeline.py`).
+- All advisor sender rules live in config (`config/financial/newsletter-advisors.yaml` — new file, P21 creates it). This keeps the advisor list out of code and editable without a deploy.
+
+**No scope divergence that requires operator pause.** Proceeding.
+
+---
+
+## Architecture & Cost-Tier Mapping
+
+```
+Cron trigger (daily, open-brain-vm)
+  │
+  ├── T0: Python reads advisor sender list from config YAML
+  ├── T0: Graph API / Gmail API → fetch full email body for each matched sender
+  ├── T0: Section parser (regex) → extracts market commentary, recommendations, deadlines
+  ├── T0: Diff against prior newsletter stored in SQLite (hash + text)
+  ├── T2: claude --print → structured synthesis prompt → action summary
+  └── POST to /api/v1/captures via lib/capture_api.py
+```
+
+**Why T2 and not T3:** Newsletters arrive asynchronously, operator is never actively waiting, synthesis is not real-time. This is precisely the batch/async T2 use case. One `claude --print` call per advisor per new newsletter — not per-email.
+
+**Aggregation rule satisfied:** collect (all newsletters from one advisor since last run) → extract (T0 section parse + diff) → one synthesis call → one capture.
+
+---
+
+## Work Items
+
+### WI-1: Config file — `config/financial/newsletter-advisors.yaml`
+
+**File:** `config/financial/newsletter-advisors.yaml` (new)
+
+Define the advisor sender list and extraction hints. Schema:
+
+```yaml
+# Financial advisor newsletter pipeline config — P21
+# Each entry: sender domain or exact address -> advisor name + extraction hints
+advisors:
+  - name: "Example Advisor"
+    sender_match: "newsletter@example-advisory.com"   # exact address
+    match_type: exact                                  # exact | domain
+    brain_view: personal
+    capture_type: observation
+    action_item_keywords:                             # T0 extraction hints
+      - "recommend"
+      - "action"
+      - "consider"
+      - "target"
+    section_headers:                                  # T0 section split markers
+      - "Market Commentary"
+      - "Portfolio Recommendations"
+      - "Key Takeaways"
+
+# Pipeline behavior
+pipeline:
+  dedupe_window_days: 7           # skip newsletter if same sender seen < 7 days ago
+  max_body_chars: 20000           # truncate before T2 prompt
+  synthesis_timeout_sec: 180
+  capture_api:
+    caller_header: "newsletter-pipeline"
+```
+
+**Acceptance:** YAML loads without error; at least one real advisor entry present (operator fills in during rollout).
+
+---
+
+### WI-2: SQLite tracking DB init — `~/.newsletter-pipeline/pipeline.db`
+
+**File:** `scripts/newsletter-pipeline.py` — `init_db()` function
+
+Tables needed:
+```sql
+CREATE TABLE IF NOT EXISTS processed_newsletters (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    advisor_name TEXT NOT NULL,
+    message_id TEXT NOT NULL UNIQUE,
+    provider TEXT NOT NULL,          -- 'hotmail' | 'gmail'
+    subject TEXT,
+    received_at TEXT,
+    body_hash TEXT,                  -- SHA-256 of full body text
+    body_preview TEXT,               -- first 500 chars, for diff display
+    synthesis_posted INTEGER DEFAULT 0,
+    capture_id TEXT,                 -- UUID from core-api response if available
+    processed_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_pn_advisor ON processed_newsletters(advisor_name, received_at);
+CREATE INDEX IF NOT EXISTS idx_pn_msg ON processed_newsletters(message_id);
+```
+
+**Acceptance:** `init_db()` is idempotent (safe to re-run).
+
+---
+
+### WI-3: Email fetch — full body retrieval from Hotmail/Gmail
+
+**File:** `scripts/newsletter-pipeline.py` — `fetch_newsletters()` function
+
+**Implementation notes:**
+- Reuse `HotmailBackend` from `email-pipeline.py` by importing it (both scripts in `scripts/`). Do NOT duplicate MSAL auth logic.
+  - Import pattern: `from email_pipeline import HotmailBackend`  (Python converts hyphen in filename; use `importlib` if needed — see note below)
+  - **Filename import note:** `email-pipeline.py` has a hyphen; Python cannot import it with a plain `import` statement. Use `importlib.util.spec_from_file_location("email_pipeline", Path(__file__).parent / "email-pipeline.py")` — same pattern as any hyphenated script in the project.
+- Graph API body endpoint: `GET /me/messages/{id}?$select=body,subject,from,receivedDateTime` — `body.content` field contains HTML. Strip tags with `re.sub(r'<[^>]+>', ' ', html)` to get plain text (T0, no external lib needed since newsletters are simple HTML).
+- Gmail equivalent: use existing gmail auth token cache from email-pipeline if present; fall back to `--setup` flow.
+- Fetch window: last N days where N = `pipeline.dedupe_window_days` from config (default 7), OR since last processed message for that advisor (whichever is shorter).
+- Filter: sender matches any `sender_match` in the advisors list.
+- Body size cap: truncate to `max_body_chars` before storing or passing to T2.
+
+**Acceptance:** `--fetch-only` dry-run mode prints matched messages and body char counts without posting.
+
+---
+
+### WI-4: T0 Section parsing and diff computation
+
+**File:** `scripts/newsletter-pipeline.py` — `parse_newsletter()` and `compute_diff()` functions
+
+`parse_newsletter(body_text, advisor_config) -> dict`:
+- Split on `section_headers` patterns (case-insensitive regex).
+- Extract action item sentences: lines containing `action_item_keywords` (word-boundary match).
+- Return: `{ sections: {header: text}, action_items: [str], word_count: int }`.
+
+`compute_diff(current_body_hash, current_preview, conn, advisor_name) -> str`:
+- Query `processed_newsletters` for most recent prior row matching `advisor_name`.
+- If no prior: return `"First newsletter from this advisor."`.
+- If body hash matches prior: return `"Duplicate — body unchanged."` → skip synthesis, skip posting.
+- Otherwise: compare `body_preview` strings and return a one-paragraph diff note (length delta, new sections detected by regex).
+
+**Acceptance:** Unit-testable pure functions; `compute_diff` returns dedup sentinel on matching hash.
+
+---
+
+### WI-5: T2 synthesis via `claude --print`
+
+**File:** `scripts/newsletter-pipeline.py` — `synthesize_newsletter()` function
+
+```python
+def synthesize_newsletter(advisor_name, subject, body_text, parsed, diff_note, cfg) -> str | None:
+    prompt = build_synthesis_prompt(advisor_name, subject, body_text, parsed, diff_note)
+    try:
+        result = subprocess.run(
+            ["claude", "--print", "-p", prompt],
+            capture_output=True, text=True,
+            timeout=cfg["pipeline"]["synthesis_timeout_sec"],
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+        log.warning(f"Claude CLI returned {result.returncode}: {result.stderr[:200]}")
+    except subprocess.TimeoutExpired:
+        log.warning("Claude CLI timed out — posting raw extraction without synthesis")
+    except FileNotFoundError:
+        log.warning("Claude CLI not found — posting raw extraction without synthesis")
+    return None
+```
+
+`build_synthesis_prompt()` includes:
+- Advisor name, newsletter subject, date
+- Section extracts (capped at `max_body_chars`)
+- T0-extracted action items
+- Diff note vs. prior newsletter
+- Instructions: "Extract 3–7 specific actionable recommendations with any stated deadlines. Note what changed since the prior newsletter. Flag any market views that differ from prior positions. Output structured markdown: ## What's New, ## Action Items, ## Market Views, ## Changed Positions."
+
+Fallback (Claude CLI absent): post raw T0 extraction only.
+
+**Acceptance:** Synthesis prompt is under 6,000 chars after truncation; fallback path posts raw extraction without crashing.
+
+---
+
+### WI-6: POST capture to core-api
+
+**File:** `scripts/newsletter-pipeline.py` — `post_newsletter_capture()` function
+
+Reuse `lib/capture_api.py`'s `post_capture()` exactly as `financial-pipeline.py` does it.
+
+Capture content format:
+```
+[Newsletter] {advisor_name} — {subject} ({date})
+
+{synthesis or raw_extraction}
+
+---
+Source: {provider} | {word_count} words | Changes: {diff_summary}
+Action items extracted: {len(action_items)}
+```
+
+`source_metadata` envelope:
+```json
+{
+  "type": "newsletter_assessment",
+  "advisor_name": "...",
+  "subject": "...",
+  "received_at": "...",
+  "provider": "hotmail|gmail",
+  "word_count": 1234,
+  "action_item_count": 5,
+  "has_synthesis": true,
+  "diff_from_prior": "summary string"
+}
+```
+
+`brain_view`: from advisor config (default `personal`).  
+`capture_type`: `observation`.  
+`X-Open-Brain-Caller`: `newsletter-pipeline` (must be added to `BYPASS_CALLERS` in `rate-limit.ts`).
+
+**Acceptance:** Successful POST returns `True`; SQLite row updated with `synthesis_posted=1`.
+
+---
+
+### WI-7: Rate-limit bypass registration
+
+**File:** `packages/core-api/src/middleware/rate-limit.ts`
+
+Add `'newsletter-pipeline'` to `BYPASS_CALLERS` Set. This follows the lockstep rule from CLAUDE.md: every internal caller sets the header AND gets a bypass entry. Even though this is a batch script (not a worker), it runs on open-brain-vm and POSTs via the internal capture API path.
+
+**Acceptance:** `BYPASS_CALLERS` contains `'newsletter-pipeline'`; existing tests still pass.
+
+---
+
+### WI-8: CLI entrypoint and cron wiring
+
+**File:** `scripts/newsletter-pipeline.py` — `main()` via `argparse`
+
+```
+python newsletter-pipeline.py --run              # fetch + parse + synthesize + post (normal cron run)
+python newsletter-pipeline.py --setup            # interactive auth (first-time Graph/Gmail)
+python newsletter-pipeline.py --fetch-only       # dry-run: print matched newsletters, no post
+python newsletter-pipeline.py --status           # show DB stats: advisors, last run, post count
+python newsletter-pipeline.py --reprocess N      # reprocess last N newsletters (re-synthesize, re-post)
+```
+
+Cron entry (open-brain-vm, `~/.crontab` or `/etc/cron.d/`):
+```
+0 8 * * * cd ~/open-brain && venv/bin/python scripts/newsletter-pipeline.py --run >> ~/logs/newsletter-pipeline.log 2>&1
+```
+
+Slot: `0 8 * * *` (08:00 daily). Verify no collision with existing cron slots. Current weekday morning cluster runs 06:00–07:15 per CLAUDE.md. 08:00 is after the cluster; safe. Not in the scheduler.ts BullMQ cron registry (this is a VM-side cron, not a workers cron).
+
+**Acceptance:** `--status` exits 0; `--run` with no matching newsletters exits 0 without error.
+
+---
+
+### WI-9: Tests
+
+**File:** `docker/ingest-sidecar/tests/test_newsletter_pipeline.py` OR `scripts/tests/test_newsletter_pipeline.py`
+
+Pattern: follow `docker/ingest-sidecar/tests/` convention (pytest, fixtures, no live API calls).
+
+Test cases:
+1. `test_init_db_idempotent`: call `init_db()` twice, assert no exception and table exists.
+2. `test_parse_newsletter_extracts_action_items`: fixture body with known keywords, assert action items list non-empty.
+3. `test_compute_diff_dedup_on_matching_hash`: insert prior row with same hash, assert dedup sentinel returned.
+4. `test_compute_diff_first_newsletter`: empty DB, assert "First newsletter" string returned.
+5. `test_post_capture_called_on_new_newsletter`: mock `post_capture` + `subprocess.run`, assert both called on new newsletter.
+6. `test_post_capture_skipped_on_dedup`: matching hash in DB, assert `post_capture` NOT called.
+7. `test_synthesis_fallback_on_cli_not_found`: `subprocess.run` raises `FileNotFoundError`, assert raw extraction is posted instead.
+
+Minimum: 7 tests. All mocked at API boundary (no live Graph API, no live core-api, no live Claude CLI).
+
+**Acceptance:** `pytest scripts/tests/test_newsletter_pipeline.py` passes; 7+ tests green.
+
+---
+
+## File Manifest
+
+| Action | Path |
+|--------|------|
+| CREATE | `scripts/newsletter-pipeline.py` |
+| CREATE | `config/financial/newsletter-advisors.yaml` |
+| CREATE | `scripts/tests/test_newsletter_pipeline.py` (or `docker/ingest-sidecar/tests/`) |
+| EDIT | `packages/core-api/src/middleware/rate-limit.ts` — add `newsletter-pipeline` to BYPASS_CALLERS |
+
+**No database migration.** The pipeline uses its own SQLite (`~/.newsletter-pipeline/pipeline.db`), not the Postgres schema. No new BullMQ workers, no `packages/workers` changes, no `scheduler.ts` changes (VM-side cron, not workers cron).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `newsletter-pipeline.py --fetch-only` prints matched messages for at least one configured advisor (requires operator to populate `newsletter-advisors.yaml` with a real sender)
+- [ ] `newsletter-pipeline.py --run` posts a capture for each new newsletter; `--status` shows `synthesis_posted=1`
+- [ ] SQLite deduplication: running `--run` twice on same day does NOT post duplicate captures
+- [ ] Fallback: when `claude` CLI is absent or times out, raw extraction is posted without crashing
+- [ ] `newsletter-pipeline` is in `BYPASS_CALLERS` in `rate-limit.ts`; existing rate-limit tests still pass
+- [ ] 7+ pytest cases green
+- [ ] `--status` exits 0 on fresh install (empty DB)
+- [ ] Last 5 newsletters processed from real advisor emails; operator validates extraction quality (manual AC — post-deploy)
+
+---
+
+## Dependencies
+
+- **Runtime (VM):** `requests`, `msal`, `pyyaml` — all already installed in open-brain-vm venv (used by `email-pipeline.py` and `financial-pipeline.py`).
+- **No new pip dependencies.** `PyMuPDF` is NOT required — newsletters arrive as email body HTML, not PDFs. If a PDF-attachment variant is needed later, that is a follow-up (not P21 scope).
+- **`email-pipeline.py` `HotmailBackend`:** imported via `importlib.util` due to hyphenated filename. Test must mock the import surface cleanly.
+- **Core-api rate-limit:** one-line BYPASS_CALLERS addition. No PR gate escalation (not a homeserver migration; no schema change).
+
+---
+
+## Rollback Plan
+
+- Script is additive (`scripts/` only). To disable: comment out or remove the cron entry on open-brain-vm.
+- The one TypeScript change (rate-limit.ts BYPASS_CALLERS) is additive and trivially reverted. It does not affect any existing bypass entry.
+- SQLite lives in `~/.newsletter-pipeline/` on open-brain-vm. Delete that directory to wipe pipeline state. No Postgres impact.
+- git revert the PR; remove cron entry on open-brain-vm.
+
+---
+
+## Effort Estimate
+
+**~1.5–2 days.** Original card said ~2 days; this is consistent given:
+- WI-1–2 (config + DB init): ~1 hour
+- WI-3 (full body fetch via importlib HotmailBackend reuse): ~2 hours
+- WI-4 (T0 parsing + diff): ~2 hours
+- WI-5 (T2 synthesis + prompt building): ~2 hours
+- WI-6–7 (capture POST + rate-limit): ~1 hour
+- WI-8 (CLI + cron): ~1 hour
+- WI-9 (tests): ~2 hours
+
+**Key complexity:** the `importlib` import pattern for `email-pipeline.py` is the main gotcha. If it proves brittle during Gate 3, the fallback is to extract `HotmailBackend` into `scripts/lib/hotmail_backend.py` — that's a 30-minute refactor and acceptable in-flight scope expansion (still one PR).
+
+---
+
+## Gate 1 Findings — No Operator Pause Required
+
+- No scope divergence that invalidates card deliverables.
+- P21 has no dependencies on P19/P20a/P20b (those are doctor labs; financial newsletter is independent).
+- No homeserver migration → Gate 5 auto-merge eligible per ORCHESTRATOR.md matrix.
+- No CLAUDE.md / PRD / TDD edits → auto-merge eligible.
+- Budget: zero LLM API cost. One `claude --print` call per new newsletter per advisor (T2 CLI, subscription-covered, not API). OpenAI embeddings fire as normal downstream (pipeline picks up the capture).

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -225,6 +225,52 @@
 
 ---
 
+### Entry 099 — P21: Financial Advisor Newsletter Assessment Pipeline
+
+**Tags:** [pipeline] [decision] [config]
+**Environment:** laptop (worktree agent-aaa983a8), open-brain-vm (cron target)
+**Branch:** `feat/phase-P21-newsletter-pipeline`
+**Date:** 2026-04-19
+
+#### Objective
+
+Implement the P21 financial advisor newsletter pipeline per IMPLEMENT_PHASE-P21.md: 9 work items covering config, SQLite tracking DB, full-body email fetch (reusing HotmailBackend via importlib), T0 section parsing + diff, T2 Claude CLI synthesis, capture POST, rate-limit bypass registration, CLI + cron wiring, and 7+ pytest cases.
+
+#### Hypothesis
+
+All 9 WIs are self-contained in `scripts/` + one 1-line TS edit (rate-limit.ts BYPASS_CALLERS). Zero schema migration. Zero new pip dependencies. T2 (`claude --print`) handles synthesis — zero LLM API cost. Expected outcome: pytest passes 7+ cases; `--status` exits 0; `--fetch-only` prints advisor matches; `--run` posts captures and deduplicates on repeat run.
+
+#### Rollback plan
+
+- Script is additive (`scripts/` only). Remove or comment out cron entry on open-brain-vm to disable.
+- rate-limit.ts change is a trivially reverted 1-line addition to the Set — does not affect any existing bypass entry.
+- SQLite in `~/.newsletter-pipeline/` on VM. Delete that directory to wipe pipeline state. No Postgres impact.
+- `git revert` the PR.
+
+#### Design decisions
+
+| # | Decision | Alternatives |
+|---|----------|-------------|
+| D-P21-1 | `importlib.util.spec_from_file_location` for `email-pipeline.py` HotmailBackend reuse (hyphenated filename) | Fallback: extract HotmailBackend to `scripts/lib/hotmail_backend.py` if importlib proves brittle |
+| D-P21-2 | Tests go in `scripts/tests/` (new dir, mirroring `docker/ingest-sidecar/tests/`) | `docker/ingest-sidecar/tests/` — wrong conceptual home for a standalone VM script |
+| D-P21-3 | Config in `config/financial/newsletter-advisors.yaml` — ship with placeholder; operator populates real senders | Hardcode in script (not editable without deploy) |
+| D-P21-4 | `X-Open-Brain-Caller: newsletter-pipeline` + BYPASS_CALLERS entry (lockstep rule per CLAUDE.md) | No header (429s under burst); shared `email-pipeline` value (bad observability) |
+
+#### Implementation notes
+
+- HotmailBackend `_get()` in email-pipeline.py uses positional `params=None` arg that is never actually passed to the requests call — body fetch calls `GET /me/messages/{id}?$select=body,subject,...` as a literal URL string, which is the correct approach.
+- Gmail body fetch: `messages.get(format='full')` → `payload.parts` walk for `text/plain` or `text/html`.
+- Dedup sentinel `"DUPLICATE"` used as constant; `compute_diff()` returns it on hash match so callers can skip synthesis + post.
+- Synthesis prompt capped to 6,000 chars (truncates body section before building).
+- `--reprocess N` re-synthesizes last N rows by setting `synthesis_posted=0` and re-running.
+- Cron slot `0 8 * * *` — after the weekday morning cluster (06:00–07:15). Safe, no collision.
+
+#### Result
+
+All 9 WIs implemented. See commits under `feat/phase-P21-newsletter-pipeline`.
+
+---
+
 ## Prior Work Summary
 
 ### Project Arc

--- a/config/financial/newsletter-advisors.yaml
+++ b/config/financial/newsletter-advisors.yaml
@@ -1,0 +1,62 @@
+# Financial advisor newsletter pipeline config — P21
+# Each entry: sender domain or exact address -> advisor name + extraction hints
+#
+# Populate sender_match with the actual From address or domain of your advisors.
+# match_type: exact (full email address) | domain (any @that.domain)
+#
+# action_item_keywords: T0 word-boundary scan for lines that likely contain
+# a specific recommendation or task to act on.
+#
+# section_headers: regex-split points — newsletter body is chunked at these
+# case-insensitive patterns so only the relevant sections go into the T2 prompt.
+
+advisors:
+  # ── Placeholder — replace with your real advisor senders ──────────────────
+  - name: "Example Advisor Firm"
+    sender_match: "newsletter@example-advisory.com"
+    match_type: exact                           # exact | domain
+    brain_view: personal
+    capture_type: observation
+    action_item_keywords:
+      - "recommend"
+      - "action"
+      - "consider"
+      - "target"
+      - "should"
+      - "suggest"
+      - "opportunity"
+      - "deadline"
+      - "by end of"
+    section_headers:
+      - "Market Commentary"
+      - "Portfolio Recommendations"
+      - "Key Takeaways"
+      - "Action Items"
+      - "Investment Outlook"
+      - "Economic Update"
+      - "What We're Watching"
+
+  # ── Add your real advisors below ──────────────────────────────────────────
+  # - name: "Schwab Intelligent Portfolio"
+  #   sender_match: "schwab.com"
+  #   match_type: domain
+  #   brain_view: personal
+  #   capture_type: observation
+  #   action_item_keywords:
+  #     - "rebalance"
+  #     - "review"
+  #     - "consider"
+  #     - "recommend"
+  #   section_headers:
+  #     - "Market Update"
+  #     - "Portfolio Review"
+  #     - "Quarterly Outlook"
+
+# Pipeline behavior
+pipeline:
+  dedupe_window_days: 7           # skip newsletter if same sender seen < 7 days ago
+  max_body_chars: 20000           # truncate body before T2 prompt (keeps prompt under 6K)
+  synthesis_timeout_sec: 180      # claude --print timeout
+  capture_api:
+    url: "https://brain.troy-davis.com/api/v1/captures"
+    caller_header: "newsletter-pipeline"

--- a/packages/core-api/src/middleware/rate-limit.ts
+++ b/packages/core-api/src/middleware/rate-limit.ts
@@ -176,6 +176,8 @@ export function rateLimit(limiter: RateLimiter): MiddlewareHandler {
       'internal:email-pipeline',
       'internal:ingest-onedrive',
       'internal:ingest-repair',
+      // P21 — financial advisor newsletter assessment pipeline (open-brain-vm cron)
+      'internal:newsletter-pipeline',
     ])
     if (BYPASS_CALLERS.has(key)) {
       await next()

--- a/scripts/newsletter-pipeline.py
+++ b/scripts/newsletter-pipeline.py
@@ -1,0 +1,937 @@
+#!/usr/bin/env python3
+"""
+Financial Advisor Newsletter Assessment Pipeline for Open Brain — P21.
+
+Fetches full-body newsletters from known advisor senders (Hotmail/Gmail),
+extracts structure + action items via T0 parsing, diffs against prior
+newsletter for the same advisor, synthesizes via T2 Claude CLI, and posts
+one capture per advisor per new newsletter to the Open Brain API.
+
+Cost tier: T0 (Python) + T2 (claude --print, subscription-covered). Zero
+LLM API cost. Aggregation rule satisfied: one synthesis call per newsletter
+per advisor, never per-email.
+
+Usage:
+    python newsletter-pipeline.py --run              # fetch + parse + synthesize + post
+    python newsletter-pipeline.py --setup            # interactive auth (first-time Graph/Gmail)
+    python newsletter-pipeline.py --fetch-only       # dry-run: print matches, no post
+    python newsletter-pipeline.py --status           # DB stats: advisors, last run, counts
+    python newsletter-pipeline.py --reprocess N      # re-synthesize last N newsletters
+
+Cron (open-brain-vm, daily 08:00):
+    0 8 * * * cd ~/open-brain && venv/bin/python scripts/newsletter-pipeline.py --run >> ~/logs/newsletter-pipeline.log 2>&1
+"""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import logging
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import requests
+import yaml
+
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("newsletter-pipeline")
+
+# ── Paths & constants ─────────────────────────────────────────────────────────
+
+PIPE_DIR = Path.home() / ".newsletter-pipeline"
+DB_PATH = PIPE_DIR / "pipeline.db"
+SCRIPTS_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = SCRIPTS_DIR.parent / "config" / "financial" / "newsletter-advisors.yaml"
+
+GRAPH = "https://graph.microsoft.com/v1.0"
+API_DELAY = 0.1
+DUPLICATE_SENTINEL = "DUPLICATE"
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+
+def load_config() -> dict:
+    """Load and validate newsletter-advisors.yaml."""
+    if not CONFIG_PATH.exists():
+        sys.exit(f"Config not found: {CONFIG_PATH}")
+    cfg = yaml.safe_load(CONFIG_PATH.read_text())
+    if not cfg.get("advisors"):
+        log.warning("No advisors configured in newsletter-advisors.yaml")
+    return cfg
+
+
+def _advisor_index(cfg: dict) -> dict[str, dict]:
+    """Build lookup: normalized_sender -> advisor_config."""
+    idx: dict[str, dict] = {}
+    for adv in cfg.get("advisors", []):
+        key = adv["sender_match"].lower().strip()
+        idx[key] = adv
+    return idx
+
+
+# ── WI-2: SQLite DB ───────────────────────────────────────────────────────────
+
+
+def init_db() -> sqlite3.Connection:
+    """Initialize SQLite tracking DB. Idempotent — safe to call multiple times."""
+    PIPE_DIR.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(DB_PATH), timeout=30)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS processed_newsletters (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            advisor_name TEXT NOT NULL,
+            message_id TEXT NOT NULL UNIQUE,
+            provider TEXT NOT NULL,
+            subject TEXT,
+            received_at TEXT,
+            body_hash TEXT,
+            body_preview TEXT,
+            synthesis_posted INTEGER DEFAULT 0,
+            capture_id TEXT,
+            processed_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_pn_advisor
+            ON processed_newsletters(advisor_name, received_at);
+        CREATE INDEX IF NOT EXISTS idx_pn_msg
+            ON processed_newsletters(message_id);
+    """)
+    conn.commit()
+    return conn
+
+
+def is_processed(conn: sqlite3.Connection, message_id: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM processed_newsletters WHERE message_id=?", (message_id,)
+    ).fetchone() is not None
+
+
+def record_newsletter(
+    conn: sqlite3.Connection,
+    advisor_name: str,
+    message_id: str,
+    provider: str,
+    subject: str,
+    received_at: str,
+    body_hash: str,
+    body_preview: str,
+    synthesis_posted: bool = False,
+    capture_id: str | None = None,
+) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO processed_newsletters "
+        "(advisor_name, message_id, provider, subject, received_at, body_hash, "
+        " body_preview, synthesis_posted, capture_id) "
+        "VALUES (?,?,?,?,?,?,?,?,?)",
+        (
+            advisor_name,
+            message_id,
+            provider,
+            subject[:500],
+            received_at,
+            body_hash,
+            body_preview[:500],
+            int(synthesis_posted),
+            capture_id,
+        ),
+    )
+    conn.commit()
+
+
+def mark_posted(conn: sqlite3.Connection, message_id: str, capture_id: str | None = None) -> None:
+    conn.execute(
+        "UPDATE processed_newsletters SET synthesis_posted=1, capture_id=? WHERE message_id=?",
+        (capture_id, message_id),
+    )
+    conn.commit()
+
+
+# ── WI-3: Email fetch helpers ─────────────────────────────────────────────────
+
+
+def _load_hotmail_backend():
+    """Load HotmailBackend from email-pipeline.py via importlib (hyphenated filename)."""
+    email_pipeline_path = SCRIPTS_DIR / "email-pipeline.py"
+    if not email_pipeline_path.exists():
+        log.error(f"email-pipeline.py not found at {email_pipeline_path}")
+        return None
+    spec = importlib.util.spec_from_file_location("email_pipeline", email_pipeline_path)
+    if spec is None or spec.loader is None:
+        log.error("importlib could not load email-pipeline.py")
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as e:
+        log.error(f"Failed to load email-pipeline.py: {e}")
+        return None
+    return getattr(mod, "HotmailBackend", None)
+
+
+def _strip_html(html: str) -> str:
+    """T0: strip HTML tags to plain text — no external lib needed."""
+    text = re.sub(r"<style[^>]*>.*?</style>", " ", html, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<script[^>]*>.*?</script>", " ", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"&nbsp;", " ", text)
+    text = re.sub(r"&amp;", "&", text)
+    text = re.sub(r"&lt;", "<", text)
+    text = re.sub(r"&gt;", ">", text)
+    text = re.sub(r"&quot;", '"', text)
+    text = re.sub(r"&#39;", "'", text)
+    text = re.sub(r"\s{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _match_sender(sender: str, advisor_index: dict[str, dict]) -> dict | None:
+    """Match a sender address against the advisor index (exact or domain)."""
+    sender = sender.lower().strip()
+    # Exact match
+    if sender in advisor_index:
+        return advisor_index[sender]
+    # Domain match
+    if "@" in sender:
+        domain = sender.split("@", 1)[1]
+        for key, adv in advisor_index.items():
+            if adv.get("match_type") == "domain" and (domain == key or domain.endswith("." + key)):
+                return adv
+    return None
+
+
+def fetch_newsletters_hotmail(
+    conn: sqlite3.Connection,
+    cfg: dict,
+    advisor_index: dict[str, dict],
+    interactive: bool = False,
+    dry_run: bool = False,
+) -> list[dict]:
+    """Fetch full-body newsletter emails from Hotmail for known advisor senders."""
+    HotmailBackend = _load_hotmail_backend()
+    if HotmailBackend is None:
+        log.error("Cannot fetch from Hotmail — HotmailBackend not available")
+        return []
+
+    # Create a minimal cfg object that HotmailBackend accepts
+    email_cfg: dict = {"_categories": set(), "sender_rules": {}, "keyword_rules": {}}
+    backend = HotmailBackend(conn, email_cfg)
+    if not backend.authenticate(interactive=interactive):
+        log.error("Hotmail authentication failed")
+        return []
+
+    dedupe_days = cfg["pipeline"].get("dedupe_window_days", 7)
+    max_chars = cfg["pipeline"].get("max_body_chars", 20000)
+    since = (datetime.now(UTC) - timedelta(days=dedupe_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Fetch inbox messages for the window
+    url = (
+        f"{GRAPH}/me/mailFolders/inbox/messages"
+        f"?$top=50"
+        f"&$select=id,subject,from,receivedDateTime"
+        f"&$filter=receivedDateTime ge {since}"
+        f"&$orderby=receivedDateTime desc"
+    )
+    results: list[dict] = []
+    while url:
+        data = backend._get(url)
+        if not data:
+            break
+        for m in data.get("value", []):
+            sender = (
+                m.get("from", {}).get("emailAddress", {}).get("address", "").lower().strip()
+            )
+            advisor = _match_sender(sender, advisor_index)
+            if advisor is None:
+                continue
+            mid = m["id"]
+            if not dry_run and is_processed(conn, mid):
+                log.debug(f"  [SKIP] already processed: {m.get('subject','')[:60]}")
+                continue
+            # Fetch full body
+            body_data = backend._get(
+                f"{GRAPH}/me/messages/{mid}"
+                f"?$select=body,subject,from,receivedDateTime"
+            )
+            if not body_data:
+                log.warning(f"  Failed to fetch body for {mid}")
+                continue
+            body_obj = body_data.get("body", {})
+            raw_body = body_obj.get("content", "")
+            content_type = body_obj.get("contentType", "text").lower()
+            body_text = _strip_html(raw_body) if content_type == "html" else raw_body
+            body_text = body_text[:max_chars]
+            results.append(
+                {
+                    "message_id": mid,
+                    "provider": "hotmail",
+                    "advisor": advisor,
+                    "subject": m.get("subject", ""),
+                    "sender": sender,
+                    "received_at": m.get("receivedDateTime", ""),
+                    "body_text": body_text,
+                }
+            )
+            time.sleep(API_DELAY)
+        url = data.get("@odata.nextLink")
+
+    return results
+
+
+def _gmail_walk_parts(payload: dict) -> str:
+    """Recursively walk Gmail message payload to extract plain/html text."""
+    mime = payload.get("mimeType", "")
+    if mime == "text/plain":
+        import base64
+        data = payload.get("body", {}).get("data", "")
+        if data:
+            return base64.urlsafe_b64decode(data + "==").decode("utf-8", errors="replace")
+    if mime == "text/html":
+        import base64
+        data = payload.get("body", {}).get("data", "")
+        if data:
+            raw = base64.urlsafe_b64decode(data + "==").decode("utf-8", errors="replace")
+            return _strip_html(raw)
+    if "parts" in payload:
+        texts = []
+        for part in payload["parts"]:
+            t = _gmail_walk_parts(part)
+            if t:
+                texts.append(t)
+        return "\n".join(texts)
+    return ""
+
+
+def fetch_newsletters_gmail(
+    conn: sqlite3.Connection,
+    cfg: dict,
+    advisor_index: dict[str, dict],
+    interactive: bool = False,
+    dry_run: bool = False,
+) -> list[dict]:
+    """Fetch full-body newsletter emails from Gmail for known advisor senders."""
+    try:
+        from google.auth.transport.requests import Request as GReq
+        from google.oauth2.credentials import Credentials
+        from google_auth_oauthlib.flow import InstalledAppFlow
+        from googleapiclient.discovery import build
+    except ImportError:
+        log.error("pip install google-auth-oauthlib google-api-python-client")
+        return []
+
+    gmail_pipe_dir = Path.home() / ".email-pipeline"
+    gmail_token = gmail_pipe_dir / "gmail_token.json"
+    gmail_creds_file = gmail_pipe_dir / "gmail_credentials.json"
+    SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+    creds = None
+    if gmail_token.exists():
+        creds = Credentials.from_authorized_user_file(str(gmail_token), SCOPES)
+    if creds and creds.expired and creds.refresh_token:
+        try:
+            creds.refresh(GReq())
+        except Exception:
+            creds = None
+    if not creds or not creds.valid:
+        if not interactive:
+            log.error("Gmail: no valid token. Run --setup")
+            return []
+        if not gmail_creds_file.exists():
+            log.error(f"Download OAuth JSON to {gmail_creds_file}")
+            return []
+        creds = InstalledAppFlow.from_client_secrets_file(
+            str(gmail_creds_file), SCOPES
+        ).run_local_server(port=0)
+    gmail_pipe_dir.mkdir(parents=True, exist_ok=True)
+    gmail_token.write_text(creds.to_json())
+
+    svc = build("gmail", "v1", credentials=creds)
+
+    dedupe_days = cfg["pipeline"].get("dedupe_window_days", 7)
+    max_chars = cfg["pipeline"].get("max_body_chars", 20000)
+    since_date = (datetime.now(UTC) - timedelta(days=dedupe_days)).strftime("%Y/%m/%d")
+
+    results: list[dict] = []
+    page_token = None
+    while True:
+        r = (
+            svc.users()
+            .messages()
+            .list(
+                userId="me",
+                q=f"in:inbox after:{since_date}",
+                maxResults=50,
+                pageToken=page_token,
+            )
+            .execute()
+        )
+        for stub in r.get("messages", []):
+            mid = stub["id"]
+            if not dry_run and is_processed(conn, mid):
+                continue
+            msg = (
+                svc.users()
+                .messages()
+                .get(userId="me", id=mid, format="metadata",
+                     metadataHeaders=["From", "Subject", "Date"])
+                .execute()
+            )
+            time.sleep(API_DELAY)
+            hdrs = {h["name"]: h["value"] for h in msg.get("payload", {}).get("headers", [])}
+            raw_from = hdrs.get("From", "")
+            match = re.search(r"<([^>]+)>", raw_from)
+            sender = (match.group(1) if match else raw_from).lower().strip()
+            advisor = _match_sender(sender, advisor_index)
+            if advisor is None:
+                continue
+            # Fetch full message for body
+            full_msg = svc.users().messages().get(userId="me", id=mid, format="full").execute()
+            time.sleep(API_DELAY)
+            body_text = _gmail_walk_parts(full_msg.get("payload", {}))[:max_chars]
+            results.append(
+                {
+                    "message_id": mid,
+                    "provider": "gmail",
+                    "advisor": advisor,
+                    "subject": hdrs.get("Subject", ""),
+                    "sender": sender,
+                    "received_at": hdrs.get("Date", ""),
+                    "body_text": body_text,
+                }
+            )
+        page_token = r.get("nextPageToken")
+        if not page_token:
+            break
+
+    return results
+
+
+# ── WI-4: T0 parsing + diff ───────────────────────────────────────────────────
+
+
+def parse_newsletter(body_text: str, advisor_config: dict) -> dict:
+    """T0: section-split + action-item extraction.
+
+    Returns:
+        {
+          sections: {header_str: body_str},
+          action_items: [str],
+          word_count: int,
+        }
+    """
+    headers = advisor_config.get("section_headers", [])
+    action_keywords = advisor_config.get("action_item_keywords", [])
+
+    # Build a single regex from section headers for splitting
+    if headers:
+        pattern = r"(?:^|\n)(" + "|".join(re.escape(h) for h in headers) + r")[\s:]*\n"
+        parts = re.split(pattern, body_text, flags=re.IGNORECASE)
+    else:
+        parts = [body_text]
+
+    sections: dict[str, str] = {}
+    if len(parts) > 1:
+        # parts alternates: [pre-text, header1, body1, header2, body2, ...]
+        sections["(intro)"] = parts[0].strip()
+        it = iter(parts[1:])
+        for hdr, body in zip(it, it):
+            sections[hdr.strip()] = body.strip()
+    else:
+        sections["(full)"] = body_text.strip()
+
+    # Extract action-item sentences
+    action_items: list[str] = []
+    if action_keywords:
+        kw_pattern = r"\b(" + "|".join(re.escape(kw) for kw in action_keywords) + r")\b"
+        for line in body_text.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            if re.search(kw_pattern, line, flags=re.IGNORECASE):
+                action_items.append(line)
+
+    word_count = len(body_text.split())
+    return {"sections": sections, "action_items": action_items[:20], "word_count": word_count}
+
+
+def _body_hash(body_text: str) -> str:
+    """SHA-256 of normalized body text."""
+    normalized = re.sub(r"\s+", " ", body_text.strip()).encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()
+
+
+def compute_diff(
+    current_hash: str,
+    current_preview: str,
+    conn: sqlite3.Connection,
+    advisor_name: str,
+) -> str:
+    """T0: compare current newsletter against the most recent prior one.
+
+    Returns DUPLICATE_SENTINEL on matching hash (caller should skip synthesis).
+    Returns "First newsletter from this advisor." on empty history.
+    Otherwise returns a short diff note.
+    """
+    row = conn.execute(
+        "SELECT body_hash, body_preview, received_at FROM processed_newsletters "
+        "WHERE advisor_name=? AND synthesis_posted=1 "
+        "ORDER BY received_at DESC LIMIT 1",
+        (advisor_name,),
+    ).fetchone()
+    if row is None:
+        return "First newsletter from this advisor."
+    prior_hash, prior_preview, prior_date = row
+    if prior_hash == current_hash:
+        return DUPLICATE_SENTINEL
+
+    # Simple structural diff
+    prior_words = len(prior_preview.split())
+    curr_words = len(current_preview.split())
+    delta = curr_words - prior_words
+    sign = "+" if delta >= 0 else ""
+    diff_note = (
+        f"Changed since {prior_date[:10]} — "
+        f"word-count delta: {sign}{delta}. "
+        f"Prior preview: {prior_preview[:200]}"
+    )
+    return diff_note
+
+
+# ── WI-5: T2 synthesis ────────────────────────────────────────────────────────
+
+
+def _build_synthesis_prompt(
+    advisor_name: str,
+    subject: str,
+    received_at: str,
+    body_text: str,
+    parsed: dict,
+    diff_note: str,
+    max_total_chars: int = 6000,
+) -> str:
+    """Assemble the Claude CLI prompt, capped at max_total_chars."""
+    section_text = ""
+    for hdr, content in parsed["sections"].items():
+        section_text += f"\n### {hdr}\n{content[:800]}\n"
+
+    action_text = (
+        "\n".join(f"- {a}" for a in parsed["action_items"])
+        if parsed["action_items"]
+        else "(none detected)"
+    )
+
+    prompt = (
+        f"You are analyzing a financial advisor newsletter for Troy Davis.\n\n"
+        f"Advisor: {advisor_name}\n"
+        f"Subject: {subject}\n"
+        f"Date: {received_at[:10] if received_at else 'unknown'}\n"
+        f"Word count: {parsed['word_count']}\n\n"
+        f"Change vs. prior newsletter: {diff_note}\n\n"
+        f"## Extracted Sections\n{section_text}\n\n"
+        f"## T0-Extracted Action Items\n{action_text}\n\n"
+        f"---\n"
+        f"Please produce a structured analysis in exactly this format:\n\n"
+        f"## What's New\n"
+        f"(2–4 bullets on key topics/themes compared to prior newsletter)\n\n"
+        f"## Action Items\n"
+        f"(3–7 specific actionable recommendations with any stated deadlines. "
+        f"If none, state 'No specific action items identified.')\n\n"
+        f"## Market Views\n"
+        f"(Current market positions or outlooks expressed by the advisor)\n\n"
+        f"## Changed Positions\n"
+        f"(Any positions or views that changed since the prior newsletter; "
+        f"'None detected' if this is the first or diff is unavailable)\n"
+    )
+
+    # Trim to cap
+    if len(prompt) > max_total_chars:
+        prompt = prompt[:max_total_chars] + "\n[truncated]"
+    return prompt
+
+
+def synthesize_newsletter(
+    advisor_name: str,
+    subject: str,
+    received_at: str,
+    body_text: str,
+    parsed: dict,
+    diff_note: str,
+    cfg: dict,
+) -> str | None:
+    """T2: call claude --print for synthesis. Returns text or None on failure."""
+    timeout = cfg["pipeline"].get("synthesis_timeout_sec", 180)
+    prompt = _build_synthesis_prompt(advisor_name, subject, received_at, body_text, parsed, diff_note)
+    try:
+        result = subprocess.run(
+            ["claude", "--print", "-p", prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+        log.warning(f"Claude CLI returned {result.returncode}: {result.stderr[:200]}")
+    except subprocess.TimeoutExpired:
+        log.warning("Claude CLI timed out — posting raw extraction without synthesis")
+    except FileNotFoundError:
+        log.warning("Claude CLI not found — posting raw extraction without synthesis")
+    return None
+
+
+def _raw_extraction_text(parsed: dict, diff_note: str) -> str:
+    """Fallback when synthesis fails: format T0 output as plain text."""
+    lines = ["## Action Items (T0 extracted)"]
+    if parsed["action_items"]:
+        for a in parsed["action_items"]:
+            lines.append(f"- {a}")
+    else:
+        lines.append("(none detected)")
+    lines.append(f"\n## Change Note\n{diff_note}")
+    lines.append(f"\n## Sections\n" + ", ".join(parsed["sections"].keys()))
+    return "\n".join(lines)
+
+
+# ── WI-6: POST capture ────────────────────────────────────────────────────────
+
+
+def post_newsletter_capture(
+    newsletter: dict,
+    parsed: dict,
+    diff_note: str,
+    synthesis: str | None,
+    cfg: dict,
+) -> bool | str:
+    """POST newsletter assessment capture to core-api.
+
+    Returns the capture_id string on success, False on failure.
+    """
+    advisor = newsletter["advisor"]
+    advisor_name = advisor["name"]
+    subject = newsletter["subject"]
+    received_at = newsletter["received_at"]
+    provider = newsletter["provider"]
+
+    body_section = synthesis if synthesis else _raw_extraction_text(parsed, diff_note)
+    date_str = received_at[:10] if received_at else "unknown"
+
+    content = (
+        f"[Newsletter] {advisor_name} — {subject} ({date_str})\n\n"
+        f"{body_section}\n\n"
+        f"---\n"
+        f"Source: {provider} | {parsed['word_count']} words | Changes: {diff_note[:200]}\n"
+        f"Action items extracted: {len(parsed['action_items'])}"
+    )
+
+    source_metadata = {
+        "type": "newsletter_assessment",
+        "advisor_name": advisor_name,
+        "subject": subject,
+        "received_at": received_at,
+        "provider": provider,
+        "word_count": parsed["word_count"],
+        "action_item_count": len(parsed["action_items"]),
+        "has_synthesis": synthesis is not None,
+        "diff_from_prior": diff_note[:200],
+    }
+
+    cap_cfg = cfg["pipeline"].get("capture_api", {})
+    import os
+    url = os.environ.get("CAPTURE_API_URL") or cap_cfg.get(
+        "url", "https://brain.troy-davis.com/api/v1/captures"
+    )
+    caller = os.environ.get("CAPTURE_API_CALLER") or cap_cfg.get(
+        "caller_header", "newsletter-pipeline"
+    )
+    brain_view = advisor.get("brain_view", "personal")
+    capture_type = advisor.get("capture_type", "observation")
+
+    try:
+        resp = requests.post(
+            url,
+            json={
+                "content": content,
+                "source": "api",
+                "capture_type": capture_type,
+                "brain_view": brain_view,
+                "metadata": {"source_metadata": source_metadata},
+            },
+            headers={
+                "Content-Type": "application/json",
+                "X-Open-Brain-Caller": caller,
+            },
+            timeout=30,
+            allow_redirects=False,
+        )
+        if resp.status_code in (200, 201):
+            data = resp.json()
+            capture_id = data.get("id")
+            log.info(f"Capture posted: {advisor_name} / {subject[:60]} → {capture_id}")
+            return capture_id or True
+        elif resp.status_code in (301, 302, 303, 307, 308):
+            loc = resp.headers.get("Location", "")[:120]
+            log.warning(
+                f"Brain POST {resp.status_code} redirect to {loc} — "
+                f"set CAPTURE_API_URL to an internal URL"
+            )
+            return False
+        else:
+            log.warning(f"Brain POST {resp.status_code}: {resp.text[:200]}")
+            return False
+    except requests.exceptions.RequestException as e:
+        log.warning(f"Brain unreachable: {e}")
+        return False
+
+
+# ── Main pipeline orchestrator ────────────────────────────────────────────────
+
+
+def process_newsletters(
+    newsletters: list[dict],
+    conn: sqlite3.Connection,
+    cfg: dict,
+    dry_run: bool = False,
+) -> dict:
+    """Parse, diff, synthesize, and post each newsletter. Returns stats dict."""
+    stats = {"total": len(newsletters), "posted": 0, "skipped_dup": 0, "failed": 0}
+
+    for n in newsletters:
+        advisor = n["advisor"]
+        advisor_name = advisor["name"]
+        body_text = n["body_text"]
+        curr_hash = _body_hash(body_text)
+        curr_preview = body_text[:500]
+
+        diff_note = compute_diff(curr_hash, curr_preview, conn, advisor_name)
+
+        if diff_note == DUPLICATE_SENTINEL:
+            log.info(f"  [DEDUP] {advisor_name} / {n['subject'][:60]} — body unchanged, skipping")
+            # Record as processed so we don't re-check each run
+            record_newsletter(
+                conn,
+                advisor_name,
+                n["message_id"],
+                n["provider"],
+                n["subject"],
+                n["received_at"],
+                curr_hash,
+                curr_preview,
+                synthesis_posted=False,
+            )
+            stats["skipped_dup"] += 1
+            continue
+
+        parsed = parse_newsletter(body_text, advisor)
+
+        if dry_run:
+            log.info(
+                f"  [DRY] {advisor_name} / {n['subject'][:60]} — "
+                f"{parsed['word_count']} words, {len(parsed['action_items'])} action items"
+            )
+            log.info(f"        Diff: {diff_note[:100]}")
+            stats["posted"] += 1
+            continue
+
+        synthesis = synthesize_newsletter(
+            advisor_name,
+            n["subject"],
+            n["received_at"],
+            body_text,
+            parsed,
+            diff_note,
+            cfg,
+        )
+
+        capture_result = post_newsletter_capture(n, parsed, diff_note, synthesis, cfg)
+        if capture_result:
+            capture_id = capture_result if isinstance(capture_result, str) else None
+            record_newsletter(
+                conn,
+                advisor_name,
+                n["message_id"],
+                n["provider"],
+                n["subject"],
+                n["received_at"],
+                curr_hash,
+                curr_preview,
+                synthesis_posted=True,
+                capture_id=capture_id,
+            )
+            stats["posted"] += 1
+        else:
+            # Record as processed (not posted) so it doesn't retry in next run
+            record_newsletter(
+                conn,
+                advisor_name,
+                n["message_id"],
+                n["provider"],
+                n["subject"],
+                n["received_at"],
+                curr_hash,
+                curr_preview,
+                synthesis_posted=False,
+            )
+            stats["failed"] += 1
+            log.warning(f"  [FAIL] POST failed: {advisor_name} / {n['subject'][:60]}")
+
+    return stats
+
+
+def run_pipeline(
+    conn: sqlite3.Connection,
+    cfg: dict,
+    interactive: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """Full pipeline: fetch from all providers, process, report."""
+    advisor_index = _advisor_index(cfg)
+    if not advisor_index:
+        log.info("No advisors configured — nothing to fetch")
+        return
+
+    all_newsletters: list[dict] = []
+
+    # Hotmail
+    try:
+        hm = fetch_newsletters_hotmail(conn, cfg, advisor_index, interactive=interactive, dry_run=dry_run)
+        all_newsletters.extend(hm)
+        log.info(f"Hotmail: {len(hm)} matched newsletters")
+    except Exception as e:
+        log.error(f"Hotmail fetch failed: {e}", exc_info=True)
+
+    # Gmail (optional — skips gracefully if no token)
+    try:
+        gm = fetch_newsletters_gmail(conn, cfg, advisor_index, interactive=interactive, dry_run=dry_run)
+        all_newsletters.extend(gm)
+        log.info(f"Gmail: {len(gm)} matched newsletters")
+    except Exception as e:
+        log.error(f"Gmail fetch failed: {e}", exc_info=True)
+
+    if not all_newsletters:
+        log.info("No new newsletters found")
+        return
+
+    log.info(f"Processing {len(all_newsletters)} newsletter(s)...")
+    stats = process_newsletters(all_newsletters, conn, cfg, dry_run=dry_run)
+    log.info(
+        f"Done — total={stats['total']}, posted={stats['posted']}, "
+        f"dedup={stats['skipped_dup']}, failed={stats['failed']}"
+    )
+
+
+# ── WI-8: CLI ─────────────────────────────────────────────────────────────────
+
+
+def cmd_status(conn: sqlite3.Connection) -> None:
+    """Print pipeline statistics."""
+    print("\n=== Newsletter Pipeline Status ===\n")
+    total = conn.execute("SELECT COUNT(*) FROM processed_newsletters").fetchone()[0]
+    print(f"Total processed:  {total}")
+    posted = conn.execute(
+        "SELECT COUNT(*) FROM processed_newsletters WHERE synthesis_posted=1"
+    ).fetchone()[0]
+    print(f"  Posted to brain: {posted}")
+    dedup = conn.execute(
+        "SELECT COUNT(*) FROM processed_newsletters WHERE synthesis_posted=0"
+    ).fetchone()[0]
+    print(f"  Not posted (dedup/failed): {dedup}")
+
+    print("\nBy advisor:")
+    for name, cnt, last in conn.execute(
+        "SELECT advisor_name, COUNT(*), MAX(received_at) FROM processed_newsletters "
+        "GROUP BY advisor_name ORDER BY MAX(received_at) DESC"
+    ).fetchall():
+        print(f"  {name}: {cnt} newsletters, last: {last or 'n/a'}")
+
+    print()
+
+
+def cmd_reprocess(conn: sqlite3.Connection, cfg: dict, n: int) -> None:
+    """Mark last N newsletters as not-posted and re-run synthesis + post."""
+    rows = conn.execute(
+        "SELECT message_id, advisor_name, provider, subject, received_at, body_hash, body_preview "
+        "FROM processed_newsletters ORDER BY processed_at DESC LIMIT ?",
+        (n,),
+    ).fetchall()
+    if not rows:
+        log.info("No newsletters to reprocess")
+        return
+    advisor_index = _advisor_index(cfg)
+    log.info(f"Reprocessing {len(rows)} newsletter(s)...")
+    for (mid, aname, prov, subj, recv, bhash, bprev) in rows:
+        conn.execute(
+            "UPDATE processed_newsletters SET synthesis_posted=0 WHERE message_id=?", (mid,)
+        )
+    conn.commit()
+    # Re-fetch body text would require API calls; instead rebuild from preview + stored data
+    # For reprocess we use a simplified note
+    for (mid, aname, prov, subj, recv, bhash, bprev) in rows:
+        adv_cfg = next(
+            (a for a in cfg.get("advisors", []) if a["name"] == aname),
+            {"name": aname, "brain_view": "personal", "capture_type": "observation",
+             "action_item_keywords": [], "section_headers": []},
+        )
+        parsed = parse_newsletter(bprev or "", adv_cfg)
+        diff_note = f"[Reprocessed] {recv[:10] if recv else 'unknown'}"
+        synthesis = synthesize_newsletter(aname, subj, recv or "", bprev or "", parsed, diff_note, cfg)
+        newsletter = {
+            "message_id": mid,
+            "advisor": adv_cfg,
+            "subject": subj or "",
+            "sender": "",
+            "received_at": recv or "",
+            "body_text": bprev or "",
+            "provider": prov,
+        }
+        result = post_newsletter_capture(newsletter, parsed, diff_note, synthesis, cfg)
+        if result:
+            capture_id = result if isinstance(result, str) else None
+            mark_posted(conn, mid, capture_id)
+            log.info(f"  Reprocessed: {aname} / {subj[:60]}")
+        else:
+            log.warning(f"  Reprocess POST failed: {aname} / {subj[:60]}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Newsletter Assessment Pipeline — P21")
+    group = ap.add_mutually_exclusive_group()
+    group.add_argument("--run", action="store_true", help="Fetch + parse + synthesize + post")
+    group.add_argument("--setup", action="store_true", help="Interactive auth setup")
+    group.add_argument("--fetch-only", action="store_true", help="Dry-run: print matches, no post")
+    group.add_argument("--status", action="store_true", help="Show DB stats")
+    group.add_argument("--reprocess", type=int, metavar="N", help="Re-synthesize last N newsletters")
+    args = ap.parse_args()
+
+    # Default to --run if no mode specified
+    if not any([args.run, args.setup, args.fetch_only, args.status, args.reprocess]):
+        args.run = True
+
+    conn = init_db()
+    cfg = load_config()
+
+    try:
+        if args.status:
+            cmd_status(conn)
+        elif args.setup:
+            run_pipeline(conn, cfg, interactive=True, dry_run=True)
+        elif args.fetch_only:
+            run_pipeline(conn, cfg, interactive=False, dry_run=True)
+        elif args.reprocess is not None:
+            cmd_reprocess(conn, cfg, args.reprocess)
+        else:  # --run
+            run_pipeline(conn, cfg, interactive=False, dry_run=False)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_newsletter_pipeline.py
+++ b/scripts/tests/test_newsletter_pipeline.py
@@ -1,0 +1,286 @@
+"""
+Tests for newsletter-pipeline.py — P21.
+
+All tests are mocked at the API boundary:
+  - No live Graph API calls
+  - No live core-api calls
+  - No live Claude CLI invocations
+
+Run: pytest scripts/tests/test_newsletter_pipeline.py -v
+"""
+
+import importlib.util
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Load the module under test ────────────────────────────────────────────────
+# newsletter-pipeline.py lives one level up from this test file.
+_MODULE_PATH = Path(__file__).resolve().parent.parent / "newsletter-pipeline.py"
+_spec = importlib.util.spec_from_file_location("newsletter_pipeline", _MODULE_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+init_db = _mod.init_db
+parse_newsletter = _mod.parse_newsletter
+compute_diff = _mod.compute_diff
+record_newsletter = _mod.record_newsletter
+DUPLICATE_SENTINEL = _mod.DUPLICATE_SENTINEL
+_body_hash = _mod._body_hash
+synthesize_newsletter = _mod.synthesize_newsletter
+post_newsletter_capture = _mod.post_newsletter_capture
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mem_db():
+    """In-memory SQLite with the newsletter pipeline schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        CREATE TABLE processed_newsletters (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            advisor_name TEXT NOT NULL,
+            message_id TEXT NOT NULL UNIQUE,
+            provider TEXT NOT NULL,
+            subject TEXT,
+            received_at TEXT,
+            body_hash TEXT,
+            body_preview TEXT,
+            synthesis_posted INTEGER DEFAULT 0,
+            capture_id TEXT,
+            processed_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE INDEX idx_pn_advisor ON processed_newsletters(advisor_name, received_at);
+        CREATE INDEX idx_pn_msg ON processed_newsletters(message_id);
+    """)
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def sample_advisor_cfg():
+    return {
+        "name": "Test Advisor",
+        "sender_match": "newsletter@test-advisor.com",
+        "match_type": "exact",
+        "brain_view": "personal",
+        "capture_type": "observation",
+        "action_item_keywords": ["recommend", "action", "consider", "target"],
+        "section_headers": ["Market Commentary", "Key Takeaways"],
+    }
+
+
+@pytest.fixture
+def sample_pipeline_cfg(tmp_path):
+    return {
+        "pipeline": {
+            "dedupe_window_days": 7,
+            "max_body_chars": 20000,
+            "synthesis_timeout_sec": 180,
+            "capture_api": {
+                "url": "http://localhost:3002/api/v1/captures",
+                "caller_header": "newsletter-pipeline",
+            },
+        },
+        "advisors": [],
+    }
+
+
+# ── Test WI-2: DB init idempotency ────────────────────────────────────────────
+
+
+def test_init_db_idempotent(tmp_path, monkeypatch):
+    """init_db() can be called multiple times without error or data loss."""
+    monkeypatch.setattr(_mod, "DB_PATH", tmp_path / "test.db")
+    monkeypatch.setattr(_mod, "PIPE_DIR", tmp_path)
+
+    conn1 = init_db()
+    conn1.execute(
+        "INSERT INTO processed_newsletters (advisor_name, message_id, provider) VALUES (?,?,?)",
+        ("TestAdvisor", "msg-001", "hotmail"),
+    )
+    conn1.commit()
+    conn1.close()
+
+    # Second call must not drop tables
+    conn2 = init_db()
+    row = conn2.execute(
+        "SELECT advisor_name FROM processed_newsletters WHERE message_id=?", ("msg-001",)
+    ).fetchone()
+    conn2.close()
+    assert row is not None
+    assert row[0] == "TestAdvisor"
+
+
+# ── Test WI-4: parse_newsletter action item extraction ─────────────────────────
+
+
+def test_parse_newsletter_extracts_action_items(sample_advisor_cfg):
+    """parse_newsletter() finds lines containing action_item_keywords."""
+    body = (
+        "General market intro.\n\n"
+        "Market Commentary\n"
+        "Equities showed mixed performance.\n"
+        "We recommend increasing allocation to bonds by 5%.\n"
+        "Consider rebalancing your portfolio before year-end.\n\n"
+        "Key Takeaways\n"
+        "Target price for tech stocks revised upward.\n"
+        "No action needed on fixed income.\n"
+    )
+    result = parse_newsletter(body, sample_advisor_cfg)
+    assert len(result["action_items"]) >= 3
+    # Should find lines with 'recommend', 'consider', 'target'
+    item_text = " ".join(result["action_items"]).lower()
+    assert "recommend" in item_text or "consider" in item_text or "target" in item_text
+
+
+# ── Test WI-4: compute_diff dedup on matching hash ─────────────────────────────
+
+
+def test_compute_diff_dedup_on_matching_hash(mem_db, sample_advisor_cfg):
+    """compute_diff() returns DUPLICATE_SENTINEL when body hash matches prior posted row."""
+    body = "Identical newsletter body text."
+    h = _body_hash(body)
+    preview = body[:500]
+    # Insert a prior POSTED row with same hash
+    mem_db.execute(
+        "INSERT INTO processed_newsletters "
+        "(advisor_name, message_id, provider, body_hash, body_preview, synthesis_posted, received_at) "
+        "VALUES (?,?,?,?,?,1,'2026-04-01T08:00:00Z')",
+        ("Test Advisor", "prior-msg-001", "hotmail", h, preview),
+    )
+    mem_db.commit()
+
+    result = compute_diff(h, preview, mem_db, "Test Advisor")
+    assert result == DUPLICATE_SENTINEL
+
+
+# ── Test WI-4: compute_diff first newsletter ──────────────────────────────────
+
+
+def test_compute_diff_first_newsletter(mem_db):
+    """compute_diff() returns 'First newsletter' when DB is empty for advisor."""
+    h = _body_hash("Some newsletter body")
+    result = compute_diff(h, "Some newsletter body"[:500], mem_db, "New Advisor")
+    assert "first" in result.lower()
+
+
+# ── Test WI-4: compute_diff changed body ─────────────────────────────────────
+
+
+def test_compute_diff_changed_body(mem_db):
+    """compute_diff() returns a diff note (not sentinel) when hash differs."""
+    prior_body = "Prior newsletter content."
+    prior_hash = _body_hash(prior_body)
+    mem_db.execute(
+        "INSERT INTO processed_newsletters "
+        "(advisor_name, message_id, provider, body_hash, body_preview, synthesis_posted, received_at) "
+        "VALUES (?,?,?,?,?,1,'2026-04-01T08:00:00Z')",
+        ("My Advisor", "old-msg-001", "hotmail", prior_hash, prior_body[:500]),
+    )
+    mem_db.commit()
+
+    new_body = "Completely different newsletter content with new market views."
+    new_hash = _body_hash(new_body)
+    result = compute_diff(new_hash, new_body[:500], mem_db, "My Advisor")
+    assert result != DUPLICATE_SENTINEL
+    assert len(result) > 0
+
+
+# ── Test WI-5: synthesis fallback on FileNotFoundError ───────────────────────
+
+
+def test_synthesis_fallback_on_cli_not_found(sample_advisor_cfg, sample_pipeline_cfg):
+    """synthesize_newsletter() returns None when claude CLI is not found."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("claude not found")):
+        result = synthesize_newsletter(
+            "Test Advisor",
+            "Q1 2026 Newsletter",
+            "2026-04-01T08:00:00Z",
+            "Some body text",
+            {"sections": {"(full)": "Some body text"}, "action_items": [], "word_count": 5},
+            "First newsletter from this advisor.",
+            sample_pipeline_cfg,
+        )
+    assert result is None
+
+
+# ── Test WI-6: post_capture called on new newsletter ─────────────────────────
+
+
+def test_post_capture_called_on_new_newsletter(
+    mem_db, sample_advisor_cfg, sample_pipeline_cfg
+):
+    """process_newsletters() calls post_newsletter_capture for a new (non-dedup) newsletter."""
+    newsletter = {
+        "message_id": "new-msg-001",
+        "provider": "hotmail",
+        "advisor": sample_advisor_cfg,
+        "subject": "April Newsletter",
+        "sender": "newsletter@test-advisor.com",
+        "received_at": "2026-04-01T08:00:00Z",
+        "body_text": "New unique content " * 20,
+    }
+
+    posted_calls = []
+
+    def fake_post(n, parsed, diff_note, synthesis, cfg):
+        posted_calls.append(n["message_id"])
+        return "capture-uuid-001"
+
+    with patch.object(_mod, "synthesize_newsletter", return_value="## Synthesis"), \
+         patch.object(_mod, "post_newsletter_capture", side_effect=fake_post):
+        _mod.process_newsletters([newsletter], mem_db, sample_pipeline_cfg, dry_run=False)
+
+    assert len(posted_calls) == 1
+    assert posted_calls[0] == "new-msg-001"
+
+
+# ── Test WI-6: post_capture skipped on dedup ─────────────────────────────────
+
+
+def test_post_capture_skipped_on_dedup(
+    mem_db, sample_advisor_cfg, sample_pipeline_cfg
+):
+    """process_newsletters() skips POST when body hash matches a prior posted row."""
+    body = "Same newsletter content that was already processed."
+    h = _body_hash(body)
+    # Insert prior POSTED row
+    mem_db.execute(
+        "INSERT INTO processed_newsletters "
+        "(advisor_name, message_id, provider, body_hash, body_preview, synthesis_posted, received_at) "
+        "VALUES (?,?,?,?,?,1,'2026-04-01T08:00:00Z')",
+        ("Test Advisor", "prior-dedup-msg", "hotmail", h, body[:500]),
+    )
+    mem_db.commit()
+
+    newsletter = {
+        "message_id": "duplicate-msg-001",
+        "provider": "hotmail",
+        "advisor": sample_advisor_cfg,
+        "subject": "April Newsletter",
+        "sender": "newsletter@test-advisor.com",
+        "received_at": "2026-04-08T08:00:00Z",
+        "body_text": body,
+    }
+
+    post_calls = []
+
+    def fake_post(n, parsed, diff_note, synthesis, cfg):
+        post_calls.append(n["message_id"])
+        return "some-capture-id"
+
+    with patch.object(_mod, "post_newsletter_capture", side_effect=fake_post):
+        stats = _mod.process_newsletters(
+            [newsletter], mem_db, sample_pipeline_cfg, dry_run=False
+        )
+
+    assert len(post_calls) == 0
+    assert stats["skipped_dup"] == 1


### PR DESCRIPTION
## Summary
- `scripts/newsletter-pipeline.py` — 937 lines: MSAL auth reuse, HTML strip, section-split, action-item extraction (T0), Claude CLI synthesis (T2), capture POST
- `config/financial/newsletter-advisors.yaml` — advisor config skeleton
- `newsletter-pipeline` added to `BYPASS_CALLERS` (17th entry, lockstep rule)
- SHA-256 dedup: skips synthesis when content unchanged
- 8 pytest tests

## Cost tier: T0 parsing + T2 Claude CLI synthesis (zero API cost)

## Test plan
- [x] 8/8 pytest tests pass
- [x] rate-limit.ts 1-line edit only
- [x] Cron slot 08:00 verified

Refs PHASED_PLAN.md § P21; closes #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)