### PR TITLE
feat(P29): pyright coverage for email scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ include = [
   #   redis.asyncio stub gaps (session.py) + Anthropic SDK content-block union
   #   narrowing (capture_extractor.py) + optional pipecat imports. Separate PR.
   "packages/file-ingestion/src",
+  # P29: email scripts cluster — typed and included
+  "scripts/email-pipeline.py",
+  "scripts/email-cleanup.py",
+  "scripts/email-cleanup-pass2.py",
+  "scripts/email-cleanup-pass4.py",
+  "scripts/email-cleanup-pass6.py",
+  "scripts/email-archive-by-year.py",
 ]
 exclude = ["scripts", "**/tests", "**/__pycache__"]
 pythonVersion = "3.12"

--- a/scripts/email-archive-by-year.py
+++ b/scripts/email-archive-by-year.py
@@ -5,14 +5,17 @@ Scans inbox, groups by receivedDateTime year, batch-moves to Archive subfolders.
 Keeps current year (2026) emails in inbox.
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
-import msal
+import msal  # type: ignore[import-untyped]
 import requests
 
-sys.stdout.reconfigure(line_buffering=True, encoding="utf-8", errors="replace")
+sys.stdout.reconfigure(line_buffering=True, encoding="utf-8", errors="replace")  # type: ignore[union-attr]
 
 CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
 SCOPES = ["Mail.ReadWrite", "User.Read"]
@@ -30,19 +33,16 @@ app = msal.PublicClientApplication(
     CLIENT_ID, authority="https://login.microsoftonline.com/common", token_cache=cache
 )
 
+session = requests.Session()
+session.headers.update({"Content-Type": "application/json"})
 
-def get_token():
-    result = app.acquire_token_silent(SCOPES, account=app.get_accounts()[0])
+
+def get_token() -> str:
+    result: dict[str, Any] = app.acquire_token_silent(SCOPES, account=app.get_accounts()[0])
     return result["access_token"]
 
 
