### PR TITLE
fix(web-next): resolve root + /captures 500 errors, suppress hydration warning

### DIFF
--- a/packages/web-next/app/(shell)/[[...slug]]/page.tsx
+++ b/packages/web-next/app/(shell)/[[...slug]]/page.tsx
@@ -3,6 +3,12 @@ import { Construction } from 'lucide-react';
 import { PageHeader } from '@/components/design-system/PageHeader';
 import { EmptyState } from '@/components/design-system/EmptyState';
 
+// Force dynamic rendering — shell layout calls isOnboardingComplete() with
+// cache: 'no-store', making it dynamic at runtime. Without this directive,
+// Next.js tries to pre-render "/" as static and then sees "Page changed from
+// static to dynamic at runtime", resulting in a 500.
+export const dynamic = 'force-dynamic';
+
 /**
  * Map of top-level route slug → owning milestone label.
  * All routes that now have dedicated pages have been removed — this catch-all
@@ -48,8 +54,4 @@ export default async function CatchAllPage({ params }: Props) {
       />
     </>
   );
-}
-
-export function generateStaticParams() {
-  return Object.keys(MILESTONE_MAP).map((slug) => ({ slug: [slug] }));
 }

--- a/packages/web-next/app/layout.tsx
+++ b/packages/web-next/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" data-wash="parchment">
+    <html lang="en" data-wash="parchment" suppressHydrationWarning>
       <head>
         {/*
           Anti-flash theme + wash script — executes synchronously before body renders.


### PR DESCRIPTION
## Summary
- **Root + /captures 500 errors**: The `[[...slug]]` catch-all page had an empty `generateStaticParams()` that forced static pre-rendering, conflicting with the shell layout's `cache: 'no-store'` fetch. Removed `generateStaticParams` and added `export const dynamic = 'force-dynamic'`.
- **React hydration warning #418**: The dark-mode blocking script in `layout.tsx` sets a class on `<html>` before React hydrates, causing a mismatch. Added `suppressHydrationWarning` to the `<html>` tag.

## Test plan
- [ ] Verify `/` loads without 500
- [ ] Verify `/captures` loads without 500
- [ ] Verify no hydration warning in browser console
- [ ] Verify dark mode toggle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)