-session = requests.Session()
-session.headers.update(
-    {"Authorization": f"Bearer {get_token()}", "Content-Type": "application/json"}
-)
-
-
-def api_get(url, params=None):
+def api_get(url: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     for attempt in range(5):
         try:
             resp = session.get(url, params=params, timeout=30)
@@ -57,9 +57,10 @@ def api_get(url, params=None):
             continue
         resp.raise_for_status()
         return resp.json()
+    raise RuntimeError("Failed after 5 retries")
 
 
-def api_post(url, json_data):
+def api_post(url: str, json_data: dict[str, Any]) -> dict[str, Any]:
     for attempt in range(5):
         try:
             resp = session.post(url, json=json_data, timeout=60)
@@ -74,136 +75,146 @@ def api_post(url, json_data):
             continue
         resp.raise_for_status()
         return resp.json()
+    raise RuntimeError("Failed after 5 retries")
 
 
-print(f"{'='*60}", flush=True)
-print("  ARCHIVE BY YEAR — Move inbox emails to Archive/YYYY", flush=True)
-print(f"  Keep in inbox: {KEEP_IN_INBOX_YEAR} and newer", flush=True)
-print(f"{'='*60}\n", flush=True)
+def main() -> None:
+    session.headers["Authorization"] = f"Bearer {get_token()}"
 
-# Step 1: Find Archive folder and year subfolders
-print("[1/3] Finding Archive year folders...", flush=True)
-folders = api_get(f"{GRAPH_BASE}/me/mailFolders", params={"$top": 50, "$select": "id,displayName"})
-archive_id = None
-for f in folders.get("value", []):
-    if f["displayName"] == "Archive":
-        archive_id = f["id"]
-        break
+    print(f"{'='*60}", flush=True)
+    print("  ARCHIVE BY YEAR — Move inbox emails to Archive/YYYY", flush=True)
+    print(f"  Keep in inbox: {KEEP_IN_INBOX_YEAR} and newer", flush=True)
+    print(f"{'='*60}\n", flush=True)
 
-if not archive_id:
-    print("  ERROR: Archive folder not found!", flush=True)
-    sys.exit(1)
+    # Step 1: Find Archive folder and year subfolders
+    print("[1/3] Finding Archive year folders...", flush=True)
+    folders = api_get(
+        f"{GRAPH_BASE}/me/mailFolders", params={"$top": 50, "$select": "id,displayName"}
+    )
+    archive_id: str | None = None
+    for f in folders.get("value", []):
+        if f["displayName"] == "Archive":
+            archive_id = f["id"]
+            break
 
-# Get year subfolders
-year_folders = {}
-children = api_get(
-    f"{GRAPH_BASE}/me/mailFolders/{archive_id}/childFolders",
-    params={"$top": 50, "$select": "id,displayName"},
-)
-for cf in children.get("value", []):
-    name = cf["displayName"]
-    if name.isdigit() and len(name) == 4:
-        year_folders[int(name)] = cf["id"]
+    if not archive_id:
+        print("  ERROR: Archive folder not found!", flush=True)
+        sys.exit(1)
 
-print(f"  Found year folders: {sorted(year_folders.keys())}", flush=True)
+    # Get year subfolders
+    year_folders: dict[int, str] = {}
+    children = api_get(
+        f"{GRAPH_BASE}/me/mailFolders/{archive_id}/childFolders",
+        params={"$top": 50, "$select": "id,displayName"},
+    )
+    for cf in children.get("value", []):
+        name: str = cf["displayName"]
+        if name.isdigit() and len(name) == 4:
+            year_folders[int(name)] = cf["id"]
 
-# Step 2: Scan inbox, group by year
-print("\n[2/3] Scanning inbox...", flush=True)
-url = f"{GRAPH_BASE}/me/mailFolders/inbox/messages"
-params = {"$top": PAGE_SIZE, "$select": "id,receivedDateTime"}
-by_year = {}
-keep_count = 0
-total = 0
+    print(f"  Found year folders: {sorted(year_folders.keys())}", flush=True)
 
-while url:
-    data = api_get(url, params if total == 0 else None)
-    for msg in data.get("value", []):
-        total += 1
-        date_str = msg.get("receivedDateTime", "")
-        year = int(date_str[:4]) if date_str else 0
+    # Step 2: Scan inbox, group by year
+    print("\n[2/3] Scanning inbox...", flush=True)
+    url: str | None = f"{GRAPH_BASE}/me/mailFolders/inbox/messages"
+    params: dict[str, Any] = {"$top": PAGE_SIZE, "$select": "id,receivedDateTime"}
+    by_year: dict[int, list[str]] = {}
+    keep_count = 0
+    total = 0
 
-        if year >= KEEP_IN_INBOX_YEAR:
-            keep_count += 1
-            continue
+    while url:
+        data = api_get(url, params if total == 0 else None)
+        for msg in data.get("value", []):
+            total += 1
+            date_str: str = msg.get("receivedDateTime", "")
+            year = int(date_str[:4]) if date_str else 0
 
-        if year not in year_folders:
-            # Create the folder if it doesn't exist
-            print(f"  Creating Archive/{year}...", flush=True)
-            resp = session.post(
-                f"{GRAPH_BASE}/me/mailFolders/{archive_id}/childFolders",
-                json={"displayName": str(year)},
-                timeout=30,
-            )
-            if resp.status_code == 201:
-                year_folders[year] = resp.json()["id"]
-            else:
-                print(f"  Error creating {year}: {resp.status_code}", flush=True)
+            if year >= KEEP_IN_INBOX_YEAR:
                 keep_count += 1
                 continue
 
-        by_year.setdefault(year, []).append(msg["id"])
-
-    url = data.get("@odata.nextLink")
-    if total % 5000 == 0:
-        print(f"  {total:,} scanned...", flush=True)
-
-print(f"\n  Scan complete: {total:,} total", flush=True)
-print(f"  Keep in inbox ({KEEP_IN_INBOX_YEAR}+): {keep_count:,}", flush=True)
-print("  Move to archive:", flush=True)
-for year in sorted(by_year.keys()):
-    print(f"    {year}: {len(by_year[year]):,} emails", flush=True)
-
-move_total = sum(len(ids) for ids in by_year.values())
-print(f"  Total to move: {move_total:,}", flush=True)
-
-# Step 3: Batch move by year
-print(f"\n[3/3] Moving {move_total:,} emails to Archive year folders...", flush=True)
-moved = 0
-errors = 0
-batch_url = f"{GRAPH_BASE}/$batch"
-
-for year in sorted(by_year.keys()):
-    ids = by_year[year]
-    dest_id = year_folders.get(year)
-    if not dest_id:
-        print(f"  Skipping {year} — no folder", flush=True)
-        continue
-
-    print(f"  {year}: moving {len(ids):,} emails...", flush=True)
-
-    for i in range(0, len(ids), BATCH_SIZE):
-        chunk = ids[i : i + BATCH_SIZE]
-        reqs = [
-            {
-                "id": str(j),
-                "method": "POST",
-                "url": f"/me/messages/{mid}/move",
-                "headers": {"Content-Type": "application/json"},
-                "body": {"destinationId": dest_id},
-            }
-            for j, mid in enumerate(chunk)
-        ]
-
-        try:
-            result = api_post(batch_url, {"requests": reqs})
-            for r in result.get("responses", []):
-                if r.get("status") in (200, 201):
-                    moved += 1
+            if year not in year_folders:
+                # Create the folder if it doesn't exist
+                print(f"  Creating Archive/{year}...", flush=True)
+                resp = session.post(
+                    f"{GRAPH_BASE}/me/mailFolders/{archive_id}/childFolders",
+                    json={"displayName": str(year)},
+                    timeout=30,
+                )
+                if resp.status_code == 201:
+                    year_folders[year] = resp.json()["id"]
                 else:
-                    errors += 1
-        except Exception:
-            errors += len(chunk)
+                    print(f"  Error creating {year}: {resp.status_code}", flush=True)
+                    keep_count += 1
+                    continue
 
-        if (i // BATCH_SIZE) % 25 == 0 and i > 0:
-            print(f"    {year}: {min(i + BATCH_SIZE, len(ids)):,}/{len(ids):,}", flush=True)
-        if (i // BATCH_SIZE) % 10 == 9:
-            time.sleep(0.5)
+            by_year.setdefault(year, []).append(msg["id"])
 
-    print(f"    {year}: done", flush=True)
+        url = data.get("@odata.nextLink")
+        if total % 5000 == 0:
+            print(f"  {total:,} scanned...", flush=True)
 
-print(f"\n{'='*60}", flush=True)
-print("  ARCHIVE COMPLETE", flush=True)
-print(f"  Moved: {moved:,}", flush=True)
-print(f"  Errors: {errors:,}", flush=True)
-print(f"  Kept in inbox: {keep_count:,} ({KEEP_IN_INBOX_YEAR}+)", flush=True)
-print(f"{'='*60}", flush=True)
+    print(f"\n  Scan complete: {total:,} total", flush=True)
+    print(f"  Keep in inbox ({KEEP_IN_INBOX_YEAR}+): {keep_count:,}", flush=True)
+    print("  Move to archive:", flush=True)
+    for year in sorted(by_year.keys()):
+        print(f"    {year}: {len(by_year[year]):,} emails", flush=True)
+
+    move_total = sum(len(ids) for ids in by_year.values())
+    print(f"  Total to move: {move_total:,}", flush=True)
+
+    # Step 3: Batch move by year
+    print(f"\n[3/3] Moving {move_total:,} emails to Archive year folders...", flush=True)
+    moved = 0
+    errors = 0
+    batch_url = f"{GRAPH_BASE}/$batch"
+
+    for year in sorted(by_year.keys()):
+        ids = by_year[year]
+        dest_id: str | None = year_folders.get(year)
+        if not dest_id:
+            print(f"  Skipping {year} — no folder", flush=True)
+            continue
+
+        print(f"  {year}: moving {len(ids):,} emails...", flush=True)
+
+        for i in range(0, len(ids), BATCH_SIZE):
+            chunk = ids[i : i + BATCH_SIZE]
+            reqs: list[dict[str, Any]] = [
+                {
+                    "id": str(j),
+                    "method": "POST",
+                    "url": f"/me/messages/{mid}/move",
+                    "headers": {"Content-Type": "application/json"},
+                    "body": {"destinationId": dest_id},
+                }
+                for j, mid in enumerate(chunk)
+            ]
+
+            try:
+                result = api_post(batch_url, {"requests": reqs})
+                for r in result.get("responses", []):
+                    if r.get("status") in (200, 201):
+                        moved += 1
+                    else:
+                        errors += 1
+            except Exception:
+                errors += len(chunk)
+
+            if (i // BATCH_SIZE) % 25 == 0 and i > 0:
+                print(f"    {year}: {min(i + BATCH_SIZE, len(ids)):,}/{len(ids):,}", flush=True)
+            if (i // BATCH_SIZE) % 10 == 9:
+                time.sleep(0.5)
+
+        print(f"    {year}: done", flush=True)
+
+    print(f"\n{'='*60}", flush=True)
+    print("  ARCHIVE COMPLETE", flush=True)
+    print(f"  Moved: {moved:,}", flush=True)
+    print(f"  Errors: {errors:,}", flush=True)
+    print(f"  Kept in inbox: {keep_count:,} ({KEEP_IN_INBOX_YEAR}+)", flush=True)
+    print(f"{'='*60}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/email-cleanup-pass2.py
+++ b/scripts/email-cleanup-pass2.py
@@ -6,6 +6,8 @@ Email Cleanup Pass 2+3 — Direct Graph API
 - Delete Sent Items older than 2025-01-01
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -15,12 +17,13 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
-import msal
+import msal  # type: ignore[import-untyped]
 import requests
 
-sys.stdout.reconfigure(line_buffering=True)
-sys.stderr.reconfigure(line_buffering=True)
+sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+sys.stderr.reconfigure(line_buffering=True)  # type: ignore[union-attr]
 
 CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
 TENANT_ID = "common"
@@ -28,27 +31,27 @@ SCOPES = ["Mail.ReadWrite", "User.Read"]
 TOKEN_CACHE_FILE = Path.home() / ".email-analyzer" / "ms_token_cache.json"
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
-PROTECTED_SENDERS = {"ash.davis@hotmail.com"}
+PROTECTED_SENDERS: set[str] = {"ash.davis@hotmail.com"}
 BATCH_SIZE = 20
 MAX_CONCURRENT = 4
 PAGE_SIZE = 999
 
 # Categories to delete ALL emails (no retention)
-DELETE_ALL_CATEGORIES = {
+DELETE_ALL_CATEGORIES: set[str] = {
     "Amateur Radio",
     "News & Commentary",
     "Jobs & Career",
 }
 
 # Shopping: keep last 30 days only
-SHOPPING_CATEGORIES = {
+SHOPPING_CATEGORIES: set[str] = {
     "Shopping & E-commerce",
     "Shipping & E-commerce",
     "Shipping & Transportation",
 }
 
 # Notification senders: delete ALL
-NOTIFICATION_SENDERS = {
+NOTIFICATION_SENDERS: set[str] = {
     "notifications@github.com",
     "troydavis.homeserver@gmail.com",
     "friendupdates@facebookmail.com",
@@ -60,7 +63,7 @@ session = requests.Session()
 session.headers["Content-Type"] = "application/json"
 
 
-def authenticate():
+def authenticate() -> str:
     print(f"  Token cache: {TOKEN_CACHE_FILE}", flush=True)
     cache = msal.SerializableTokenCache()
     if TOKEN_CACHE_FILE.exists():
@@ -75,7 +78,7 @@ def authenticate():
 
     accounts = app.get_accounts()
     if accounts:
-        result = app.acquire_token_silent(SCOPES, account=accounts[0])
+        result: dict[str, Any] = app.acquire_token_silent(SCOPES, account=accounts[0])
         if result and "access_token" in result:
             print(f"  Authenticated as {accounts[0]['username']} (cached)", flush=True)
             if cache.has_state_changed:
@@ -85,7 +88,7 @@ def authenticate():
     print("\n" + "=" * 60)
     print("MICROSOFT AUTHENTICATION REQUIRED")
     print("=" * 60)
-    flow = app.initiate_device_flow(scopes=SCOPES)
+    flow: dict[str, Any] = app.initiate_device_flow(scopes=SCOPES)
     if "user_code" not in flow:
         raise RuntimeError(f"Failed: {flow.get('error_description')}")
     print(flow["message"])
@@ -97,7 +100,11 @@ def authenticate():
     raise RuntimeError(f"Auth failed: {result.get('error_description')}")
 
 
-def api_get(url, params=None, retries=5):
+def api_get(
+    url: str,
+    params: dict[str, Any] | None = None,
+    retries: int = 5,
+) -> dict[str, Any]:
     for attempt in range(retries):
         try:
             resp = session.get(url, params=params, timeout=30)
@@ -120,7 +127,11 @@ def api_get(url, params=None, retries=5):
     raise RuntimeError(f"Failed after {retries} retries: {url}")
 
 
-def api_post(url, json_data, retries=5):
+def api_post(
+    url: str,
+    json_data: dict[str, Any],
+    retries: int = 5,
+) -> dict[str, Any]:
     for attempt in range(retries):
         try:
             resp = session.post(url, json=json_data, timeout=60)
@@ -143,13 +154,16 @@ def api_post(url, json_data, retries=5):
     raise RuntimeError(f"Failed after {retries} retries: {url}")
 
 
-def collect_message_ids(folder, odata_filter=None):
-    url = f"{GRAPH_BASE}/me/mailFolders/{folder}/messages"
-    params = {"$top": PAGE_SIZE, "$select": "id"}
+def collect_message_ids(
+    folder: str,
+    odata_filter: str | None = None,
+) -> list[str]:
+    url: str | None = f"{GRAPH_BASE}/me/mailFolders/{folder}/messages"
+    params: dict[str, Any] = {"$top": PAGE_SIZE, "$select": "id"}
     if odata_filter:
         params["$filter"] = odata_filter
 
-    ids = []
+    ids: list[str] = []
     page = 0
     while url:
         data = api_get(url, params if page == 0 else None)
@@ -159,7 +173,11 @@ def collect_message_ids(folder, odata_filter=None):
     return ids
 
 
-def collect_ids_for_sender(sender, folder="inbox", date_filter=None):
+def collect_ids_for_sender(
+    sender: str,
+    folder: str = "inbox",
+    date_filter: str | None = None,
+) -> list[str]:
     odata_filter = f"from/emailAddress/address eq '{sender}'"
     if date_filter:
         odata_filter += f" and receivedDateTime lt {date_filter}"
@@ -170,7 +188,11 @@ def collect_ids_for_sender(sender, folder="inbox", date_filter=None):
         return []
 
 
-def batch_delete(message_ids, label="", dry_run=False):
+def batch_delete(
+    message_ids: list[str],
+    label: str = "",
+    dry_run: bool = False,
+) -> int:
     if not message_ids:
         return 0
 
@@ -183,7 +205,7 @@ def batch_delete(message_ids, label="", dry_run=False):
         if dry_run:
             deleted += len(chunk)
         else:
-            requests_payload = [
+            requests_payload: list[dict[str, Any]] = [
                 {"id": str(j), "method": "DELETE", "url": f"/me/messages/{mid}"}
                 for j, mid in enumerate(chunk)
             ]
@@ -205,26 +227,28 @@ def batch_delete(message_ids, label="", dry_run=False):
     return deleted
 
 
-def load_senders_by_category():
+def load_senders_by_category() -> dict[str, set[str]]:
     corpus_path = os.path.expanduser("~/data/outputs/email_corpus.json")
     clf_path = os.path.expanduser("~/data/outputs/classify_report_batch.json")
 
     with open(corpus_path, encoding="utf-8") as f:
-        corpus = json.load(f)
+        corpus: dict[str, Any] = json.load(f)
     with open(clf_path, encoding="utf-8") as f:
-        clf_data = json.load(f)
+        clf_data: dict[str, Any] = json.load(f)
 
-    email_info = {}
+    email_info: dict[str, str] = {}
     for email in corpus["emails"]:
         email_info[email["id"]] = email["sender_email"]
 
-    sender_cats = defaultdict(lambda: defaultdict(int))
+    sender_cats: defaultdict[str, defaultdict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
     for email_id, info in clf_data["categorized_emails"].items():
-        sender = email_info.get(email_id, "")
+        sender: str = email_info.get(email_id, "")
         if sender:
             sender_cats[sender][info["category"]] += 1
 
-    result = {"delete_all": set(), "shopping": set()}
+    result: dict[str, set[str]] = {"delete_all": set(), "shopping": set()}
     for sender, cats in sender_cats.items():
         if sender.lower() in PROTECTED_SENDERS:
             continue
@@ -237,13 +261,19 @@ def load_senders_by_category():
     return result
 
 
-def query_senders_parallel(senders, date_filter=None, label=""):
-    all_ids = []
+def query_senders_parallel(
+    senders: set[str],
+    date_filter: str | None = None,
+    label: str = "",
+) -> list[str]:
+    all_ids: list[str] = []
     completed = 0
     total = len(senders)
 
     with ThreadPoolExecutor(max_workers=MAX_CONCURRENT) as pool:
-        futures = {pool.submit(collect_ids_for_sender, s, "inbox", date_filter): s for s in senders}
+        futures = {
+            pool.submit(collect_ids_for_sender, s, "inbox", date_filter): s for s in senders
+        }
         for future in as_completed(futures):
             try:
                 ids = future.result()
@@ -261,7 +291,7 @@ def query_senders_parallel(senders, date_filter=None, label=""):
     return all_ids
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Email cleanup pass 2+3")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()

--- a/scripts/email-cleanup-pass4.py
+++ b/scripts/email-cleanup-pass4.py
@@ -9,6 +9,8 @@ Uses an inverted approach: identify senders in KEEP categories, then delete
 all emails NOT from those senders (plus a date safety net for uncategorized).
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -17,12 +19,13 @@ import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any
 
-import msal
+import msal  # type: ignore[import-untyped]
 import requests
 
-sys.stdout.reconfigure(line_buffering=True)
-sys.stderr.reconfigure(line_buffering=True)
+sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+sys.stderr.reconfigure(line_buffering=True)  # type: ignore[union-attr]
 
 CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
 TENANT_ID = "common"
@@ -35,7 +38,7 @@ MAX_CONCURRENT = 4
 PAGE_SIZE = 999
 
 # Categories to KEEP — everything else gets deleted
-KEEP_CATEGORIES = {
+KEEP_CATEGORIES: set[str] = {
     "Personal & Reminders",
     "Jamie",
     "Ashley",
@@ -47,13 +50,13 @@ KEEP_CATEGORIES = {
 }
 
 # Extra protected senders (regardless of category)
-PROTECTED_SENDERS = {"ash.davis@hotmail.com"}
+PROTECTED_SENDERS: set[str] = {"ash.davis@hotmail.com"}
 
 session = requests.Session()
 session.headers["Content-Type"] = "application/json"
 
 
-def authenticate():
+def authenticate() -> str:
     print(f"  Token cache: {TOKEN_CACHE_FILE}", flush=True)
     cache = msal.SerializableTokenCache()
     if TOKEN_CACHE_FILE.exists():
@@ -68,7 +71,7 @@ def authenticate():
 
     accounts = app.get_accounts()
     if accounts:
-        result = app.acquire_token_silent(SCOPES, account=accounts[0])
+        result: dict[str, Any] = app.acquire_token_silent(SCOPES, account=accounts[0])
         if result and "access_token" in result:
             print(f"  Authenticated as {accounts[0]['username']} (cached)", flush=True)
             if cache.has_state_changed:
@@ -78,7 +81,7 @@ def authenticate():
     print("\n" + "=" * 60)
     print("MICROSOFT AUTHENTICATION REQUIRED")
     print("=" * 60)
-    flow = app.initiate_device_flow(scopes=SCOPES)
+    flow: dict[str, Any] = app.initiate_device_flow(scopes=SCOPES)
     if "user_code" not in flow:
         raise RuntimeError(f"Failed: {flow.get('error_description')}")
     print(flow["message"])
@@ -90,7 +93,11 @@ def authenticate():
     raise RuntimeError(f"Auth failed: {result.get('error_description')}")
 
 
-def api_get(url, params=None, retries=5):
+def api_get(
+    url: str,
+    params: dict[str, Any] | None = None,
+    retries: int = 5,
+) -> dict[str, Any]:
     for attempt in range(retries):
         try:
             resp = session.get(url, params=params, timeout=30)
@@ -113,7 +120,11 @@ def api_get(url, params=None, retries=5):
     raise RuntimeError(f"Failed after {retries} retries: {url}")
 
 
-def api_post(url, json_data, retries=5):
+def api_post(
+    url: str,
+    json_data: dict[str, Any],
+    retries: int = 5,
+) -> dict[str, Any]:
     for attempt in range(retries):
         try:
             resp = session.post(url, json=json_data, timeout=60)
@@ -136,13 +147,16 @@ def api_post(url, json_data, retries=5):
     raise RuntimeError(f"Failed after {retries} retries: {url}")
 
 
-def collect_message_ids(folder, odata_filter=None):
-    url = f"{GRAPH_BASE}/me/mailFolders/{folder}/messages"
-    params = {"$top": PAGE_SIZE, "$select": "id"}
+def collect_message_ids(
+    folder: str,
+    odata_filter: str | None = None,
+) -> list[str]:
+    url: str | None = f"{GRAPH_BASE}/me/mailFolders/{folder}/messages"
+    params: dict[str, Any] = {"$top": PAGE_SIZE, "$select": "id"}
     if odata_filter:
         params["$filter"] = odata_filter
 
-    ids = []
+    ids: list[str] = []
     page = 0
     while url:
         data = api_get(url, params if page == 0 else None)
@@ -152,7 +166,7 @@ def collect_message_ids(folder, odata_filter=None):
     return ids
 
 
-def collect_ids_for_sender(sender, folder="inbox"):
+def collect_ids_for_sender(sender: str, folder: str = "inbox") -> list[str]:
     odata_filter = f"from/emailAddress/address eq '{sender}'"
     try:
         return collect_message_ids(folder, odata_filter)
@@ -161,7 +175,11 @@ def collect_ids_for_sender(sender, folder="inbox"):
         return []
 
 
-def batch_delete(message_ids, label="", dry_run=False):
+def batch_delete(
+    message_ids: list[str],
+    label: str = "",
+    dry_run: bool = False,
+) -> int:
     if not message_ids:
         return 0
 
@@ -174,7 +192,7 @@ def batch_delete(message_ids, label="", dry_run=False):
         if dry_run:
             deleted += len(chunk)
         else:
-            requests_payload = [
+            requests_payload: list[dict[str, Any]] = [
                 {"id": str(j), "method": "DELETE", "url": f"/me/messages/{mid}"}
                 for j, mid in enumerate(chunk)
             ]
@@ -196,30 +214,32 @@ def batch_delete(message_ids, label="", dry_run=False):
     return deleted
 
 
-def load_sender_sets():
+def load_sender_sets() -> tuple[set[str], set[str], defaultdict[str, int], defaultdict[str, int]]:
     """Build KEEP and DELETE sender sets from classification data."""
     corpus_path = os.path.expanduser("~/data/outputs/email_corpus.json")
     clf_path = os.path.expanduser("~/data/outputs/classify_report_batch.json")
 
     with open(corpus_path, encoding="utf-8") as f:
-        corpus = json.load(f)
+        corpus: dict[str, Any] = json.load(f)
     with open(clf_path, encoding="utf-8") as f:
-        clf_data = json.load(f)
+        clf_data: dict[str, Any] = json.load(f)
 
-    email_info = {}
+    email_info: dict[str, str] = {}
     for email in corpus["emails"]:
         email_info[email["id"]] = email["sender_email"]
 
-    sender_cats = defaultdict(lambda: defaultdict(int))
+    sender_cats: defaultdict[str, defaultdict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
     for email_id, info in clf_data["categorized_emails"].items():
-        sender = email_info.get(email_id, "")
+        sender: str = email_info.get(email_id, "")
         if sender:
             sender_cats[sender][info["category"]] += 1
 
-    keep_senders = set()
-    delete_senders = set()
-    keep_category_counts = defaultdict(int)
-    delete_category_counts = defaultdict(int)
+    keep_senders: set[str] = set()
+    delete_senders: set[str] = set()
+    keep_category_counts: defaultdict[str, int] = defaultdict(int)
+    delete_category_counts: defaultdict[str, int] = defaultdict(int)
 
     for sender, cats in sender_cats.items():
         primary = max(cats, key=cats.get)
@@ -240,7 +260,7 @@ def load_sender_sets():
     return keep_senders, delete_senders, keep_category_counts, delete_category_counts
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Email cleanup pass 4 — delete all except protected categories"
     )
@@ -275,7 +295,7 @@ def main():
 
     # Query delete senders
     print(f"\n[3/5] Querying {len(delete_senders)} senders to delete...", flush=True)
-    all_delete_ids = []
+    all_delete_ids: list[str] = []
     completed = 0
 
     with ThreadPoolExecutor(max_workers=MAX_CONCURRENT) as pool:

--- a/scripts/email-cleanup-pass6.py
+++ b/scripts/email-cleanup-pass6.py
@@ -6,17 +6,20 @@ directly to identify automated/marketing senders. Flipped approach: protect
 personal email domains and known keepers, delete everything matching patterns.
 """
 
+from __future__ import annotations
+
 import argparse
 import re
 import sys
 import time
 from collections import Counter
 from pathlib import Path
+from typing import Any
 
-import msal
+import msal  # type: ignore[import-untyped]
 import requests
 
-sys.stdout.reconfigure(line_buffering=True)
+sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
 
 CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
 TENANT_ID = "common"
@@ -27,14 +30,14 @@ BATCH_SIZE = 20
 PAGE_SIZE = 999
 
 # --- PROTECTED: never delete from these ---
-PROTECTED_ADDRESSES = {
+PROTECTED_ADDRESSES: set[str] = {
     "troy.davis@hotmail.com",
     "ash.davis@hotmail.com",
     "km4ack@arrl.net",
 }
 
 # Personal email domains — real humans, keep all
-PERSONAL_DOMAINS = {
+PERSONAL_DOMAINS: set[str] = {
     "gmail.com",
     "hotmail.com",
     "outlook.com",
@@ -59,7 +62,7 @@ PERSONAL_DOMAINS = {
 }
 
 # --- AUTOMATED SENDER PATTERNS (local part) ---
-AUTO_LOCAL_PATTERNS = [
+AUTO_LOCAL_PATTERNS: list[str] = [
     "noreply",
     "donotreply",
     "no-reply",
@@ -110,7 +113,7 @@ AUTO_LOCAL_PATTERNS = [
 ]
 
 # --- AUTOMATED SENDER DOMAIN PATTERNS ---
-AUTO_DOMAIN_PATTERNS = [
+AUTO_DOMAIN_PATTERNS: list[str] = [
     r"^mail\.",
     r"^email\.",
     r"^email\d?\.",
@@ -127,10 +130,12 @@ AUTO_DOMAIN_PATTERNS = [
     r"^campaign\.",
     r"^bulk\.",
 ]
-AUTO_DOMAIN_RE = [re.compile(p, re.IGNORECASE) for p in AUTO_DOMAIN_PATTERNS]
+AUTO_DOMAIN_RE: list[re.Pattern[str]] = [
+    re.compile(p, re.IGNORECASE) for p in AUTO_DOMAIN_PATTERNS
+]
 
 # Known bulk/newsletter platform domains
-PLATFORM_DOMAINS = {
+PLATFORM_DOMAINS: set[str] = {
     "beehiiv.com",
     "substack.com",
     "groups.io",
@@ -154,7 +159,7 @@ PLATFORM_DOMAINS = {
 }
 
 
-def is_automated_sender(address):
+def is_automated_sender(address: str) -> bool:
     """Determine if a sender address is automated/marketing."""
     address = address.lower().strip()
     local, _, domain = address.partition("@")
@@ -187,7 +192,7 @@ def is_automated_sender(address):
     return False
 
 
-def authenticate():
+def authenticate() -> tuple[str, Any, msal.SerializableTokenCache]:
     cache = msal.SerializableTokenCache()
     if TOKEN_CACHE_FILE.exists():
         cache.deserialize(TOKEN_CACHE_FILE.read_text())
@@ -198,7 +203,7 @@ def authenticate():
     )
     accounts = app.get_accounts()
     if accounts:
-        result = app.acquire_token_silent(SCOPES, account=accounts[0])
+        result: dict[str, Any] = app.acquire_token_silent(SCOPES, account=accounts[0])
         if result and "access_token" in result:
             print(f"  Authenticated as {accounts[0]['username']} (cached)", flush=True)
             if cache.has_state_changed:
@@ -206,7 +211,7 @@ def authenticate():
             return result["access_token"], app, cache
 
     print("\nMICROSOFT AUTHENTICATION REQUIRED", flush=True)
-    flow = app.initiate_device_flow(scopes=SCOPES)
+    flow: dict[str, Any] = app.initiate_device_flow(scopes=SCOPES)
     print(flow["message"], flush=True)
     result = app.acquire_token_by_device_flow(flow)
     if "access_token" in result:
@@ -217,18 +222,18 @@ def authenticate():
 
 session = requests.Session()
 session.headers["Content-Type"] = "application/json"
-_app = None
-_cache = None
+_app: Any = None
+_cache: msal.SerializableTokenCache | None = None
 
 
-def refresh_token():
+def refresh_token() -> str:
     global _app, _cache
     accounts = _app.get_accounts()
-    result = _app.acquire_token_silent(SCOPES, account=accounts[0])
+    result: dict[str, Any] = _app.acquire_token_silent(SCOPES, account=accounts[0])
     return result["access_token"]
 
 
-def api_get(url, params=None):
+def api_get(url: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     for attempt in range(5):
         try:
             resp = session.get(url, params=params, timeout=30)
@@ -248,7 +253,7 @@ def api_get(url, params=None):
     raise RuntimeError("Failed after 5 retries")
 
 
-def api_post(url, json_data):
+def api_post(url: str, json_data: dict[str, Any]) -> dict[str, Any]:
     for attempt in range(5):
         try:
             resp = session.post(url, json=json_data, timeout=60)
@@ -267,7 +272,7 @@ def api_post(url, json_data):
     raise RuntimeError("Failed after 5 retries")
 
 
-def main():
+def main() -> None:
     global _app, _cache
 
     parser = argparse.ArgumentParser(description="Pass 6: Pattern-based automated sender cleanup")
@@ -287,20 +292,22 @@ def main():
 
     # Phase 1: Scan entire inbox, classify each sender
     print("\n[2/3] Scanning inbox for automated senders...", flush=True)
-    url = f"{GRAPH_BASE}/me/mailFolders/inbox/messages"
-    params = {"$top": PAGE_SIZE, "$select": "id,from"}
+    url: str | None = f"{GRAPH_BASE}/me/mailFolders/inbox/messages"
+    params: dict[str, Any] = {"$top": PAGE_SIZE, "$select": "id,from"}
 
-    auto_ids = []
+    auto_ids: list[str] = []
     keep_count = 0
-    auto_senders = Counter()
-    keep_senders = Counter()
+    auto_senders: Counter[str] = Counter()
+    keep_senders: Counter[str] = Counter()
     total = 0
     page = 0
 
     while url:
         data = api_get(url, params if page == 0 else None)
         for msg in data.get("value", []):
-            addr = msg.get("from", {}).get("emailAddress", {}).get("address", "unknown").lower()
+            addr: str = (
+                msg.get("from", {}).get("emailAddress", {}).get("address", "unknown").lower()
+            )
             total += 1
             if is_automated_sender(addr):
                 auto_ids.append(msg["id"])
@@ -342,7 +349,7 @@ def main():
 
     for i in range(0, len(auto_ids), BATCH_SIZE):
         chunk = auto_ids[i : i + BATCH_SIZE]
-        reqs = [
+        reqs: list[dict[str, Any]] = [
             {"id": str(j), "method": "DELETE", "url": f"/me/messages/{mid}"}
             for j, mid in enumerate(chunk)
         ]

--- a/scripts/email-cleanup.py
+++ b/scripts/email-cleanup.py
@@ -8,6 +8,8 @@ Actions:
 3. Empty Deleted Items folder
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -17,13 +19,14 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
-import msal
+import msal  # type: ignore[import-untyped]
 import requests
 
 # Force unbuffered output
-sys.stdout.reconfigure(line_buffering=True)
-sys.stderr.reconfigure(line_buffering=True)
+sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+sys.stderr.reconfigure(line_buffering=True)  # type: ignore[union-attr]
 
 # --- Auth config (matches email-corpus-analyzer) ---
 CLIENT_ID = "14d82eec-204b-4c2f-b7e8-296a70dab67e"
@@ -33,7 +36,7 @@ TOKEN_CACHE_FILE = Path.home() / ".email-analyzer" / "ms_token_cache.json"
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
 # --- Cleanup config ---
-PROTECTED_SENDERS = {"ash.davis@hotmail.com"}
+PROTECTED_SENDERS: set[str] = {"ash.davis@hotmail.com"}
 BATCH_SIZE = 20  # Graph API $batch limit
 MAX_CONCURRENT = 4  # parallel queries
 PAGE_SIZE = 999  # Graph API max per page
@@ -43,7 +46,7 @@ session = requests.Session()
 session.headers["Content-Type"] = "application/json"
 
 
-def authenticate():
+def authenticate() -> str:
     """MSAL device code auth with token caching."""
     print(f"  Token cache: {TOKEN_CACHE_FILE}", flush=True)
     cache = msal.SerializableTokenCache()
@@ -61,7 +64,7 @@ def authenticate():
 
     accounts = app.get_accounts()
     if accounts:
-        result = app.acquire_token_silent(SCOPES, account=accounts[0])
+        result: dict[str, Any] = app.acquire_token_silent(SCOPES, account=accounts[0])
         if result and "access_token" in result:
             print(f"  Authenticated as {accounts[0]['username']} (cached)")
             save_cache(cache)
@@ -70,7 +73,7 @@ def authenticate():
     print("\n" + "=" * 60)
     print("MICROSOFT AUTHENTICATION REQUIRED")
     print("=" * 60)
-    flow = app.initiate_device_flow(scopes=SCOPES)
+    flow: dict[str, Any] = app.initiate_device_flow(scopes=SCOPES)
     if "user_code" not in flow:
         raise RuntimeError(f"Failed to create device flow: {flow.get('error_description')}")
     print(flow["message"])
@@ -83,13 +86,13 @@ def authenticate():
     raise RuntimeError(f"Auth failed: {result.get('error_description')}")
 
 
-def save_cache(cache):
+def save_cache(cache: msal.SerializableTokenCache) -> None:
     if cache.has_state_changed:
         TOKEN_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
         TOKEN_CACHE_FILE.write_text(cache.serialize())
 
 
-def api_get(url, params=None, retries=3):
+def api_get(url: str, params: dict[str, Any] | None = None, retries: int = 3) -> dict[str, Any]:
     """GET with retry on 429."""
     for _attempt in range(retries):
         resp = session.get(url, params=params, timeout=30)
@@ -107,7 +110,11 @@ def api_get(url, params=None, retries=3):
     raise RuntimeError(f"Failed after {retries} retries: {url}")
 
 
-def api_post(url, json_data, retries=3):
+def api_post(
+    url: str,
+    json_data: dict[str, Any],
+    retries: int = 3,
+) -> dict[str, Any]:
     """POST with retry on 429."""
     for _attempt in range(retries):
         resp = session.post(url, json=json_data, timeout=60)
@@ -125,22 +132,30 @@ def api_post(url, json_data, retries=3):
     raise RuntimeError(f"Failed after {retries} retries: {url}")
 
 
-def collect_message_ids(folder, odata_filter=None, label=""):
+def collect_message_ids(
+    folder: str,
+    odata_filter: str | None = None,
+    label: str = "",
+) -> list[str]:
     """Collect all message IDs from a folder, optionally filtered."""
-    url = f"{GRAPH_BASE}/me/mailFolders/{folder}/messages"
-    params = {"$top": PAGE_SIZE, "$select": "id", "$orderby": "receivedDateTime asc"}
+    url: str | None = f"{GRAPH_BASE}/me/mailFolders/{folder}/messages"
+    params: dict[str, Any] = {
+        "$top": PAGE_SIZE,
+        "$select": "id",
+        "$orderby": "receivedDateTime asc",
+    }
     if odata_filter:
         params["$filter"] = odata_filter
         # OData filter + orderby can conflict; remove orderby
         del params["$orderby"]
 
-    ids = []
+    ids: list[str] = []
     page = 0
     while url:
         data = api_get(url, params if page == 0 else None)
         batch = [m["id"] for m in data.get("value", [])]
         ids.extend(batch)
-        next_link = data.get("@odata.nextLink")
+        next_link: str | None = data.get("@odata.nextLink")
         if next_link:
             url = next_link
             page += 1
@@ -149,7 +164,11 @@ def collect_message_ids(folder, odata_filter=None, label=""):
     return ids
 
 
-def batch_delete(message_ids, label="", dry_run=False):
+def batch_delete(
+    message_ids: list[str],
+    label: str = "",
+    dry_run: bool = False,
+) -> int:
     """Delete messages in batches of 20 using Graph $batch API."""
     if not message_ids:
         return 0
@@ -164,7 +183,7 @@ def batch_delete(message_ids, label="", dry_run=False):
             deleted += len(chunk)
             continue
 
-        requests_payload = []
+        requests_payload: list[dict[str, Any]] = []
         for j, mid in enumerate(chunk):
             requests_payload.append(
                 {
@@ -195,7 +214,11 @@ def batch_delete(message_ids, label="", dry_run=False):
     return deleted
 
 
-def collect_ids_for_sender(sender, cutoff_iso, folder="inbox"):
+def collect_ids_for_sender(
+    sender: str,
+    cutoff_iso: str,
+    folder: str = "inbox",
+) -> list[str]:
     """Query inbox for a sender's emails before cutoff date."""
     odata_filter = (
         f"from/emailAddress/address eq '{sender}' " f"and receivedDateTime lt {cutoff_iso}"
@@ -207,7 +230,7 @@ def collect_ids_for_sender(sender, cutoff_iso, folder="inbox"):
         return []
 
 
-def load_marketing_senders():
+def load_marketing_senders() -> list[tuple[str, int, str]]:
     """Load senders from classification data."""
     corpus_path = os.path.expanduser("~/data/outputs/email_corpus.json")
     clf_path = os.path.expanduser("~/data/outputs/classify_report_batch.json")
@@ -217,21 +240,23 @@ def load_marketing_senders():
         sys.exit(1)
 
     with open(corpus_path, encoding="utf-8") as f:
-        corpus = json.load(f)
+        corpus: dict[str, Any] = json.load(f)
     with open(clf_path, encoding="utf-8") as f:
-        clf_data = json.load(f)
+        clf_data: dict[str, Any] = json.load(f)
 
-    email_info = {}
+    email_info: dict[str, str] = {}
     for email in corpus["emails"]:
         email_info[email["id"]] = email["sender_email"]
 
-    sender_cats = defaultdict(lambda: defaultdict(int))
+    sender_cats: defaultdict[str, defaultdict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
     for email_id, info in clf_data["categorized_emails"].items():
-        sender = email_info.get(email_id, "")
+        sender: str = email_info.get(email_id, "")
         if sender:
             sender_cats[sender][info["category"]] += 1
 
-    spam_categories = {
+    spam_categories: set[str] = {
         "Spam & Junk",
         "Newsletters & Marketing",
         "Shopping & E-commerce",
@@ -257,20 +282,20 @@ def load_marketing_senders():
         "sendgrid",
     ]
 
-    senders = []
-    for sender, cats in sender_cats.items():
+    senders: list[tuple[str, int, str]] = []
+    for sndr, cats in sender_cats.items():
         primary_cat = max(cats, key=cats.get)
         is_marketing = primary_cat in spam_categories or any(
-            sig in sender.lower() for sig in marketing_signals
+            sig in sndr.lower() for sig in marketing_signals
         )
-        if is_marketing and sender.lower() not in PROTECTED_SENDERS:
-            senders.append((sender, sum(cats.values()), primary_cat))
+        if is_marketing and sndr.lower() not in PROTECTED_SENDERS:
+            senders.append((sndr, sum(cats.values()), primary_cat))
 
     senders.sort(key=lambda x: x[1], reverse=True)
     return senders
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Email cleanup via Graph API")
     parser.add_argument("--dry-run", action="store_true", help="Count without deleting")
     parser.add_argument("--skip-junk", action="store_true", help="Skip emptying Junk folder")
@@ -326,7 +351,7 @@ def main():
         print(f"  Found {len(senders)} marketing senders (excluding {PROTECTED_SENDERS})")
         print(f"  Querying inbox for emails older than {args.days} days...")
 
-        all_ids = []
+        all_ids: list[str] = []
         completed = 0
 
         with ThreadPoolExecutor(max_workers=MAX_CONCURRENT) as pool:

--- a/scripts/email-pipeline.py
+++ b/scripts/email-pipeline.py
@@ -14,6 +14,8 @@ Usage:
     python email-pipeline.py --status                      # pipeline stats
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging
@@ -25,13 +27,14 @@ import time
 from collections import Counter
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
-import msal
+import msal  # type: ignore[import-untyped]
 import requests
-import yaml
+import yaml  # type: ignore[import-untyped]
 
-sys.stdout.reconfigure(line_buffering=True)
-sys.stderr.reconfigure(line_buffering=True)
+sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+sys.stderr.reconfigure(line_buffering=True)  # type: ignore[union-attr]
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -57,11 +60,11 @@ BATCH = 50
 # ── Config ───────────────────────────────────────────────────────────────────
 
 
-def load_config() -> dict:
+def load_config() -> dict[str, Any]:
     """Load and normalize email-categories.yaml."""
     if not CONFIG_PATH.exists():
         sys.exit(f"Config not found: {CONFIG_PATH}")
-    cfg = yaml.safe_load(CONFIG_PATH.read_text())
+    cfg: dict[str, Any] = yaml.safe_load(CONFIG_PATH.read_text())
     cfg["_categories"] = {c for cats in cfg["groups"].values() for c in cats}
     cfg["sender_rules"] = {k.lower(): v for k, v in cfg["sender_rules"].items()}
     cfg["keyword_rules"] = {c: [w.lower() for w in ws] for c, ws in cfg["keyword_rules"].items()}
@@ -104,14 +107,25 @@ def init_db() -> sqlite3.Connection:
     return conn
 
 
-def is_processed(conn, mid: str) -> bool:
+def is_processed(conn: sqlite3.Connection, mid: str) -> bool:
     return (
         conn.execute("SELECT 1 FROM processed_emails WHERE message_id=?", (mid,)).fetchone()
         is not None
     )
 
 
-def record_email(conn, mid, provider, sender, subject, cat, conf, tier, fid, moved):
+def record_email(
+    conn: sqlite3.Connection,
+    mid: str,
+    provider: str,
+    sender: str,
+    subject: str,
+    cat: str,
+    conf: float,
+    tier: str,
+    fid: str,
+    moved: bool,
+) -> None:
     conn.execute(
         "INSERT OR REPLACE INTO processed_emails "
         "(message_id,provider,sender,subject,category,confidence,tier,folder_id,moved) "
@@ -121,7 +135,13 @@ def record_email(conn, mid, provider, sender, subject, cat, conf, tier, fid, mov
     conn.commit()
 
 
-def record_correction(conn, mid, provider, old_cat, new_cat):
+def record_correction(
+    conn: sqlite3.Connection,
+    mid: str,
+    provider: str,
+    old_cat: str,
+    new_cat: str,
+) -> None:
     conn.execute(
         "INSERT INTO corrections(message_id,provider,old_category,new_category) VALUES(?,?,?,?)",
         (mid, provider, old_cat, new_cat),
@@ -129,14 +149,20 @@ def record_correction(conn, mid, provider, old_cat, new_cat):
     conn.commit()
 
 
-def get_folder_id(conn, provider, category) -> str | None:
+def get_folder_id(conn: sqlite3.Connection, provider: str, category: str) -> str | None:
     r = conn.execute(
         "SELECT folder_id FROM folder_map WHERE provider=? AND category=?", (provider, category)
     ).fetchone()
     return r[0] if r else None
 
 
-def save_folder_id(conn, provider, category, fid, fname):
+def save_folder_id(
+    conn: sqlite3.Connection,
+    provider: str,
+    category: str,
+    fid: str,
+    fname: str,
+) -> None:
     conn.execute(
         "INSERT OR REPLACE INTO folder_map(provider,category,folder_id,folder_name) VALUES(?,?,?,?)",
         (provider, category, fid, fname),
@@ -147,7 +173,13 @@ def save_folder_id(conn, provider, category, fid, fname):
 # ── Graph API helpers ────────────────────────────────────────────────────────
 
 
-def _graph_request(session, method, url, json_data=None, refresh_fn=None):
+def _graph_request(
+    session: requests.Session,
+    method: str,
+    url: str,
+    json_data: dict[str, Any] | None = None,
+    refresh_fn: Any = None,
+) -> dict[str, Any] | None:
     """Generic Graph API call with retry, rate limit, and 401 refresh."""
     for attempt in range(5):
         try:
@@ -173,14 +205,15 @@ def _graph_request(session, method, url, json_data=None, refresh_fn=None):
 
 
 class HotmailBackend:
-    def __init__(self, conn, cfg):
-        self.conn, self.cfg = conn, cfg
+    def __init__(self, conn: sqlite3.Connection, cfg: dict[str, Any]) -> None:
+        self.conn = conn
+        self.cfg = cfg
         self.session = requests.Session()
         self.session.headers["Content-Type"] = "application/json"
-        self._cache = msal.SerializableTokenCache()
-        self._app = None
+        self._cache: msal.SerializableTokenCache = msal.SerializableTokenCache()
+        self._app: msal.PublicClientApplication | None = None
 
-    def authenticate(self, interactive=False) -> bool:
+    def authenticate(self, interactive: bool = False) -> bool:
         if MS_TOKEN_CACHE.exists():
             self._cache.deserialize(MS_TOKEN_CACHE.read_text())
         self._app = msal.PublicClientApplication(
@@ -190,7 +223,7 @@ class HotmailBackend:
         )
         accounts = self._app.get_accounts()
         if accounts:
-            r = self._app.acquire_token_silent(MS_SCOPES, account=accounts[0])
+            r: dict[str, Any] = self._app.acquire_token_silent(MS_SCOPES, account=accounts[0])
             if r and "access_token" in r:
                 self.session.headers["Authorization"] = f"Bearer {r['access_token']}"
                 self._save_cache()
@@ -199,7 +232,7 @@ class HotmailBackend:
         if not interactive:
             log.error("Hotmail: no cached token. Run --setup --provider hotmail")
             return False
-        flow = self._app.initiate_device_flow(scopes=MS_SCOPES)
+        flow: dict[str, Any] = self._app.initiate_device_flow(scopes=MS_SCOPES)
         if "user_code" not in flow:
             log.error(f"Device flow failed: {flow.get('error_description')}")
             return False
@@ -213,30 +246,32 @@ class HotmailBackend:
         log.error(f"Auth failed: {r.get('error_description')}")
         return False
 
-    def _save_cache(self):
+    def _save_cache(self) -> None:
         PIPE_DIR.mkdir(parents=True, exist_ok=True)
         MS_TOKEN_CACHE.write_text(self._cache.serialize())
 
-    def _refresh(self):
+    def _refresh(self) -> bool:
+        if self._app is None:
+            return False
         accounts = self._app.get_accounts()
         if accounts:
-            r = self._app.acquire_token_silent(MS_SCOPES, account=accounts[0])
+            r: dict[str, Any] = self._app.acquire_token_silent(MS_SCOPES, account=accounts[0])
             if r and "access_token" in r:
                 self.session.headers["Authorization"] = f"Bearer {r['access_token']}"
                 self._save_cache()
                 return True
         return False
 
-    def _get(self, url, params=None):
+    def _get(self, url: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
         return _graph_request(
             self.session, "get", url if not params else url, refresh_fn=self._refresh
         )
 
-    def _post(self, url, data):
+    def _post(self, url: str, data: dict[str, Any]) -> dict[str, Any] | None:
         return _graph_request(self.session, "post", url, json_data=data, refresh_fn=self._refresh)
 
-    def list_folders(self) -> dict:
-        folders = {}
+    def list_folders(self) -> dict[str, str]:
+        folders: dict[str, str] = {}
         data = self._get(f"{GRAPH}/me/mailFolders?$top=100")
         if not data or "value" not in data:
             return folders
@@ -248,14 +283,14 @@ class HotmailBackend:
                     folders[c["displayName"]] = c["id"]
         return folders
 
-    def setup_folders(self):
+    def setup_folders(self) -> None:
         existing = self.list_folders()
         inbox_id = existing.get("Inbox")
         if not inbox_id:
             return log.error("Cannot find Inbox folder")
         for cat in sorted(list(self.cfg["_categories"]) + ["Needs Review"]):
             if cat in existing:
-                fid = existing[cat]
+                fid: str | None = existing[cat]
             else:
                 r = self._post(
                     f"{GRAPH}/me/mailFolders/{inbox_id}/childFolders", {"displayName": cat}
@@ -268,15 +303,13 @@ class HotmailBackend:
             save_folder_id(self.conn, "hotmail", cat, fid, cat)
         log.info("Hotmail: folders ready")
 
-    def fetch_inbox(self, since_hours=1) -> list:
+    def fetch_inbox(self, since_hours: int = 1) -> list[dict[str, Any]]:
         since = (datetime.now(UTC) - timedelta(hours=since_hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
-        emails, url = (
-            [],
-            (
-                f"{GRAPH}/me/mailFolders/inbox/messages?$top={BATCH}"
-                f"&$select=id,subject,from,receivedDateTime,bodyPreview"
-                f"&$filter=receivedDateTime ge {since}&$orderby=receivedDateTime desc"
-            ),
+        emails: list[dict[str, Any]] = []
+        url = (
+            f"{GRAPH}/me/mailFolders/inbox/messages?$top={BATCH}"
+            f"&$select=id,subject,from,receivedDateTime,bodyPreview"
+            f"&$filter=receivedDateTime ge {since}&$orderby=receivedDateTime desc"
         )
         while url and len(emails) < 200:
             data = self._get(url)
@@ -299,10 +332,10 @@ class HotmailBackend:
             url = data.get("@odata.nextLink")
         return emails
 
-    def move_email(self, mid, fid) -> bool:
+    def move_email(self, mid: str, fid: str) -> bool:
         return self._post(f"{GRAPH}/me/messages/{mid}/move", {"destinationId": fid}) is not None
 
-    def cleanup_spam(self):
+    def cleanup_spam(self) -> None:
         cutoff = (
             datetime.now(UTC) - timedelta(days=self.cfg.get("spam_max_age_days", 30))
         ).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -310,7 +343,10 @@ class HotmailBackend:
         junk_id, del_id = folders.get("Junk Email"), folders.get("Deleted Items")
         if not (junk_id and del_id):
             return
-        url = f"{GRAPH}/me/mailFolders/{junk_id}/messages?$top={BATCH}&$select=id&$filter=receivedDateTime lt {cutoff}"
+        url: str | None = (
+            f"{GRAPH}/me/mailFolders/{junk_id}/messages?$top={BATCH}"
+            f"&$select=id&$filter=receivedDateTime lt {cutoff}"
+        )
         moved = 0
         while url and moved < 200:
             data = self._get(url)
@@ -323,14 +359,14 @@ class HotmailBackend:
         if moved:
             log.info(f"Hotmail: trashed {moved} old spam")
 
-    def detect_corrections(self):
+    def detect_corrections(self) -> None:
         rows = self.conn.execute(
             "SELECT message_id,category,folder_id FROM processed_emails "
             "WHERE provider='hotmail' AND moved=1 AND processed_at>datetime('now','-7 days')"
         ).fetchall()
         if not rows:
             return
-        fid_to_cat = dict(
+        fid_to_cat: dict[str, str] = dict(
             self.conn.execute(
                 "SELECT folder_id,category FROM folder_map WHERE provider='hotmail'"
             ).fetchall()
@@ -354,21 +390,24 @@ class HotmailBackend:
 
 
 class GmailBackend:
-    def __init__(self, conn, cfg):
-        self.conn, self.cfg = conn, cfg
-        self.svc = None
+    def __init__(self, conn: sqlite3.Connection, cfg: dict[str, Any]) -> None:
+        self.conn = conn
+        self.cfg = cfg
+        self.svc: Any = None
 
-    def authenticate(self, interactive=False) -> bool:
+    def authenticate(self, interactive: bool = False) -> bool:
         try:
-            from google.auth.transport.requests import Request as GReq
-            from google.oauth2.credentials import Credentials
-            from google_auth_oauthlib.flow import InstalledAppFlow
-            from googleapiclient.discovery import build
+            from google.auth.transport.requests import (
+                Request as GReq,  # type: ignore[import-untyped]
+            )
+            from google.oauth2.credentials import Credentials  # type: ignore[import-untyped]
+            from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-untyped]
+            from googleapiclient.discovery import build  # type: ignore[import-untyped]
         except ImportError:
             log.error("pip install google-auth-oauthlib google-api-python-client")
             return False
         SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
-        creds = None
+        creds: Any = None
         if GMAIL_TOKEN.exists():
             creds = Credentials.from_authorized_user_file(str(GMAIL_TOKEN), SCOPES)
         if creds and creds.expired and creds.refresh_token:
@@ -392,18 +431,18 @@ class GmailBackend:
         log.info("Gmail: authenticated")
         return True
 
-    def list_labels(self) -> dict:
-        r = self.svc.users().labels().list(userId="me").execute()
+    def list_labels(self) -> dict[str, str]:
+        r: dict[str, Any] = self.svc.users().labels().list(userId="me").execute()
         return {lb["name"]: lb["id"] for lb in r.get("labels", [])}
 
-    def setup_labels(self):
+    def setup_labels(self) -> None:
         existing = self.list_labels()
         for cat in sorted(list(self.cfg["_categories"]) + ["Needs Review"]):
             if cat in existing:
-                lid = existing[cat]
+                lid: str = existing[cat]
             else:
                 try:
-                    r = (
+                    r: dict[str, Any] = (
                         self.svc.users()
                         .labels()
                         .create(
@@ -424,11 +463,12 @@ class GmailBackend:
             save_folder_id(self.conn, "gmail", cat, lid, cat)
         log.info("Gmail: labels ready")
 
-    def fetch_inbox(self, since_hours=1) -> list:
+    def fetch_inbox(self, since_hours: int = 1) -> list[dict[str, Any]]:
         since = (datetime.now(UTC) - timedelta(hours=since_hours)).strftime("%Y/%m/%d")
-        emails, page_token = [], None
+        emails: list[dict[str, Any]] = []
+        page_token: str | None = None
         while len(emails) < 200:
-            r = (
+            r: dict[str, Any] = (
                 self.svc.users()
                 .messages()
                 .list(
@@ -437,7 +477,7 @@ class GmailBackend:
                 .execute()
             )
             for stub in r.get("messages", []):
-                m = (
+                m: dict[str, Any] = (
                     self.svc.users()
                     .messages()
                     .get(
@@ -449,7 +489,10 @@ class GmailBackend:
                     .execute()
                 )
                 time.sleep(API_DELAY)
-                hdrs = {h["name"]: h["value"] for h in m.get("payload", {}).get("headers", [])}
+                hdrs: dict[str, str] = {
+                    h["name"]: h["value"]
+                    for h in m.get("payload", {}).get("headers", [])
+                }
                 raw_from = hdrs.get("From", "")
                 match = re.search(r"<([^>]+)>", raw_from)
                 emails.append(
@@ -467,7 +510,7 @@ class GmailBackend:
                 break
         return emails
 
-    def label_email(self, mid, lid) -> bool:
+    def label_email(self, mid: str, lid: str) -> bool:
         try:
             self.svc.users().messages().modify(
                 userId="me", id=mid, body={"addLabelIds": [lid], "removeLabelIds": ["INBOX"]}
@@ -478,16 +521,17 @@ class GmailBackend:
             log.error(f"Label failed {mid}: {e}")
             return False
 
-    def move_email(self, mid, lid) -> bool:
+    def move_email(self, mid: str, lid: str) -> bool:
         return self.label_email(mid, lid)
 
-    def cleanup_spam(self):
+    def cleanup_spam(self) -> None:
         cutoff = (
             datetime.now(UTC) - timedelta(days=self.cfg.get("spam_max_age_days", 30))
         ).strftime("%Y/%m/%d")
-        trashed, pt = 0, None
+        trashed = 0
+        pt: str | None = None
         while trashed < 200:
-            r = (
+            r: dict[str, Any] = (
                 self.svc.users()
                 .messages()
                 .list(userId="me", q=f"in:spam before:{cutoff}", maxResults=BATCH, pageToken=pt)
@@ -506,14 +550,14 @@ class GmailBackend:
         if trashed:
             log.info(f"Gmail: trashed {trashed} old spam")
 
-    def detect_corrections(self):
+    def detect_corrections(self) -> None:
         rows = self.conn.execute(
             "SELECT message_id,category,folder_id FROM processed_emails "
             "WHERE provider='gmail' AND moved=1 AND processed_at>datetime('now','-7 days')"
         ).fetchall()
         if not rows:
             return
-        lid_to_cat = dict(
+        lid_to_cat: dict[str, str] = dict(
             self.conn.execute(
                 "SELECT folder_id,category FROM folder_map WHERE provider='gmail'"
             ).fetchall()
@@ -521,11 +565,13 @@ class GmailBackend:
         found = 0
         for mid, old_cat, old_lid in rows:
             try:
-                m = self.svc.users().messages().get(userId="me", id=mid, format="minimal").execute()
+                m: dict[str, Any] = (
+                    self.svc.users().messages().get(userId="me", id=mid, format="minimal").execute()
+                )
                 time.sleep(API_DELAY)
             except Exception:
                 continue
-            cur_labels = set(m.get("labelIds", []))
+            cur_labels: set[str] = set(m.get("labelIds", []))
             if old_lid not in cur_labels:
                 new_cat = next((lid_to_cat[l] for l in cur_labels if l in lid_to_cat), "unknown")
                 record_correction(self.conn, mid, "gmail", old_cat, new_cat)
@@ -537,9 +583,12 @@ class GmailBackend:
 # ── Classifier ───────────────────────────────────────────────────────────────
 
 
-def classify_by_sender(email, sender_rules) -> tuple | None:
+def classify_by_sender(
+    email: dict[str, Any],
+    sender_rules: dict[str, str],
+) -> tuple[str, float, str] | None:
     """T0: exact email or domain suffix match. Returns (category, 1.0, 'sender')."""
-    sender = email["sender"]
+    sender: str = email["sender"]
     if sender in sender_rules:
         return (sender_rules[sender], 1.0, "sender")
     if "@" in sender:
@@ -550,10 +599,14 @@ def classify_by_sender(email, sender_rules) -> tuple | None:
     return None
 
 
-def classify_by_keyword(email, keyword_rules) -> tuple | None:
+def classify_by_keyword(
+    email: dict[str, Any],
+    keyword_rules: dict[str, list[str]],
+) -> tuple[str, float, str] | None:
     """T0: subject keyword match. Confidence 0.5-0.9 based on hit count."""
-    subj = email["subject"].lower()
-    best, best_n = None, 0
+    subj: str = email["subject"].lower()
+    best: str | None = None
+    best_n = 0
     for cat, kws in keyword_rules.items():
         n = sum(1 for kw in kws if kw in subj)
         if n > best_n:
@@ -563,9 +616,12 @@ def classify_by_keyword(email, keyword_rules) -> tuple | None:
     return None
 
 
-def classify_by_jetson(email, cfg) -> tuple | None:
+def classify_by_jetson(
+    email: dict[str, Any],
+    cfg: dict[str, Any],
+) -> tuple[str, float, str] | None:
     """T1: Jetson LLM classification. Returns (category, confidence, 'jetson')."""
-    jcfg = cfg.get("jetson", {})
+    jcfg: dict[str, Any] = cfg.get("jetson", {})
     cats = sorted(cfg["_categories"])
     prompt = (
         f"Classify this email into exactly one of these categories:\n{json.dumps(cats)}\n\n"
@@ -590,11 +646,11 @@ def classify_by_jetson(email, cfg) -> tuple | None:
         if resp.status_code != 200:
             log.warning(f"Jetson {resp.status_code}: {resp.text[:200]}")
             return None
-        content = resp.json()["choices"][0]["message"]["content"].strip()
+        content: str = resp.json()["choices"][0]["message"]["content"].strip()
         content = re.sub(r"^```(?:json)?\s*", "", content)
         content = re.sub(r"\s*```$", "", content)
         content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL).strip()
-        r = json.loads(content)
+        r: dict[str, Any] = json.loads(content)
         cat, conf = r.get("category", ""), float(r.get("confidence", 0))
         return (cat, conf, "jetson") if cat in cfg["_categories"] else None
     except Exception as e:
@@ -602,7 +658,10 @@ def classify_by_jetson(email, cfg) -> tuple | None:
         return None
 
 
-def classify_email(email, cfg) -> tuple:
+def classify_email(
+    email: dict[str, Any],
+    cfg: dict[str, Any],
+) -> tuple[str, float, str]:
     """Tiered classification: sender -> keyword -> Jetson -> Needs Review."""
     return (
         classify_by_sender(email, cfg["sender_rules"])
@@ -615,7 +674,13 @@ def classify_email(email, cfg) -> tuple:
 # ── Pipeline Orchestrator ────────────────────────────────────────────────────
 
 
-def run_pipeline(backend, conn, cfg, dry_run=False, since_hours=1):
+def run_pipeline(
+    backend: HotmailBackend | GmailBackend,
+    conn: sqlite3.Connection,
+    cfg: dict[str, Any],
+    dry_run: bool = False,
+    since_hours: int = 1,
+) -> None:
     """Fetch -> classify -> organize -> cleanup -> detect corrections."""
     provider = "hotmail" if isinstance(backend, HotmailBackend) else "gmail"
     log.info(f"--- {provider.upper()} pipeline start ---")
@@ -624,8 +689,8 @@ def run_pipeline(backend, conn, cfg, dry_run=False, since_hours=1):
     new = [e for e in emails if not is_processed(conn, e["id"])]
     log.info(f"Fetched {len(emails)}, new: {len(new)}")
 
-    threshold = cfg.get("auto_move_threshold", 0.85)
-    stats = Counter()
+    threshold: float = cfg.get("auto_move_threshold", 0.85)
+    stats: Counter[str] = Counter()
 
     for e in new:
         cat, conf, tier = classify_email(e, cfg)
@@ -660,7 +725,7 @@ def run_pipeline(backend, conn, cfg, dry_run=False, since_hours=1):
 # ── Daily Summary ────────────────────────────────────────────────────────────
 
 
-def generate_daily_summary(conn, cfg):
+def generate_daily_summary(conn: sqlite3.Connection, cfg: dict[str, Any]) -> None:
     """Aggregate today's emails, synthesize via claude --print, POST to brain."""
     today = datetime.now().strftime("%Y-%m-%d")
     existing = conn.execute(
@@ -677,8 +742,8 @@ def generate_daily_summary(conn, cfg):
     if not rows:
         return log.info(f"No emails on {today}, skipping summary")
 
-    cat_counts = Counter(r[3] for r in rows)
-    tier_counts = Counter(r[5] for r in rows)
+    cat_counts: Counter[str] = Counter(r[3] for r in rows)
+    tier_counts: Counter[str] = Counter(r[5] for r in rows)
     lines = [f"- [{r[0]}] {r[1]} | {r[2]} | {r[3]} ({r[5]}, {r[4]:.0%})" for r in rows[:100]]
 
     prompt = (
@@ -691,6 +756,7 @@ def generate_daily_summary(conn, cfg):
         "actionable items by category, notable senders, patterns worth noting."
     )
 
+    summary: str | None
     try:
         r = subprocess.run(
             ["claude", "--print", "-p", prompt], capture_output=True, text=True, timeout=120
@@ -710,7 +776,7 @@ def generate_daily_summary(conn, cfg):
     )
     conn.commit()
 
-    scfg = cfg.get("daily_summary", {})
+    scfg: dict[str, Any] = cfg.get("daily_summary", {})
     url = scfg.get("open_brain_url", "https://brain.troy-davis.com/api/v1/captures")
     try:
         resp = requests.post(
@@ -744,15 +810,15 @@ def generate_daily_summary(conn, cfg):
 # ── Status ───────────────────────────────────────────────────────────────────
 
 
-def show_status(conn):
+def show_status(conn: sqlite3.Connection) -> None:
     """Print pipeline statistics."""
     print("\n=== Email Pipeline Status ===\n")
-    total = conn.execute("SELECT COUNT(*) FROM processed_emails").fetchone()[0]
+    total: int = conn.execute("SELECT COUNT(*) FROM processed_emails").fetchone()[0]
     print(f"Total processed: {total}")
     for p in ("hotmail", "gmail"):
-        n = conn.execute("SELECT COUNT(*) FROM processed_emails WHERE provider=?", (p,)).fetchone()[
-            0
-        ]
+        n: int = conn.execute(
+            "SELECT COUNT(*) FROM processed_emails WHERE provider=?", (p,)
+        ).fetchone()[0]
         print(f"  {p}: {n}")
 
     print("\nTiers (7d):")
@@ -769,7 +835,7 @@ def show_status(conn):
     ).fetchall():
         print(f"  {cat}: {n}")
 
-    corr = conn.execute("SELECT COUNT(*) FROM corrections").fetchone()[0]
+    corr: int = conn.execute("SELECT COUNT(*) FROM corrections").fetchone()[0]
     print(f"\nCorrections: {corr}")
     if corr:
         for old, new, n in conn.execute(
@@ -779,7 +845,9 @@ def show_status(conn):
             print(f"  {old} -> {new}: {n}x")
 
     for p in ("hotmail", "gmail"):
-        n = conn.execute("SELECT COUNT(*) FROM folder_map WHERE provider=?", (p,)).fetchone()[0]
+        n = conn.execute(
+            "SELECT COUNT(*) FROM folder_map WHERE provider=?", (p,)
+        ).fetchone()[0]
         print(f"\n{p} folders mapped: {n}")
 
     r = conn.execute(
@@ -793,7 +861,7 @@ def show_status(conn):
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 
-def main():
+def main() -> None:
     ap = argparse.ArgumentParser(description="Email Classification Pipeline")
     ap.add_argument("--provider", choices=["hotmail", "gmail", "both"], default="both")
     ap.add_argument("--setup", action="store_true", help="Authenticate + create folders/labels")
@@ -812,12 +880,12 @@ def main():
         return conn.close()
 
     cfg = load_config()
-    providers = ["hotmail", "gmail"] if args.provider == "both" else [args.provider]
+    providers: list[str] = ["hotmail", "gmail"] if args.provider == "both" else [args.provider]
 
     for p in providers:
         try:
             if p == "hotmail":
-                be = HotmailBackend(conn, cfg)
+                be: HotmailBackend | GmailBackend = HotmailBackend(conn, cfg)
                 if not be.authenticate(interactive=args.setup):
                     continue
                 if args.setup:


### PR DESCRIPTION
## Summary

- Added `from __future__ import annotations` and full type hints to all 6 email scripts
- Function signatures (params + return types) and key local variables annotated throughout
- Used `dict[str, Any]` for MSAL and Graph API payloads (appropriate for untyped external APIs)
- Added `# type: ignore[import-untyped]` for msal, yaml, and optional Google auth imports
- Refactored `email-archive-by-year.py` to wrap top-level script logic in a `main()` function (required for pyright to check module-level code properly; no runtime behavior change)
- Added all 6 file paths to `[tool.pyright] include` in `pyproject.toml`

## Files changed

- `scripts/email-pipeline.py`
- `scripts/email-cleanup.py`
- `scripts/email-cleanup-pass2.py`
- `scripts/email-cleanup-pass4.py`
- `scripts/email-cleanup-pass6.py`
- `scripts/email-archive-by-year.py`
- `pyproject.toml`

## Test plan

- [ ] `python -m pyright scripts/email-pipeline.py scripts/email-cleanup.py scripts/email-cleanup-pass2.py scripts/email-cleanup-pass4.py scripts/email-cleanup-pass6.py scripts/email-archive-by-year.py` → 0 errors, 0 warnings
- [ ] `python -m ruff check scripts/email-*.py` → All checks passed
- [ ] CI passes

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)