### PR TITLE
chore: post-remediation phase 1 quick wins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ After any non-trivial finding (container startup failure, networking quirk, pipe
 
 **Testing / CI**
 - Integration tests: `pnpm --filter @open-brain/core-api exec vitest run --config vitest.config.integration.ts` (not `npx`; filename word order matters).
+- **Windows local integration runner:** root `pnpm test:integration` is not reliable on PowerShell as of 2026-05-06; pnpm parsed `test:integration;` as a script name and exited 0 before tests ran. Use explicit sequence locally: `docker compose -f docker-compose.test.yml up -d --wait; pnpm --filter @open-brain/core-api test:integration; docker compose -f docker-compose.test.yml down -v`. Tracked as A129 for cross-platform script cleanup.
 - All test HTTP helpers send `X-Open-Brain-Caller: integration-test` header — rate limiter bypasses this key. Without it, strict tier (20 req/min) exhausts.
 - **Vitest `pool: 'forks'` requires both `minForks: 1` + `maxForks: N`** on vitest 1.6 (single-arg trips Tinypool `RangeError`). Applied in core-api + workers configs with `hookTimeout/testTimeout: 30_000` — avoids Windows ioredis/bullmq races.
 - Mock external service calls in tests (Pushgateway, Prometheus) — `pushMetrics()` hits `http://pushgateway:9091` which hangs on DNS in tests (5s). Always `vi.mock('../lib/push-metrics.js', ...)`.

--- a/IMPLEMENTATION_PLAN-POST-REMEDIATION.md
+++ b/IMPLEMENTATION_PLAN-POST-REMEDIATION.md
@@ -1,0 +1,552 @@
+# Implementation Plan: Post-Remediation Cleanup (Entry 106 + Entry 107)
+
+**Date:** 2026-05-06
+**Source:** `/ultra-plan` analysis of LAB_NOTEBOOK Entry 106 (Post-Remediation Architectural Audit) + Entry 107 (Post-Remediation Intent Review).
+**Based On:** In-conversation Phase 0–5 ultra-plan output, 2026-05-06.
+**Output:** This file.
+
+## Scope
+
+Outstanding tech-debt and doc-drift surfaced after PR #175 (R1–R12 architecture remediation arc) closed. Architecture scorecard 3.7/5.0; intent scorecard 7/10. Sound fundamentals; finishing-quality debt.
+
+**In scope:** F1–F8 (Entry 106 audit) + W1, W2, W3, W4, W7 + S1, S3, S4, S5, W6 (Entry 107 intent review), reorganized into four change sets:
+
+| Set | Items | Effort | Phases |
+|---|---|---|---|
+| A — Quick wins | F3 + F4 + F6 + F7 | S | Phase 1 |
+| B — Documentation alignment | W1 + W2 + W3 + W4 + W7 + S1 + S3 + S4 + S5 + W6 | M | Phase 2 |
+| C — Type system & lint hygiene | F1 + F5 | S–M | Phase 3 |
+| D — Workers test rigor | F8 + F2 | M | Phase 4 |
+| E — Strategic (deferred) | F9 (Vitest 2.x migration) | L | **Deferred** to separate plan |
+
+**Out of scope:**
+- **F9 (Vitest 2.x migration)** — Strategic; deserves its own plan with Windows forks-pool compat verification first. Bundling here couples a high-risk migration to low-risk housekeeping.
+- **R10 (`morning-brief.ts` decomposition, XL)** — Conditional on adding delivery channels (per Entry 106). Not currently triggered.
+- **A71 (memory-consolidation task key)** — Already tracked in CLAUDE.md as a pending action item.
+- **A125 (`init-schema.sql` migration parity)** — Separate audit task tracked since arch review.
+- **A128 (TanStack Query hook extraction)** — Deferred from arch review Phase 8a; separate plan.
+- **All 32 Critical+High items from the 2026-04-18 architecture audit** — closed via PR #175 (R1–R12). Risk Acceptance Register items remain accepted by design.
+- **Cloudscape M2/M3/M4 plans** — distinct active plans; no overlap.
+- **`IMPLEMENTATION_PLAN.md` (LLM model consolidation)** — distinct active plan; partially complete.
+
+## Verification Commands (Detected)
+
+| Check | Command | Notes |
+|---|---|---|
+| Unit tests (all) | `pnpm -r test` | Root script |
+| Unit tests (per-pkg) | `pnpm --filter @open-brain/<pkg> test` | Vitest |
+| Integration tests | `pnpm test:integration` | Spins up `docker-compose.test.yml`, then runs `vitest run --config vitest.config.integration.ts` |
+| Lint (all) | `pnpm -r lint` | Includes `tsc --noEmit` per package |
+| Validation | `pnpm test:validation` | Top-level config/schema validation |
+| Build | `pnpm -r build` | tsup/Vite/Next per package |
+| TypeScript only | `pnpm -r exec tsc --noEmit` | Cross-package type check |
+| Coverage (workers) | `pnpm --filter @open-brain/workers test -- --coverage` | New gate in Phase 4 |
+| Frozen lockfile | `pnpm install --frozen-lockfile` | CI parity check |
+
+## Architectural Constraints (from CLAUDE.md)
+
+Every phase MUST comply with:
+
+1. **LAB_NOTEBOOK.md entry created BEFORE the first commit in the phase** (blocking precondition).
+2. **`pnpm-lock.yaml` committed with any `package.json` change** — CI uses `--frozen-lockfile`.
+3. **Vitest forks pool config preserved** (`pool: 'forks'`, `minForks: 1`, `maxForks: N`, `hookTimeout/testTimeout: 30_000`) when adding new test config (Phase 4).
+4. **Internal HTTP callers** still set `X-Open-Brain-Caller`. Phase 1 module-scope hoist of `BYPASS_CALLERS` preserves all 17 entries verbatim.
+5. **Cost-tier compliance** — no per-item LLM calls introduced anywhere.
+6. **All secrets via Bitwarden** — no new secrets introduced in this plan.
+7. **Node 22 LTS runtime** — Phase 3 aligns `@types/node` to ^22 to match runtime.
+
+## Phase Summary Table
+
+| # | Title | Effort | Files (est) | LOC (est) | Depends on | Risk |
+|---|---|---|---|---|---|---|
+| 1 | Quick wins (deps + perf microfixes) | S | ~5 | ~80 + lockfile | — | Low |
+| 2 | Documentation alignment (README + PRD + TDD) | M | 3 | ~400 doc lines | — | None |
+| 3 | Type system & lint hygiene | S–M | 3 + (?) | ~10 + lockfile + (?) | — | Med |
+| 4 | Workers test rigor (coverage + CI) | M | 2–3 | ~50 | — | Med |
+
+**Total:** 4 phases. ~13–14 files touched. ~540 LOC + ~400 doc lines.
+
+**Critical path:** None. Phases 1–4 are mutually independent (no file overlap) and could ship in parallel branches. Recommended sequential order is increasing-risk: 1 → 2 → 3 → 4 — so the riskiest change tests against the most-recently-clean baseline.
+
+### Execution Hints
+
+| Phase | Model Tier | Context Budget | Notes |
+|---|---|---|---|
+| 1 | `haiku` | Minimal | Mechanical: dep removals, const hoist, N+1 collect-and-batch |
+| 2 | `sonnet` | Standard | Cross-reference every claim against code (docker-compose services, route files, skill registry) |
+| 3 | `sonnet` | Standard | Budget 30–60 min for tsc-error fixes after `@types/node` downgrade |
+| 4 | `sonnet` | Standard | CI verification + coverage baseline measurement first |
+
+## Generated ADRs
+
+**None.** This is L0–L2 housekeeping; no architectural decisions outlive the plan.
+
+---
+
+<!-- BEGIN PHASES -->
+
+## Phase 1: Quick Wins (Deps + Perf Microfixes)
+
+**Set:** A
+**Effort:** S
+**Goal:** Remove unused dependencies; hoist module-scope state; fix one N+1 query. All low-risk; tiny LOC; parallelizable internally.
+
+### 1.1 Hoist `BYPASS_CALLERS` to module scope
+
+**Files:** `packages/core-api/src/middleware/rate-limit.ts` (line ~274)
+
+**Acceptance:**
+- [ ] `const BYPASS_CALLERS = new Set([...])` moved from inside the closure (currently constructed per request) to module scope, after imports, before middleware export.
+- [ ] All 17 internal-caller entries preserved verbatim.
+- [ ] Inline comment added: `// Module-scope: constructed once, not per-request.`
+- [ ] Existing rate-limit unit + integration tests pass without modification.
+- [ ] Observable behavior unchanged (verify with `curl -H 'X-Open-Brain-Caller: integration-test' ...`).
+
+**Requirement Refs:** F7
+
+### 1.2 Fix N+1 in `GET /api/v1/ingest/uploads`
+
+**Files:** `packages/core-api/src/routes/ingest.ts` (lines 156–189 and `:435`)
+
+**Acceptance:**
+- [ ] List endpoint at `:435` collects all `captureId`s from upload rows BEFORE shaping responses.
+- [ ] Single `db.select().from(captures).where(inArray(captures.id, captureIds))` issued — replaces N round-trips.
+- [ ] `Map<string, Capture>` lookup passed to `shapeFileUploadRow()` (or function signature refactored to accept prefetched capture).
+- [ ] Response shape byte-identical (`pnpm --filter @open-brain/core-api test` covers route).
+- [ ] Query count drops from N+1 to 2 (verify via debug logging once, remove before commit).
+
+**Requirement Refs:** F6
+
+### 1.3 Remove redundant markdown deps from workers
+
+**Files:** `packages/workers/package.json` (lines 33–39), `pnpm-lock.yaml`
+
+**Acceptance:**
+- [ ] Pre-flight: `grep -rn "import.*\(remark\|rehype\|unified\|xss\)" packages/workers/src/` returns zero matches (already verified during planning).
+- [ ] `pnpm --filter @open-brain/workers remove remark-parse remark-rehype rehype-slug rehype-stringify rehype-autolink-headings unified xss` executed.
+- [ ] `pnpm install` regenerates `pnpm-lock.yaml`.
+- [ ] `pnpm --filter @open-brain/workers build` exits 0.
+- [ ] `pnpm --filter @open-brain/workers test` exits 0.
+
+**Requirement Refs:** F3
+
+### 1.4 Remove orphaned `@anthropic-ai/sdk` from root
+
+**Files:** `package.json` (root, line 31), `pnpm-lock.yaml`
+
+**Acceptance:**
+- [ ] Pre-flight: confirm no root TS file imports `@anthropic-ai/sdk` (workspace root has no application code; SDK is independently declared in shared/core-api/workers/voice-capture).
+- [ ] `pnpm remove -w @anthropic-ai/sdk` executed.
+- [ ] `pnpm install` regenerates `pnpm-lock.yaml`.
+- [ ] All consumer packages still build and test green.
+
+**Requirement Refs:** F4
+
+### Phase 1 Completion Checklist
+
+- [ ] All 4 work items complete.
+- [ ] Lab notebook entry created BEFORE first commit.
+- [ ] `pnpm-lock.yaml` committed in same PR as `package.json` changes.
+- [ ] CI green.
+- [ ] `git status` shows clean working tree at end.
+
+### Definition of Done (Runnable)
+<!-- BEGIN DOD -->
+| Check | Command | Pass Criteria |
+|---|---|---|
+| TypeScript | `pnpm -r exec tsc --noEmit` | Exit code 0 |
+| Tests | `pnpm -r test` | Exit code 0 |
+| Integration | `pnpm test:integration` | Exit code 0 |
+| Lint | `pnpm -r lint` | Exit code 0 |
+| Build | `pnpm -r build` | Exit code 0 |
+| Frozen lockfile | `pnpm install --frozen-lockfile` | Exit code 0 |
+| Workers grep | `grep -rn "import.*\(remark\|rehype\|unified\|xss\)" packages/workers/src/` | Zero matches |
+<!-- END DOD -->
+
+---
+
+## Phase 2: Documentation Alignment (README + PRD + TDD)
+
+**Set:** B
+**Effort:** M
+**Goal:** Bring README, PRD, and TDD into alignment with shipped code reality. Zero code risk; cross-reference every claim.
+
+### 2.1 README sweep — container count, package layout, version refs
+
+**Files:** `README.md`
+
+**Acceptance:**
+- [ ] **Container count:** line ~218 ("9 containers") corrected to authoritative count from `docker compose -f docker-compose.yml config --services | wc -l`. Recommend stating "13 core services" (per CLAUDE.md P11a) with note that ingest cron services bring active count to 17 in production.
+- [ ] **Architecture table** (line ~31): `open-brain-web ... Vite + React + shadcn/ui` row removed (web deleted in Phase 8b per ADR-0001). Replace with `open-brain-web-next ... Next.js 16 + Cloudscape + React 19 + TanStack Query` row.
+- [ ] **Monorepo layout** (line ~39): `packages/web/` row removed. Add rows for `packages/web-next/`, `packages/voice-pipecat/` (Pipecat VAD→Deepgram→Claude→TTS), `packages/file-ingestion/` (FastAPI file extraction), `packages/mobile/` (Expo React Native).
+- [ ] **Deleted file references** (lines 271–272): `packages/web/src/content/USER_QUICK_START.md` + `USER_GUIDE.md` references removed (deleted in Phase 8b).
+- [ ] **Stale "Deferred Features"** (lines 159–160): daily-connections + drift-monitor removed from deferred list (both shipped with cron schedules at 6:10 AM and 7:15 AM).
+- [ ] **PRD/TDD version references** updated from v0.6 → v0.7 (S5 fold-in).
+- [ ] **Verification:** `grep -c "packages/web/" README.md` returns 0.
+
+**Requirement Refs:** W1, W2, W3, S5, W6 (partial)
+
+### 2.2 PRD feature table update
+
+**Files:** `docs/PRD.md`
+
+**Acceptance:**
+- [ ] **F19 description:** "Web dashboard (Vite + React PWA)" → "Web dashboard (Next.js 16 + Cloudscape + React 19)".
+- [ ] **F21 (daily-connections), F22 (drift-monitor):** Status `Deferred` → `Complete` with approximate ship date (cron registration in `packages/workers/src/scheduler.ts` is authoritative).
+- [ ] **F29–F35:** Status `Planned` → `Complete` with ship dates.
+- [ ] **New feature IDs (F36+) added** for previously-undocumented capabilities:
+  - `monthly-reflection` — monthly summary skill
+  - `morning-brief` — proactive AM briefing
+  - `capture-reminder-morning` + `capture-reminder-evening` — autonomy-gated nudges
+  - `cost-analysis` — budget reporting skill
+  - `container-health` — synthetic monitor
+  - `storage-audit` — disk-usage skill
+  - `secret-rotation` — BWS rotation runbook trigger
+  - `capture-dedup-sweep` — dedup hygiene skill
+  - `refine-brief` — async LLM HTML transform
+  - `entity-brief` — entity-page synthesis
+  - `extract-commitments` — LLM commitment extraction (full pipeline + table + routes)
+  - `voice-sessions` — Pipecat session lifecycle REST API
+- [ ] **Status column** reflects code reality (cross-reference `packages/workers/src/skills/` directory + `packages/core-api/src/routes/`).
+- [ ] **Three undocumented packages** (W6) added to PRD §1 (System Overview): voice-pipecat, file-ingestion, mobile.
+
+**Requirement Refs:** W4, S1, S3, S4, W6 (partial)
+
+### 2.3 TDD §2.1 demote Jetson/Spark to optional
+
+**Files:** `docs/TDD.md`
+
+**Acceptance:**
+- [ ] **§2.1:** "Jetson Orin Nano (Required)" → "Jetson Orin Nano (Optional cost-saving tier)".
+- [ ] **§2.1:** "DGX Spark (Required)" → "DGX Spark (Optional cost-saving tier)".
+- [ ] **Explicit note added:** "Core system runs on OpenAI API alone; Jetson/Spark provide free-tier cost savings via `t1_jetson`/`t1_spark` entries in `config/ai-routing.yaml`. Neither is required to deploy or operate the system."
+- [ ] **Verification:** cross-reference `config/ai-routing.yaml` confirms `t1_jetson`/`t1_spark` are tier entries with explicit `cost_per_1k_*: 0`, not hard dependencies.
+
+**Requirement Refs:** W7
+
+### Phase 2 Completion Checklist
+
+- [ ] All 3 work items complete.
+- [ ] Lab notebook entry created BEFORE first commit.
+- [ ] Manual proofread: every file path in README exists; every PRD feature ID matches a code surface; TDD §2.1 matches `ai-routing.yaml`.
+- [ ] `grep -c "packages/web/" README.md` returns 0.
+
+### Definition of Done (Runnable)
+<!-- BEGIN DOD -->
+| Check | Command | Pass Criteria |
+|---|---|---|
+| Web reference scrub | `grep -c "packages/web/" README.md` | 0 |
+| Container count sanity | `docker compose -f docker-compose.yml config --services \| wc -l` | Number matches README claim |
+| Doc-sync CI | (existing `doc-sync` job in `.github/workflows/ci.yml`) | Green |
+<!-- END DOD -->
+
+---
+
+## Phase 3: Type System & Lint Hygiene
+
+**Set:** C
+**Effort:** S–M
+**Goal:** Align `@types/node` to runtime version; bump `eslint-config-next` to match Next.js 16. Both touch `package.json` + lockfile; both can surface latent errors needing same-PR fixes.
+
+### 3.1 Pre-flight: enumerate latent type errors (resolve U1)
+
+**Files:** none (research)
+
+**Acceptance:**
+- [ ] Branch `chore/types-node-22-pin` created.
+- [ ] `packages/core-api/package.json:46` `^25.3.5` → `^22.0.0`.
+- [ ] `packages/voice-capture/package.json:29` `^25.3.5` → `^22.0.0`.
+- [ ] `pnpm install` regenerates lockfile.
+- [ ] `pnpm -r exec tsc --noEmit` run; any errors enumerated in lab notebook entry.
+- [ ] **Decision gate:** if errors > 5 surfaces, escalate as a separate fix-and-pin PR before 3.2 lands. If ≤ 5, proceed to 3.2 in same PR.
+
+**Requirement Refs:** F1
+
+### 3.2 Align `@types/node` to ^22 + fix any surfaced errors
+
+**Files:** `packages/core-api/package.json:46`, `packages/voice-capture/package.json:29`, plus any source files surfaced by 3.1
+
+**Acceptance:**
+- [ ] Both packages pinned to `^22.0.0` (matching `packages/web-next/package.json:30` baseline).
+- [ ] All tsc errors surfaced in 3.1 fixed in same PR (preferred) OR explicitly enumerated and deferred with rationale (if escalated per 3.1 decision gate).
+- [ ] `pnpm -r exec tsc --noEmit` exits 0.
+- [ ] `pnpm -r build` exits 0.
+
+**Requirement Refs:** F1
+
+### 3.3 Bump `eslint-config-next` to ^16
+
+**Files:** `packages/web-next/package.json:39`
+
+**Acceptance:**
+- [ ] `eslint-config-next: ^15.0.0` → `^16.2.4` (matching `next: ^16.2.4`).
+- [ ] `pnpm install`.
+- [ ] `pnpm --filter @open-brain/web-next lint` run.
+- [ ] **Decision gate:** any new errors fixed in same PR. Goal: A127 baseline (24 errors in `HelpContent.tsx`) UNCHANGED. If new rules unavoidably extend the baseline, document in CLAUDE.md alongside A127.
+
+**Requirement Refs:** F5
+
+### 3.4 Lockfile commit
+
+**Files:** `pnpm-lock.yaml`
+
+**Acceptance:**
+- [ ] `pnpm install` after 3.2 + 3.3.
+- [ ] Lockfile committed in same PR as `package.json` changes.
+- [ ] `pnpm install --frozen-lockfile` exits 0 (CI parity).
+
+**Requirement Refs:** F1, F5
+
+### Phase 3 Completion Checklist
+
+- [ ] All 4 work items complete.
+- [ ] Lab notebook entry created BEFORE first commit (with U1 + U4 resolution recorded).
+- [ ] `pnpm-lock.yaml` committed alongside package.json changes.
+- [ ] A127 baseline unchanged (or documented if extended).
+- [ ] CI green.
+
+### Definition of Done (Runnable)
+<!-- BEGIN DOD -->
+| Check | Command | Pass Criteria |
+|---|---|---|
+| Frozen lockfile | `pnpm install --frozen-lockfile` | Exit code 0 |
+| TypeScript | `pnpm -r exec tsc --noEmit` | Exit code 0 |
+| Lint | `pnpm -r lint` | Exit code 0 (A127 baseline preserved) |
+| Build | `pnpm -r build` | Exit code 0 |
+| Tests | `pnpm -r test` | Exit code 0 |
+<!-- END DOD -->
+
+---
+
+## Phase 4: Workers Test Rigor
+
+**Set:** D
+**Effort:** M
+**Goal:** Add coverage thresholds to workers (matching core-api's 80% bar) AND wire workers integration tests into CI. Both ship together: thresholds without CI = unenforced; CI without thresholds = empty rigor.
+
+### 4.1 Measure workers coverage baseline (resolve U2)
+
+**Files:** none (measurement)
+
+**Acceptance:**
+- [ ] Run `pnpm --filter @open-brain/workers test -- --coverage`.
+- [ ] Document `lines%` and `functions%` in lab notebook entry.
+- [ ] Decide threshold value: pin to **floor** of measured baseline (safer; same pattern as core-api Phase 4 of arch-review remediation). Plan to raise incrementally toward 80% in follow-ups.
+
+**Requirement Refs:** F8
+
+### 4.2 Add coverage thresholds to workers vitest config
+
+**Files:** `packages/workers/vitest.config.ts`
+
+**Acceptance:**
+- [ ] `test.coverage` extended to mirror `packages/core-api/vitest.config.ts:20-29`:
+  ```typescript
+  coverage: {
+    provider: 'v8',
+    reporter: ['text', 'lcov', 'json-summary'],
+    include: ['src/**/*.ts'],
+    exclude: ['src/index.ts', 'src/main.ts', 'src/__tests__/**'],
+    thresholds: { lines: <baseline>, functions: <baseline> },
+  }
+  ```
+- [ ] `<baseline>` value pinned to the floor measured in 4.1.
+- [ ] Existing `pool: 'forks'` + `minForks: 1` + `maxForks: 4` + 30 s timeouts preserved (CLAUDE.md mandate).
+- [ ] `pnpm --filter @open-brain/workers test -- --coverage` exits 0.
+
+**Requirement Refs:** F8
+
+### 4.3 Verify (or create) `vitest.config.integration.ts` for workers (resolve U3)
+
+**Files:** `packages/workers/vitest.config.integration.ts` (verify or create)
+
+**Acceptance:**
+- [ ] File existence checked. If absent: create mirroring `packages/core-api/vitest.config.integration.ts` shape.
+- [ ] Required config: `include: ['src/__tests__/integration/**/*.test.ts']`, `pool: 'forks'`, `minForks: 1`, `maxForks: 4`, `hookTimeout: 30_000`, `testTimeout: 30_000`.
+- [ ] Locally: `docker compose -f docker-compose.test.yml up -d --wait` then `pnpm --filter @open-brain/workers exec vitest run --config vitest.config.integration.ts` — all 3 test files (`pipeline.test.ts`, `ingest-e2e.test.ts`, `access-stats-e2e.test.ts`) pass.
+
+**Requirement Refs:** F2
+
+### 4.4 Add workers integration test step to CI
+
+**Files:** `.github/workflows/ci.yml`
+
+**Acceptance:**
+- [ ] New step added in the `integration-test` job, **after** the existing "Run integration tests" step at line ~200, **before** "Dump service logs on failure":
+  ```yaml
+  - name: Run workers integration tests
+    run: pnpm --filter @open-brain/workers exec vitest run --config vitest.config.integration.ts
+    env:
+      TEST_POSTGRES_URL: postgresql://openbrain_test:test_password@localhost:5433/openbrain_test
+      TEST_REDIS_URL: redis://localhost:6381
+      NODE_ENV: test
+  ```
+- [ ] Reuses already-running `docker-compose.test.yml` services (started at line 198) — no new services or volumes added.
+- [ ] Step is part of the existing required `integration-test` job (no separate `continue-on-error: true` job needed; tests pass locally and use the same infrastructure).
+- [ ] `gh run list --workflow=ci.yml --limit 5` after merge shows ≥4/5 green runs.
+
+**Requirement Refs:** F2
+
+### 4.5 Verify branch protection still required
+
+**Files:** none (GitHub repo settings audit)
+
+**Acceptance:**
+- [ ] `gh api repos/davistroy/open-brain/branches/main/protection --jq '.required_status_checks.contexts'` includes `"Integration tests (core-api + real DB)"` (already required since arch-review Phase 5b — workers step inherits the gate by being part of that job).
+
+**Requirement Refs:** F2
+
+### Phase 4 Completion Checklist
+
+- [ ] All 5 work items complete.
+- [ ] Lab notebook entry created BEFORE first commit (with U2 + U3 resolutions recorded).
+- [ ] Workers coverage gate active.
+- [ ] CI workers integration step green for ≥4/5 consecutive runs.
+- [ ] Branch protection confirmed.
+
+### Definition of Done (Runnable)
+<!-- BEGIN DOD -->
+| Check | Command | Pass Criteria |
+|---|---|---|
+| Workers coverage | `pnpm --filter @open-brain/workers test -- --coverage` | Exit code 0 (thresholds met) |
+| Integration (local) | `docker compose -f docker-compose.test.yml up -d --wait && pnpm --filter @open-brain/workers exec vitest run --config vitest.config.integration.ts` | Exit code 0 |
+| Tests (all) | `pnpm -r test` | Exit code 0 |
+| CI gate | `gh run list --workflow=ci.yml --limit 5` | ≥4/5 green |
+| Branch protection | `gh api repos/davistroy/open-brain/branches/main/protection --jq '.required_status_checks.contexts'` | Includes `"Integration tests (core-api + real DB)"` |
+<!-- END DOD -->
+
+---
+
+## Phase 5: Vitest 2.x Migration (DEFERRED)
+
+**Set:** E
+**Effort:** L
+**Status:** **DEFERRED** to its own implementation plan.
+
+**Rationale:** Vitest 2.x reorganizes `poolOptions` config keys; CLAUDE.md explicitly notes that `pool: 'forks'` with `minForks/maxForks` is required for Windows ioredis/bullmq race avoidance. A116 already tracks this as "Out of scope" pending tooling pass. Bundling here would couple a high-risk migration to low-risk housekeeping and risk taint-by-association if migration flakes.
+
+**Triggering condition for separate plan:** Either (a) a new test feature only available in Vitest 2.x is needed, or (b) a known Vitest 1.6 bug bites. Until then: defer.
+
+**When picked up:** investigate forks-pool compat first via local Windows verification + per-package smoke testing, then write a dedicated plan with explicit rollback gates.
+
+<!-- END PHASES -->
+
+---
+
+<!-- BEGIN TABLES -->
+
+## Parallel Work Opportunities
+
+| Work Item | Can Run In Parallel With | Notes |
+|---|---|---|
+| 1.1, 1.2, 1.3, 1.4 | Each other (within Phase 1) | Independent files; only 1.3 + 1.4 share lockfile commit (sequence at end) |
+| 2.1, 2.2, 2.3 | Each other (within Phase 2) | Different files (README / PRD / TDD); zero overlap |
+| Phase 1 | Phases 2, 3, 4 | No file overlap across phases |
+| Phase 2 | Phases 1, 3, 4 | Doc-only — independent of all code work |
+| Phase 3 | Phases 1, 2 | Type/lint hygiene — distinct files from Phase 1 code paths |
+| Phase 4 | Phases 1, 2, 3 | Workers config + CI — distinct files |
+
+**Recommendation:** sequential 1 → 2 → 3 → 4 in increasing-risk order. Each phase ends with a clean baseline that the next phase tests against.
+
+## Risk Mitigation
+
+| ID | Risk | Severity | Affected Phase | Mitigation | Rollback |
+|---|---|---|---|---|---|
+| R-1 | Removing markdown deps breaks workers via dynamic import | Low | 1 | Pre-flight `grep` (verified zero imports). | `git revert` + `pnpm install` |
+| R-2 | Removing root `@anthropic-ai/sdk` breaks phantom-dep import | Low | 1 | All consumers explicitly declare. Pre-flight cross-package grep. | `git revert` + `pnpm install` |
+| R-3 | N+1 refactor changes response shape | Low | 1 | Existing route tests assert shape. Keep `shapeFileUploadRow()` signature compatible. | `git revert` |
+| R-4 | `BYPASS_CALLERS` hoist drops an entry | Low | 1 | Copy verbatim; integration test 2.4 from arch-review (`rate-limit-public.test.ts`) catches missing entries. | `git revert` |
+| R-5 | Doc updates introduce new factual errors | Low | 2 | Cross-reference every claim against code (docker-compose services, route files, skill registry). | `git revert` |
+| R-6 | `@types/node` downgrade surfaces tsc errors | Medium | 3 | 3.1 pre-flight investigation. Budget 30–60 min for fixes in same PR. If errors > 5, defer and fix-then-pin. | `git revert` + `pnpm install` |
+| R-7 | `eslint-config-next` bump expands A127 baseline | Medium | 3 | Run lint immediately after bump. Goal: zero new errors. If unavoidable, document in CLAUDE.md. | `git revert` |
+| R-8 | Workers coverage threshold breaks build | High → mitigated | 4 | 4.1 measures first; 4.2 sets threshold to baseline floor. | Adjust threshold value (config-only edit) |
+| R-9 | Workers integration tests flake in CI | Medium | 4 | Tests pass locally with `docker-compose.test.yml`. If flake: factor into separate job with `continue-on-error: true` and observe 5 PRs (matches `doc-sync` pattern). | Remove CI step |
+
+## Unknowns Register
+
+| ID | Unknown | Severity | Affected Phase/Item | Resolution Strategy | Status |
+|---|---|---|---|---|---|
+| U1 | How many `@types/node` 25-only API references exist in core-api/voice-capture? | Medium | 3.1, 3.2 | 3.1 pre-flight: branch + downgrade + `tsc --noEmit`; enumerate errors before committing | Open |
+| U2 | What is the current workers test coverage `lines%` and `functions%`? | Medium | 4.1, 4.2 | Run `pnpm --filter @open-brain/workers test -- --coverage` on main; record baseline | Open |
+| U3 | Does `packages/workers/vitest.config.integration.ts` exist? | Low | 4.3, 4.4 | First step of 4.3: file check; create if absent | Open |
+| U4 | Does `eslint-config-next@^16.2.4` introduce lint rules that fail outside `HelpContent.tsx`? | Low | 3.3 | First step of 3.3: bump + lint + count errors | Open |
+| U5 | Authoritative container count for README — 13 (CLAUDE.md "P11a") or 17 (Entry 107)? | Low | 2.1 | `docker compose -f docker-compose.yml config --services \| wc -l` is authoritative | Open |
+
+## Success Metrics
+
+| Metric | Pre-Plan Baseline | Post-Plan Target |
+|---|---|---|
+| Workers integration tests in CI | 0 (none invoked) | 3 (`pipeline`, `ingest-e2e`, `access-stats-e2e`) |
+| Workers coverage gate | None | Threshold pinned to measured baseline floor |
+| Root unused deps | 1 (`@anthropic-ai/sdk`) | 0 |
+| Workers redundant deps | 7 (markdown stack) | 0 |
+| Per-request `Set` allocations in rate-limit middleware | 1 (17-entry Set) | 0 (module-scope) |
+| `@types/node` version drift across packages | 2 (^25.3.5 vs ^22.0.0) | 0 (all ^22.x.x) |
+| `eslint-config-next` lag behind Next.js | 1 major version | 0 |
+| N+1 queries in `GET /api/v1/ingest/uploads` | 21 (1 list + 20 per-row) | 2 (1 list + 1 batched) |
+| README claims contradicting code reality | ≥6 (containers, packages, deferred features, paths) | 0 |
+| PRD features with stale "Planned"/"Deferred" status while shipped | 9 (F19, F21, F22, F29–F35) | 0 |
+| TDD §2.1 false "Required" infrastructure claims | 2 (Jetson, Spark) | 0 |
+
+## Requirement Traceability
+
+| Requirement | Source | Phase | Work Item |
+|---|---|---|---|
+| F1: Align `@types/node` to ^22 | Entry 106 | 3 | 3.1, 3.2, 3.4 |
+| F2: Workers integration tests in CI | Entry 106 | 4 | 4.3, 4.4, 4.5 |
+| F3: Remove redundant markdown deps from workers | Entry 106 | 1 | 1.3 |
+| F4: Remove root `@anthropic-ai/sdk` | Entry 106 | 1 | 1.4 |
+| F5: Bump `eslint-config-next` to ^16 | Entry 106 | 3 | 3.3, 3.4 |
+| F6: Fix N+1 in `GET /api/v1/ingest/uploads` | Entry 106 | 1 | 1.2 |
+| F7: Hoist `BYPASS_CALLERS` to module scope | Entry 106 | 1 | 1.1 |
+| F8: Workers coverage thresholds | Entry 106 | 4 | 4.1, 4.2 |
+| F9: Vitest 2.x migration | Entry 106 | — | **DEFERRED** to separate plan |
+| W1: README container count | Entry 107 | 2 | 2.1 |
+| W2: README references deleted `packages/web` | Entry 107 | 2 | 2.1 |
+| W3: README version/feature status stale | Entry 107 | 2 | 2.1 |
+| W4: PRD F19, F21/F22, F29–F35 status drift | Entry 107 | 2 | 2.2 |
+| W6: Three undocumented packages | Entry 107 | 2 | 2.1, 2.2 |
+| W7: TDD §2.1 Jetson/Spark "Required" | Entry 107 | 2 | 2.3 |
+| S1: 10+ skills absent from PRD | Entry 107 | 2 | 2.2 |
+| S3: extract-commitments undocumented | Entry 107 | 2 | 2.2 |
+| S4: Voice sessions partially documented | Entry 107 | 2 | 2.2 |
+| S5: README PRD/TDD version refs stale | Entry 107 | 2 | 2.1 |
+| R10: morning-brief.ts decomposition | Entry 106 | — | **OUT OF SCOPE** (conditional on adding delivery channels) |
+| S2: A71 memory-consolidation task key | Entry 107 | — | **OUT OF SCOPE** (already tracked in CLAUDE.md) |
+| S7: ingest.ts TODO | Entry 107 | — | **OUT OF SCOPE** (documentation-level placeholder) |
+
+## Milestones
+
+| Milestone | Phases | Indicates |
+|---|---|---|
+| M1: Tech-debt cleared | 1 | Quick wins shipped; root + workers package.json clean |
+| M2: Docs match reality | 2 | README, PRD, TDD reflect code state; intent scorecard ≥9/10 |
+| M3: Type/lint hygiene | 3 | `@types/node` aligned to runtime; eslint-config-next current |
+| M4: Workers test rigor | 4 | Integration tests in CI; coverage gate active |
+
+<!-- END TABLES -->
+
+---
+
+## Deferred Items (Action Item Registry)
+
+Items surfaced during this plan's investigation, with status as of 2026-05-06.
+
+| ID | Description | Status | Location | Unblock / Resolution |
+|----|-------------|--------|----------|----------------------|
+| F9 | Vitest 2.x migration | **DEFERRED** to its own plan | `packages/*/package.json`, `vitest.config.ts` files | Separate plan with Windows forks-pool compat verification first |
+| R10 | `morning-brief.ts` decomposition (XL) | Out of scope | `packages/workers/src/skills/morning-brief.ts` | Trigger condition: adding new brief delivery channels (email, push, etc.) |
+| A71 | memory-consolidation task key rename | Pre-existing | `packages/workers/src/skills/memory-consolidation.ts:348` | Add `memory_consolidation` task key to `config/ai-routing.yaml`; tracked in CLAUDE.md |
+| A125 | `init-schema.sql` migration parity audit | Pre-existing | `scripts/init-schema.sql` | Schema parity sweep — audit init-schema.sql against all `0*.sql` migrations |
+| A128 | TanStack Query hooks extraction (R9 follow-up) | Pre-existing | `packages/web-next/lib/api/` | Separate plan; design work scoped after Phase 8a file split |
+| A127 | 24 `react/no-unescaped-entities` lint errors in `HelpContent.tsx` | Pre-existing baseline | `packages/web-next/src/components/help/HelpContent.tsx` | Tracked since arch-review Phase 7.3; targeted cleanup PR |
+
+### Guidance for future sessions
+
+- **Open items affecting operational behavior:** F9 (test runner upgrade), A71 (skill task routing), A125 (DR-criticality of init-schema parity).
+- **Pre-existing baselines (long-term debt, do not fix in this scope):** A127, A128. Will need targeted cleanup PRs.
+- **Periodic intent review:** every 2–3 months to catch doc drift early. Future skills + features must add PRD F-IDs at ship time to avoid re-accruing this debt.
+
+---
+
+*Source: `/personal-plugin:ultra-plan` invocation following Phase 0–5 analysis on 2026-05-06.*

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -133,6 +133,7 @@
 | D121 | Mobile app: expo-av for voice recording, batch upload to voice-capture:3001 (not streaming) | 2026-04-22 | ACTIVE | Entry 130 | Streaming requires voice-pipecat WebSocket integration — separate project. Batch Whisper is proven. |
 | D122 | Mobile app: jest with babel-jest (not jest-expo preset) for pnpm monorepo compatibility | 2026-04-22 | ACTIVE | Entry 130 | jest-expo setup.js deeply requires react-native internals that fail under pnpm .pnpm hoisting |
 | D123 | Mobile app: TanStack React Query v5 for data layer (not SWR, not custom) | 2026-04-22 | ACTIVE | Entry 130 | Matches web-next pattern, built-in mutations for board patches, staleTime/retry configurable |
+| D124 | Post-remediation baseline: 3.7/5 architectural health, 7/10 intent alignment. No CRITICAL findings. Primary gap is documentation staleness, not structural defects. | 2026-05-06 | ACTIVE | Entry 106, 107 | Full /review-arch + /review-intent audits run post-PR #175/#178/#179; see Entries 106 and 107 for detailed findings and remediation roadmap |
 
 ## Action Items
 
@@ -10145,3 +10146,178 @@ Tags: [web] [refactor] [deletion] [ci]
 - TypeScript: 0 errors across all packages post-deletion
 
 **Duration:** ~30 min (4 rounds, parallel where possible)
+
+---
+
+### Entry 106 — Post-Remediation Architectural Audit [architecture] [audit]
+**Date:** 2026-05-06
+**Environment:** Local (post-PR #175, #178, #179 merge)
+**Objective:** Baseline architectural health assessment after R1-R12 remediation arc completion.
+
+**Architecture Scorecard:**
+| Dimension | Rating | Notes |
+|---|---|---|
+| Structure & Organization | 4/5 | Clean star-topology, proper service layer, bounded ingest.ts exception |
+| Code Quality | 4/5 | Large files well-structured, consistent skill/query split pattern |
+| Dependency Management | 3/5 | @types/node mismatch, redundant declarations, vitest 1.6 vs 2.x |
+| Testing | 3/5 | Strong core-api (80% thresholds), workers integration tests not in CI |
+| Security | 4/5 | Timing-safe tokens, fail-closed, IP-gated bypass, no hardcoded secrets |
+| Performance & Scalability | 4/5 | Optimized search hot path, one N+1 in low-traffic endpoint |
+| **Overall** | **3.7/5** | Sound fundamentals, finishing-quality debt remaining |
+
+**Findings:**
+
+**F1 — @types/node version mismatch (MEDIUM)**
+core-api + voice-capture declare @types/node ^25.3.5; web-next declares ^22.0.0. Runtime is Node 22. Node 25 types expose APIs that don't exist on Node 22 runtime — type-clean builds could fail at runtime. Two separate resolution trees confirmed in pnpm-lock.yaml.
+Location: packages/core-api/package.json:46, packages/voice-capture/package.json:29, packages/web-next/package.json:30
+
+**F2 — Workers integration tests not in CI (MEDIUM)**
+CI integration-test job runs only core-api integration tests. Three workers integration tests (pipeline.test.ts, ingest-e2e.test.ts, access-stats-e2e.test.ts) exist but are never invoked in GitHub Actions. BullMQ pipeline job chain has no automated regression guard.
+Location: packages/workers/src/__tests__/integration/, .github/workflows/ci.yml
+
+**F3 — Markdown/XSS ecosystem declared in both shared and workers (LOW)**
+remark-parse, remark-rehype, rehype-slug, rehype-stringify, rehype-autolink-headings, xss, unified declared in both packages. Only shared uses them (brief-renderer.ts). Workers declarations are redundant — doubled install, confusing ownership.
+Location: packages/shared/package.json, packages/workers/package.json
+
+**F4 — @anthropic-ai/sdk orphaned in root package.json (LOW)**
+Root package.json declares @anthropic-ai/sdk ^0.39.0 as a dependency. No root-level TS file imports it. SDK is independently declared in shared, core-api, workers, voice-capture.
+Location: /package.json:31
+
+**F5 — eslint-config-next version behind Next.js (LOW)**
+eslint-config-next ^15.0.0 vs next ^16.2.4. Next 16 lint rules silently missing.
+Location: packages/web-next/package.json:39
+
+**F6 — N+1 query in GET /api/v1/ingest/uploads (LOW)**
+shapeFileUploadRow() issues one SELECT per upload row (max 20 per page). Negligible at current scale but structurally wrong.
+Fix: collect all capture_ids, issue one inArray query, build lookup map.
+Location: packages/core-api/src/routes/ingest.ts:435, lines 156-189
+
+**F7 — BYPASS_CALLERS Set rebuilt on every request (LOW)**
+new Set([...17 entries...]) constructed inside middleware closure on every HTTP request. Should be module-scope const.
+Location: packages/core-api/src/middleware/rate-limit.ts:274-296
+
+**F8 — Workers package has no coverage thresholds (LOW)**
+Core-api enforces 80% line/function coverage. Workers has no thresholds despite housing 24 skills and all BullMQ job processors.
+Location: packages/workers/vitest.config.ts
+
+**F9 — Vitest 1.6.1 with 2.x available (LOW)**
+Major-version lag on primary test runner. v2 adds improved pool handling. Windows forks-pool compat needs verification before upgrade.
+
+**Remediation Roadmap:**
+- Quick wins (S): R1 hoist BYPASS_CALLERS, R2 remove root @anthropic-ai/sdk, R3 remove redundant markdown deps from workers, R4 bump eslint-config-next to ^16
+- Short-term (M): R5 add workers integration tests to CI, R6 fix N+1 in ingest/uploads, R7 add workers coverage thresholds
+- Strategic (L): R8 align @types/node to ^22 across all packages, R9 vitest 2.x migration
+- Long-term (XL): R10 morning-brief.ts decomposition (only if adding delivery channels)
+
+---
+
+### Entry 107 — Post-Remediation Intent Review [docs] [audit]
+**Date:** 2026-05-06
+**Environment:** Local (post-PR #175, #178, #179 merge)
+**Objective:** Compare original project intent (PRD, TDD, README) against current implementation to surface documentation drift and scope tracking gaps.
+
+**Intent Scorecard:**
+| Dimension | Score | Status |
+|---|---|---|
+| Feature Completeness | 8/10 | All Must/Should features shipped; 4 genuinely deferred (F24, F25, F26, F27) |
+| Architecture Alignment | 9/10 | Stack matches TDD; one stale infrastructure description |
+| Documentation Accuracy | 4/10 | README wrong on container count, packages, feature status; PRD 9 features misstated |
+| Scope Discipline | 7/10 | 10+ undocumented skills + 3 undocumented packages; all coherent, none bloat |
+| Overall Intent Alignment | 7/10 | Building the right thing; docs haven't kept pace |
+
+**WARNING Findings:**
+
+**W1 — README container count wrong by 2x**
+README states "9 containers." Reality: 17 active services in docker-compose.yml. Missing: voice-pipecat, file-ingestion, web-next, financial-ingest, utility-ingest, loki, pushgateway, prometheus, grafana, cloudflared.
+
+**W2 — README references deleted packages/web**
+README lines 44-45 reference packages/web/ in monorepo layout. Lines 271-272 reference packages/web/src/content/USER_QUICK_START.md and USER_GUIDE.md. Both paths deleted in PR #175.
+
+**W3 — README version/status description stale**
+README line 6: "v1.5.0" and architecture table still lists open-brain-web with Vite/React/shadcn stack. System has grown substantially since this was written.
+
+**W4 — README falsely states F21/F22 have "no handler code"**
+README lines 159-160 under "Deferred Features": daily-connections and drift-monitor listed as "Removed from KNOWN_SKILLS; no handler code." Both are fully implemented with cron schedules (daily-connections at 6:10 AM, drift-monitor at 7:15 AM), registered in skill-config.ts DEFAULT_SKILLS, and have dedicated query modules.
+
+**W5 — PRD F29-F35 marked "Planned" but all implemented**
+PRD table marks F29 (Queue Management), F30 (Trigger Delete Fix), F31 (Skill Schedule Editing), F32 (Dark Mode), F33 (Settings Reorganization), F34 (Help Page), F35 (Slack Channel Cleanup) as "Planned." Code confirms all shipped months ago.
+
+**W6 — Three undocumented packages in monorepo**
+voice-pipecat (Python, Pipecat VAD→Deepgram STT→Claude LLM→TTS), file-ingestion (Python, FastAPI file extraction), mobile (Expo React Native) — none in README or PRD. voice-pipecat and file-ingestion are in docker-compose.yml as active services.
+
+**W7 — TDD §2.1 lists Jetson/Spark as "Required"**
+TDD describes Jetson GPU and DGX Spark as "Required" infrastructure. Current runtime uses OpenAI API directly for all inference. Jetson/Spark are optional cost-saving tiers in ai-routing.yaml, not prerequisites.
+
+**SUGGESTION Findings:**
+
+**S1 — 10+ skills implemented but absent from PRD**
+monthly-reflection, morning-brief, capture-reminder (morning + evening), cost-analysis, container-health, storage-audit, secret-rotation, capture-dedup-sweep, refine-brief, entity-brief — all well-implemented, no PRD feature IDs.
+
+**S2 — Known TODO: memory-consolidation task key (A71)**
+workers/src/skills/memory-consolidation.ts:348 — pre-existing known deferral, correctly documented in CLAUDE.md.
+
+**S3 — extract-commitments job undocumented**
+Full LLM-based commitment extraction pipeline with dedicated commitments table, API routes, status filters — no PRD feature entry.
+
+**S4 — Voice sessions / Pipecat integration partially documented**
+core-api/src/routes/voice-sessions.ts provides full REST API for Pipecat voice session lifecycle. Infrastructure substantially built; soak test is the outstanding gap.
+
+**S5 — README PRD/TDD version references stale**
+README references PRD as v0.6 (actual: v0.7), TDD as v0.6 (actual: v0.7).
+
+**S6 — F19 description wrong in PRD**
+PRD lists F19 as "Web dashboard (Vite + React PWA)" — now Next.js 16 + Cloudscape + React 19, and packages/web is deleted.
+
+**S7 — ingest.ts TODO is documentation-level**
+Code comment explaining intentional placeholder; not a functional regression.
+
+**Quantitative Summary:**
+- PRD features defined: 35 (F01-F35)
+- PRD Must/Should implemented: 30/30
+- PRD features marked "Planned" but shipped: 7 (F29-F35)
+- PRD features marked "Deferred" but shipped: 2 (F21, F22)
+- Skills not in PRD: 10+
+- Packages not in README: 4
+- Active containers vs README stated: 17 vs 9
+- Implemented routes not in PRD: 9
+
+**Recommendations:**
+1. README rewrite (1 session) — container table, package layout, feature status, version refs
+2. PRD feature table update (1 hour) — fix 9 status errors, update F19, add IDs for undocumented capabilities
+3. TDD §2.1 — demote Jetson/Spark from "Required" to "Optional cost-saving tier"
+4. Scope decisions — document voice-pipecat transition plan, mobile package status, F24 roadmap decision
+
+---
+
+--- New session: 2026-05-06 — Post-remediation Phase 1 quick wins ---
+
+### Entry 131 — Post-Remediation Phase 1: deps + perf microfixes [api] [pipeline] [config] [testing]
+**Date:** 2026-05-06
+**Environment:** Local laptop (`C:\Users\Troy Davis\dev\personal\open-brain`), branch `main` behind `origin/main` by 2 commits. Pre-existing worktree state before this entry: `LAB_NOTEBOOK.md` modified; `IMPLEMENTATION_PLAN-POST-REMEDIATION.md` and `OPEN_ITEMS.md` untracked.
+**Objective:** Execute Phase 1 of `IMPLEMENTATION_PLAN-POST-REMEDIATION.md`: hoist `BYPASS_CALLERS`, fix the `GET /api/v1/ingest/uploads` N+1 capture lookup, remove redundant markdown/XSS deps from workers, and remove orphaned root `@anthropic-ai/sdk`.
+**Hypothesis:** The four quick wins are low-risk and behavior-preserving. Success criteria: all 17 internal bypass caller entries remain verbatim; upload list response shape stays unchanged while capture lookup drops from per-row SELECTs to one batched SELECT; `packages/workers/package.json`, root `package.json`, and `pnpm-lock.yaml` stay synchronized; targeted core-api/workers build/test checks and `pnpm install --frozen-lockfile` pass.
+**Rollback plan:** Revert this Phase 1 changeset with `git revert` (or restore the touched files from the pre-change branch state) and run `pnpm install` to restore `pnpm-lock.yaml` if dependency removals need to be undone.
+**Duration:** ~25 min.
+
+**Results log:**
+- Pre-flight read-only review complete before modifying application files. Source docs read in requested order: `OPEN_ITEMS.md`, `IMPLEMENTATION_PLAN-POST-REMEDIATION.md`, `CLAUDE.md`, then LAB_NOTEBOOK Entry 106 and Entry 107.
+- Worktree pre-flight: `git status --short --branch` showed `main...origin/main [behind 2]`, modified `LAB_NOTEBOOK.md`, and untracked `IMPLEMENTATION_PLAN-POST-REMEDIATION.md` + `OPEN_ITEMS.md`. No attempt made to pull, reset, or push.
+- Workers markdown import pre-flight: `Select-String -Path 'packages\workers\src\**\*.ts' -Pattern 'import.*(remark|rehype|unified|xss)'` returned zero matches.
+- Root Anthropic import pre-flight: root-level `*.ts/*.tsx/*.mts/*.cts` search for `@anthropic-ai/sdk` returned zero matches. Cross-package imports also returned zero matches; package declarations remain independent per the Entry 106 finding.
+- Code edit 1.1: moved the 17-entry `BYPASS_CALLERS` Set from inside `rateLimit()` to module scope in `packages/core-api/src/middleware/rate-limit.ts`; preserved every entry verbatim and added `// Module-scope: constructed once, not per-request.`
+- Code edit 1.2: updated `packages/core-api/src/routes/ingest.ts` so `GET /api/v1/ingest/uploads` collects unique `capture_ids`, issues one batched `captures` select, builds a `Map`, and passes it to `shapeFileUploadRow()` instead of issuing one capture lookup per upload row. Single-upload detail still falls back to the existing on-demand lookup.
+- Dependency edit 1.3: `pnpm --filter @open-brain/workers remove remark-parse remark-rehype rehype-slug rehype-stringify rehype-autolink-headings unified xss` exited 0. Warnings were existing ecosystem noise: `node_modules` present, deprecated transitive deps, and mobile peer warnings.
+- Dependency edit 1.4: `pnpm remove -w @anthropic-ai/sdk` exited 0 and removed the root dependency. Root `devDependencies` remained `tsx` and `vitest`; pnpm reordered those keys only.
+- Post-removal manifest checks: workers package no longer declares the seven markdown/XSS deps; root `package.json` no longer declares `@anthropic-ai/sdk`; `pnpm-lock.yaml` importer sections for root and workers changed in lockstep. Shared/core-api/workers/voice-capture package-owned Anthropic declarations remain untouched.
+- Verification: `pnpm --filter @open-brain/core-api exec tsc --noEmit` exited 1 on known pre-existing A106 baseline: `src/__tests__/entity-resolution.test.ts(345,59): error TS2502: 'tx' is referenced directly or indirectly in its own type annotation.` No Phase 1 touched-file errors surfaced before that baseline failure.
+- Verification: `pnpm --filter @open-brain/core-api exec vitest run src/__tests__/rate-limit.test.ts src/__tests__/ingest-routes.test.ts` exited 0. Result: 2 test files passed, 67 tests passed.
+- Verification: `pnpm --filter @open-brain/core-api build` exited 0. `tsup` ESM and DTS builds succeeded.
+- Verification: `pnpm --filter @open-brain/workers build` exited 0. Both `src/index.ts` and `src/main.ts` tsup builds succeeded.
+- Verification: `pnpm --filter @open-brain/workers test` exited 0. Result: 51 test files passed, 1,021 tests passed. Logged warn/error lines are expected test fixtures for failure-path behavior.
+- Verification: `pnpm install --frozen-lockfile` exited 0. Lockfile is up to date; resolution step skipped.
+- Verification: `pnpm --filter @open-brain/shared build` exited 0; `pnpm --filter @open-brain/shared test` exited 0 with 18 test files passed and 336 tests passed.
+- Verification: `pnpm --filter @open-brain/voice-capture build` exited 0; `pnpm --filter @open-brain/voice-capture test` exited 0 with 5 test files passed and 82 tests passed.
+- Verification: BYPASS caller audit counted 17 quoted `internal:*` entries in `packages/core-api/src/middleware/rate-limit.ts`: `integration-test`, `web-ui`, `email-worker`, `financial-pipeline`, `utility-pipeline`, `ingest`, `slack-bot`, `voice-capture`, `memory-consolidation`, `workers`, `email-classify`, `email-compose-skill`, `batch-wiki-ingest`, `email-pipeline`, `ingest-onedrive`, `ingest-repair`, `newsletter-pipeline`.
+- Verification: final workers markdown import grep returned zero matches.
+- Verification attempt: `pnpm test:integration` exited 1 before tests ran because Docker Desktop is not running/available on this laptop (`failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine`). No containers were started.
+- Outcome: Phase 1 code/dependency work completed locally. No commits created and nothing pushed.

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10321,3 +10321,7 @@ Code comment explaining intentional placeholder; not a functional regression.
 - Verification: final workers markdown import grep returned zero matches.
 - Verification attempt: `pnpm test:integration` exited 1 before tests ran because Docker Desktop is not running/available on this laptop (`failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine`). No containers were started.
 - Outcome: Phase 1 code/dependency work completed locally. No commits created and nothing pushed.
+- Git: created branch `codex/post-remediation-phase-1`; staged Phase 1 files plus `OPEN_ITEMS.md` and `IMPLEMENTATION_PLAN-POST-REMEDIATION.md`; committed local change as `8775eec` (`chore: post-remediation phase 1 quick wins`). No push.
+- Verification retry: started Docker Desktop, confirmed Docker engine `29.4.1`.
+- Verification attempt: `pnpm test:integration` exited 0 but did not run core-api integration tests on Windows. Root cause: the root package script's shell separator caused pnpm to look for a package script named `test:integration;`. Follow-up tracked as A129 in `OPEN_ITEMS.md`; do not fix in Phase 1.
+- Verification: explicit Windows-safe sequence `docker compose -f docker-compose.test.yml up -d --wait; pnpm --filter @open-brain/core-api test:integration; docker compose -f docker-compose.test.yml down -v` exited 0. Result: 7 integration test files passed, 126 tests passed. Test containers and network were removed afterward.

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10325,3 +10325,26 @@ Code comment explaining intentional placeholder; not a functional regression.
 - Verification retry: started Docker Desktop, confirmed Docker engine `29.4.1`.
 - Verification attempt: `pnpm test:integration` exited 0 but did not run core-api integration tests on Windows. Root cause: the root package script's shell separator caused pnpm to look for a package script named `test:integration;`. Follow-up tracked as A129 in `OPEN_ITEMS.md`; do not fix in Phase 1.
 - Verification: explicit Windows-safe sequence `docker compose -f docker-compose.test.yml up -d --wait; pnpm --filter @open-brain/core-api test:integration; docker compose -f docker-compose.test.yml down -v` exited 0. Result: 7 integration test files passed, 126 tests passed. Test containers and network were removed afterward.
+
+### Entry 132 — PR #180 GitHub CI remediation: mobile lint baseline [mobile] [deps] [testing]
+**Date:** 2026-05-06
+**Environment:** Local laptop (`C:\Users\Troy Davis\dev\personal\open-brain`), branch `codex/post-remediation-phase-1`, PR #180 open and pushed at `1cd7c73`.
+**Objective:** Fix all GitHub-identified failures on PR #180 before merge. Current GitHub findings: both failed `build-and-test` jobs stop at `packages/mobile lint`; all integration, Python, doc sync, schema, and GitGuardian checks pass.
+**Hypothesis:** The mobile lint failure is caused by the mobile package pinning `react-test-renderer` and `@types/react-test-renderer` to React 19.0-era packages while the app itself uses React 19.1. Aligning the test renderer packages with React 19.1 should remove the duplicate `@types/react@19.0.14` type universe and make the existing tests type-check without behavior changes.
+**Rollback plan:** Revert the mobile dependency alignment and lockfile changes, then rerun `pnpm install --frozen-lockfile` and `pnpm --filter @open-brain/mobile lint` to restore and verify the prior baseline if the fix introduces new failures.
+**Duration:** ~35 min.
+
+**Results log:**
+- GitHub pre-flight: `gh pr checks 180` showed only two failing checks, both named `build-and-test`; `gh pr view 180` showed no review comments or PR comments.
+- Failed job log review: both `build-and-test` jobs fail during `packages/mobile lint` with TS2345 errors in `__tests__/components/MPill.test.tsx` and `__tests__/components/TabBar.test.tsx`.
+- Local reproduction: `pnpm --filter @open-brain/mobile lint` reproduced the same TS2345 errors.
+- Dependency audit: `pnpm --filter @open-brain/mobile why @types/react` showed direct `@types/react@19.1.17` plus transitive `@types/react@19.0.14` from `@types/react-test-renderer@19.0.0`; `pnpm --filter @open-brain/mobile why react-test-renderer` showed direct `react-test-renderer@19.0.0` while `jest-expo` already brings `react-test-renderer@19.1.0`.
+- Dependency fix: updated `packages/mobile` dev dependencies to `react-test-renderer@19.1.0` and `@types/react-test-renderer@^19.1.0`; committed the matching `pnpm-lock.yaml` change.
+- Verification: `pnpm --filter @open-brain/mobile lint` exited 0 after dependency alignment.
+- Verification: `pnpm install --frozen-lockfile` exited 0.
+- Verification: CI build sequence exited 0: `pnpm --filter @open-brain/shared build`, then `pnpm --filter "!@open-brain/shared" -r build`.
+- Follow-on lint finding: full `pnpm -r lint` then advanced past mobile and exposed the known core-api A106 test type issue in `entity-resolution.test.ts` line 345 (`tx` referenced directly or indirectly in its own type annotation).
+- Core-api lint fix: added a local `type TxMock = typeof tx` alias before the mocked transaction callback and used that alias in the callback signature, preserving runtime test behavior.
+- Verification: full `pnpm -r lint` exited 0.
+- Verification note: plain local `pnpm -r test` timed out because at least one test command is watch-mode sensitive outside CI. Stale pnpm/vitest test processes from that timeout were stopped.
+- Verification: `$env:CI='true'; pnpm -r test` exited 0, matching GitHub Actions behavior for the Node test step.

--- a/OPEN_ITEMS.md
+++ b/OPEN_ITEMS.md
@@ -1,0 +1,133 @@
+# Open Items Registry
+
+**Purpose:** Single index of what's actually open across all implementation plans. Each entry links to the source plan for detail. Update when plans ship items or new plans land.
+
+**Last refreshed:** 2026-05-06
+
+---
+
+## Active plans (with pending work)
+
+### [IMPLEMENTATION_PLAN-POST-REMEDIATION.md](IMPLEMENTATION_PLAN-POST-REMEDIATION.md) — all pending
+
+**Scope:** F1–F8 (Entry 106 architectural audit) + W1, W2, W3, W4, W7, S1, S3, S4, S5, W6 (Entry 107 intent review). Authored 2026-05-06.
+
+| Phase | Items | Effort | Risk |
+|---|---|---|---|
+| 1 — Quick wins (deps + perf microfixes) | 4 | S | Low |
+| 2 — Documentation alignment (README + PRD + TDD) | 3 | M | None |
+| 3 — Type system & lint hygiene | 4 | S–M | Med |
+| 4 — Workers test rigor (coverage + CI) | 5 | M | Med |
+| 5 — Vitest 2.x migration | — | L | **DEFERRED** to its own plan |
+
+**Total:** 16 work items pending. Phases 1–4 mutually independent (no file overlap); recommended sequential 1→2→3→4 in increasing-risk order.
+
+---
+
+### [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md) — LLM model consolidation — verification residue
+
+**Scope:** Move hardcoded LLM model references into `config/ai-routing.yaml`. Authored 2026-04-21.
+
+**Real status:** Implementation looks done — `[x]` checkboxes for code changes; `[ ]` checkboxes are verification boxes ("existing tests pass") that haven't been ticked. Most likely the work shipped and box-ticking lapsed.
+
+| Phase | Status | Action |
+|---|---|---|
+| 1.1 — Add missing task_routing entries | Code likely done; verification box unticked | Run `pnpm --filter @open-brain/core-api test` and tick if green |
+| 1.2 — Wire configService to wiki-ingest | Code done (3/4 boxes); test box unticked | Same |
+| 1.3 — Wire configService to wiki-lint | Same shape | Same |
+| 1.4 — Wire configService to monthly-reflection | Same shape | Same |
+| 1.6 — Update tests for new model resolution | Verification sweep | Run full test suite, tick |
+| Phase 2 verification | TypeScript clean + grep for hardcoded models | One-shot audit |
+
+**Recommendation:** ~30-min close-out session — run tests, grep, tick boxes, mark plan COMPLETE.
+
+---
+
+### [IMPLEMENT_MASTER_PLAN.md](IMPLEMENT_MASTER_PLAN.md) + [PHASED_PLAN.md](PHASED_PLAN.md) — 5 gated tail items
+
+**Scope:** Master roadmap (Arcs 0–5) and 45-PR phased rollout. ~85% of items shipped via PRs P01–P32 + Cloudscape arc; tail items are all gated by external triggers.
+
+| Item | Source | Gate | Effort |
+|---|---|---|---|
+| P23 — Cognitive memory tuning | Master 4C / Phased Wave 5 | **Data-gated:** ≥4 weeks search activity since P06 producer wiring (2026-04-19). Earliest start ~2026-05-17. | S |
+| P24 — Pipecat voice soak test | Master 0D / Phased Wave 6 | **Manual:** 2-week structured conversation soak; needs Troy time. | Manual / 2 wk |
+| P25 — Voice architecture decision | Master 1C / Phased Wave 6 | **Depends on P24** results. Likely "keep both unless Pipecat gains HTTP upload". | S |
+| P33 — Qdrant evaluation | Phased Wave 9 | **Scale-gated:** fires when embeddings count ≥ 50K (currently ~11K). | M |
+| P34 — RTX PRO 2000 deployment | Master 5A / Phased Wave 9 | **Hardware:** purchase decision; eliminates API embedding cost when local. | Hardware / 1 wk |
+
+**Plus stragglers from Master Plan:** "Observability & Monitoring" + "LiteLLM Cost Routing" already substantially shipped (Loki, Grafana, Prometheus live; LiteLLM retired in CS5) — likely close-out items.
+
+---
+
+### Mobile deferred — see [mobile-app-deferred.md](~/.claude/projects/.../memory/mobile-app-deferred.md) memory
+
+**Scope:** Mobile app blueprint at `docs/superpowers/plans/2026-04-22-mobile-app.md` shipped via PR #172 (11 screens) + PR #174 (Expo SDK 54 upgrade). Items intentionally deferred from that initial release:
+
+| Item | Notes |
+|---|---|
+| Streaming transcript UI | Real-time transcript display during voice capture |
+| Push notifications | iOS/Android push for proactive briefings |
+| EAS Build | TestFlight / production app store distribution |
+| Cloudflare Tunnel for voice | Voice endpoint not yet behind tunnel (mobile uses Bearer auth) |
+| Shared types export path | `@open-brain/shared` types accessible to mobile |
+| Web `Voice.tsx` field bug | Pre-existing bug in deleted `packages/web` — irrelevant after Phase 8b deletion |
+
+**Source plan:** `docs/superpowers/plans/2026-04-22-mobile-app.md` (3,936 lines — blueprint, not work-tracking; the 80 task items in it are mostly shipped per git log).
+
+---
+
+## Tracked action items — arch-review registry
+
+From [IMPLEMENTATION_PLAN-ARCH-REVIEW.md §Deferred Items](IMPLEMENTATION_PLAN-ARCH-REVIEW.md#deferred-items-action-item-registry). Most A-numbers are CLOSED; below is the active subset:
+
+| ID | Description | Class | Trigger to address |
+|---|---|---|---|
+| A71 | memory-consolidation task key (`'search_synthesis'` placeholder; real key `'memory_consolidation'` not in `ai-routing.yaml`) | Operational | ~1 hr filler work |
+| A107 | `strictLimiter` double-registered on `/captures` (halves effective rate-limit budget) | Operational | Phase 5 D candidate |
+| A110 | Settings `GET` has no whitelist gate — non-whitelisted key returns 404 instead of 400 | Operational | Future scope |
+| A111 | `email_allowlist` has no array validator in `SETTINGS_VALIDATORS` | Operational | With A110 |
+| A113 | UUID validation on briefs/sessions `:id` path param | Operational | Future scope |
+| A114 | `sessions` `status_filter` silently dropped instead of 400-rejected | Operational | Future scope |
+| A125 | `init-schema.sql` missing migration 0025 CHECK constraints (parity audit) | Operational | Schema parity sweep |
+| A127 | 24 `react/no-unescaped-entities` lint errors in `HelpContent.tsx` | Pre-existing baseline | Targeted cleanup PR |
+| A128 | TanStack Query hooks extraction (Phase 8a follow-up) | Pre-existing baseline | Separate plan; design work |
+| A116 | Vitest 2.x bump for per-file glob threshold support | Pre-existing baseline | See post-remediation Phase 5 (deferred) |
+| A117 | SSE `onAbort` / post-promise cleanup branches unreachable | Pre-existing baseline | Excluded via `/* v8 ignore */` |
+| A106 | TS2502 in `entity-resolution.test.ts:345` | Pre-existing baseline | Out of scope |
+| A120 | TS2345 in `MPill.test.tsx` + `TabBar.test.tsx` (React 19 / react-test-renderer drift) | Pre-existing baseline | Separate PR |
+
+**Operational items (7):** real follow-ups that should land in a future plan.
+**Pre-existing baselines (6):** long-term debt; do not bundle into operational work.
+
+---
+
+## Recently-closed plans (archive references)
+
+| Plan | Status | Closed | Notes |
+|---|---|---|---|
+| [IMPLEMENTATION_PLAN-ARCH-REVIEW.md](IMPLEMENTATION_PLAN-ARCH-REVIEW.md) | ✅ COMPLETE | PR #175 (2026-05-05) | R1–R12 (R10 dropped); 9 phases |
+| [IMPLEMENTATION_PLAN-CLOUDSCAPE-M2.md](IMPLEMENTATION_PLAN-CLOUDSCAPE-M2.md) | ✅ COMPLETE | 2026-04-21 | 8/8 phases, 41 work items |
+| [IMPLEMENTATION_PLAN-CLOUDSCAPE-M3.md](IMPLEMENTATION_PLAN-CLOUDSCAPE-M3.md) | ✅ COMPLETE | 2026-04-22 (PR #170) | 8/8 phases; entity-brief, commitments, board, settings, onboarding |
+| [IMPLEMENTATION_PLAN-CLOUDSCAPE-M4.md](IMPLEMENTATION_PLAN-CLOUDSCAPE-M4.md) | ✅ COMPLETE | 2026-04-22 | 4/4 phases, 8 work items |
+| Mobile app blueprint (`docs/superpowers/plans/2026-04-22-mobile-app.md`) | ✅ Substantially SHIPPED | PR #172 (2026-04-22) + PR #174 | 11 screens; deferred items tracked in `mobile-app-deferred.md` |
+
+---
+
+## Cross-plan interaction notes
+
+| Risk | Detail |
+|---|---|
+| **Post-remediation Phase 3 (`@types/node` align) ↔ Mobile deferred** | If picking up mobile EAS Build before post-remediation Phase 3 lands, ensure mobile package isn't pinned at a different `@types/node`. |
+| **Post-remediation Phase 4 (workers CI) ↔ A128 (TanStack Query)** | Both touch testing infrastructure; sequence post-remediation first since it's smaller scope. |
+| **A71 (memory-consolidation task key) ↔ Post-remediation Phase 2** | Phase 2 PRD update should add the F-ID for memory-consolidation skill; A71 fix is independent (config edit) but worth bundling for one PR. |
+| **P23 (cognitive memory tuning) ↔ A107 (strictLimiter double-reg)** | P23 measures live search behavior; A107 affects rate-limit effective budget — fix A107 before P23 starts to keep measurement clean. |
+
+---
+
+## Maintenance
+
+- **When a plan ships:** mark COMPLETE here with closure date + PR number; move plan reference to "Recently-closed" section.
+- **When a new plan lands:** add an entry to "Active plans" with a 1–2 line summary + link.
+- **When an action item closes:** strike it from the table OR move to a separate "Closed action items" section if pattern emerges.
+- **Authoritative source:** each row in this file links to the plan that owns the work. This file is an index, not a substitute. Detail lives in the source plan.
+- **Memory pointer:** add a single line to `~/.claude/projects/<path>/memory/MEMORY.md` pointing to this file so it's discoverable across sessions.

--- a/OPEN_ITEMS.md
+++ b/OPEN_ITEMS.md
@@ -91,12 +91,13 @@ From [IMPLEMENTATION_PLAN-ARCH-REVIEW.md §Deferred Items](IMPLEMENTATION_PLAN-A
 | A125 | `init-schema.sql` missing migration 0025 CHECK constraints (parity audit) | Operational | Schema parity sweep |
 | A127 | 24 `react/no-unescaped-entities` lint errors in `HelpContent.tsx` | Pre-existing baseline | Targeted cleanup PR |
 | A128 | TanStack Query hooks extraction (Phase 8a follow-up) | Pre-existing baseline | Separate plan; design work |
+| A129 | Root `pnpm test:integration` script is not Windows-safe; PowerShell/pnpm parsed `test:integration;` as a script name, so use explicit compose up → package test → compose down sequence locally | Operational | Cross-platform script cleanup PR |
 | A116 | Vitest 2.x bump for per-file glob threshold support | Pre-existing baseline | See post-remediation Phase 5 (deferred) |
 | A117 | SSE `onAbort` / post-promise cleanup branches unreachable | Pre-existing baseline | Excluded via `/* v8 ignore */` |
 | A106 | TS2502 in `entity-resolution.test.ts:345` | Pre-existing baseline | Out of scope |
 | A120 | TS2345 in `MPill.test.tsx` + `TabBar.test.tsx` (React 19 / react-test-renderer drift) | Pre-existing baseline | Separate PR |
 
-**Operational items (7):** real follow-ups that should land in a future plan.
+**Operational items (8):** real follow-ups that should land in a future plan.
 **Pre-existing baselines (6):** long-term debt; do not bundle into operational work.
 
 ---

--- a/package.json
+++ b/package.json
@@ -27,11 +27,8 @@
       ]
     }
   },
-  "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0"
-  },
   "devDependencies": {
-    "vitest": "^1.6.0",
-    "tsx": "^4.7.0"
+    "tsx": "^4.7.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/core-api/src/__tests__/entity-resolution.test.ts
+++ b/packages/core-api/src/__tests__/entity-resolution.test.ts
@@ -334,6 +334,7 @@ describe('EntityResolutionService.merge', () => {
       update: txUpdate,
       delete: txDelete,
     }
+    type TxMock = typeof tx
 
     let selectCallCount = 0
     const db = {
@@ -342,7 +343,7 @@ describe('EntityResolutionService.merge', () => {
         if (selectCallCount === 1) return selectChain([sourceEntity])  // source lookup
         return selectChain([targetEntity])  // target lookup
       }),
-      transaction: vi.fn().mockImplementation((callback: (tx: typeof tx) => Promise<unknown>) => callback(tx)),
+      transaction: vi.fn().mockImplementation((callback: (tx: TxMock) => Promise<unknown>) => callback(tx)),
     }
 
     const service = new EntityResolutionService(db as any)

--- a/packages/core-api/src/middleware/rate-limit.ts
+++ b/packages/core-api/src/middleware/rate-limit.ts
@@ -30,6 +30,31 @@ export const RATE_LIMIT_TIERS = {
   mobile: { maxRequests: 200, windowMs: 60_000 },
 } as const satisfies Record<string, RateLimitConfig>
 
+// Module-scope: constructed once, not per-request.
+const BYPASS_CALLERS = new Set([
+  'internal:integration-test',
+  'internal:web-ui',
+  'internal:email-worker',
+  'internal:financial-pipeline',
+  'internal:utility-pipeline',
+  // CS3 — batch ingest sidecar + ingest-process worker callbacks
+  'internal:ingest',
+  // P07 — new internal service callers
+  'internal:slack-bot',
+  'internal:voice-capture',
+  'internal:memory-consolidation',
+  'internal:workers',
+  // P07 — callers that already set the header but were missing from bypass
+  'internal:email-classify',
+  'internal:email-compose-skill',
+  'internal:batch-wiki-ingest',
+  'internal:email-pipeline',
+  'internal:ingest-onedrive',
+  'internal:ingest-repair',
+  // P21 — financial advisor newsletter assessment pipeline (open-brain-vm cron)
+  'internal:newsletter-pipeline',
+])
+
 /** Sliding window entry: list of request timestamps within the current window */
 interface WindowEntry {
   timestamps: number[]
@@ -271,29 +296,6 @@ export function rateLimit(limiter: RateLimiter, mobileLimiter?: RateLimiter): Mi
     // Bypass rate limiting for trusted internal callers.
     // mobile-app removed in Phase 6 (R8) — now authenticated via Bearer
     // (mobile-auth middleware) and rate-limited via the 'mobile' tier instead.
-    const BYPASS_CALLERS = new Set([
-      'internal:integration-test',
-      'internal:web-ui',
-      'internal:email-worker',
-      'internal:financial-pipeline',
-      'internal:utility-pipeline',
-      // CS3 — batch ingest sidecar + ingest-process worker callbacks
-      'internal:ingest',
-      // P07 — new internal service callers
-      'internal:slack-bot',
-      'internal:voice-capture',
-      'internal:memory-consolidation',
-      'internal:workers',
-      // P07 — callers that already set the header but were missing from bypass
-      'internal:email-classify',
-      'internal:email-compose-skill',
-      'internal:batch-wiki-ingest',
-      'internal:email-pipeline',
-      'internal:ingest-onedrive',
-      'internal:ingest-repair',
-      // P21 — financial advisor newsletter assessment pipeline (open-brain-vm cron)
-      'internal:newsletter-pipeline',
-    ])
     if (BYPASS_CALLERS.has(key)) {
       await next()
       return

--- a/packages/core-api/src/routes/ingest.ts
+++ b/packages/core-api/src/routes/ingest.ts
@@ -52,6 +52,11 @@ import {
 /** Hard cap (100 MiB) — enforced while streaming the request body. */
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024
 
+type CaptureSnippetRow = {
+  id: string
+  content: string | null
+}
+
 /**
  * Root directory that contains one subfolder per IngestSourceType. Matches the
  * bind-mount the sidecars will receive in CS3.13 deploy. Overridable for
@@ -149,21 +154,29 @@ async function streamBodyToFile(
 }
 
 /**
- * GET-side row shaper. Joins capture rows on demand to produce the
- * `captures` snippet array the dashboard needs. A zero-capture row
- * returns `captures: []` without an extra query.
+ * GET-side row shaper. Uses a prefetched capture lookup when supplied to
+ * avoid per-upload SELECTs on list responses. A zero-capture row returns
+ * `captures: []` without an extra query.
  */
 async function shapeFileUploadRow(
   db: Database,
   row: typeof file_uploads.$inferSelect,
+  captureLookup?: Map<string, CaptureSnippetRow>,
 ): Promise<FileUploadRow> {
   const ids = (row.capture_ids ?? []) as string[]
   let captureSummaries: { id: string; title_snippet: string }[] = []
   if (ids.length > 0) {
-    const rows = await db
-      .select({ id: captures.id, content: captures.content })
-      .from(captures)
-      .where(inArray(captures.id, ids))
+    let rows: CaptureSnippetRow[]
+    if (captureLookup) {
+      rows = ids
+        .map((id) => captureLookup.get(id))
+        .filter((r): r is CaptureSnippetRow => Boolean(r))
+    } else {
+      rows = await db
+        .select({ id: captures.id, content: captures.content })
+        .from(captures)
+        .where(inArray(captures.id, ids))
+    }
     captureSummaries = rows.map((r) => ({
       id: r.id,
       title_snippet: (r.content ?? '').slice(0, 120),
@@ -432,7 +445,17 @@ export function registerIngestRoutes(
         .where(where),
     ])
 
-    const uploads = await Promise.all(rows.map((r) => shapeFileUploadRow(db, r)))
+    const captureIds = Array.from(
+      new Set(rows.flatMap((r) => ((r.capture_ids ?? []) as string[]))),
+    )
+    const captureRows = captureIds.length > 0
+      ? await db
+        .select({ id: captures.id, content: captures.content })
+        .from(captures)
+        .where(inArray(captures.id, captureIds))
+      : []
+    const captureLookup = new Map(captureRows.map((r) => [r.id, r]))
+    const uploads = await Promise.all(rows.map((r) => shapeFileUploadRow(db, r, captureLookup)))
     const total = totalRow[0]?.count ?? 0
 
     const response: ListUploadsResponse = {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -37,10 +37,10 @@
     "@testing-library/react-native": "^12.9.0",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.1.17",
-    "@types/react-test-renderer": "^19.0.0",
+    "@types/react-test-renderer": "^19.1.0",
     "jest": "^29.7.0",
     "jest-expo": "~54.0.17",
-    "react-test-renderer": "19.0.0",
+    "react-test-renderer": "19.1.0",
     "typescript": "~5.9.3"
   }
 }

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -30,13 +30,6 @@
     "openai": "^4.98.0",
     "pdf-parse": "^2.4.5",
     "pino": "^10.3.1",
-    "rehype-autolink-headings": "^7.1.0",
-    "rehype-slug": "^6.0.0",
-    "rehype-stringify": "^10.0.1",
-    "remark-parse": "^11.0.0",
-    "remark-rehype": "^11.1.1",
-    "unified": "^11.0.5",
-    "xss": "^1.0.15",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 15.0.8(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(xyorhun2szkoyrq5vu2nbmpimm)
+        version: 6.0.23(tdpl3vcdkdrtpi4u3mqw5upr3a)
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.33)
@@ -168,7 +168,7 @@ importers:
     devDependencies:
       '@testing-library/react-native':
         specifier: ^12.9.0
-        version: 12.9.0(jest@29.7.0(@types/node@25.3.5))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.0.0(react@19.1.0))(react@19.1.0)
+        version: 12.9.0(jest@29.7.0(@types/node@25.3.5))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -176,8 +176,8 @@ importers:
         specifier: ~19.1.17
         version: 19.1.17
       '@types/react-test-renderer':
-        specifier: ^19.0.0
-        version: 19.0.0
+        specifier: ^19.1.0
+        version: 19.1.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@25.3.5)
@@ -185,8 +185,8 @@ importers:
         specifier: ~54.0.17
         version: 54.0.17(@babel/core@7.29.0)(expo@54.0.33)(jest@29.7.0(@types/node@25.3.5))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-test-renderer:
-        specifier: 19.0.0
-        version: 19.0.0(react@19.1.0)
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -3146,11 +3146,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react-test-renderer@19.0.0':
-    resolution: {integrity: sha512-qDVnNybqFm2eZKJ4jD34EvRd6VHD67KjgnWaEMM0Id9L22EpWe3nOSVKHWL1XWRCxUWe3lhXwlEeCKD1BlJCQA==}
-
-  '@types/react@19.0.14':
-    resolution: {integrity: sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==}
+  '@types/react-test-renderer@19.1.0':
+    resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
   '@types/react@19.1.17':
     resolution: {integrity: sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==}
@@ -7072,11 +7069,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-test-renderer@19.0.0:
-    resolution: {integrity: sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==}
-    peerDependencies:
-      react: ^19.0.0
-
   react-test-renderer@19.1.0:
     resolution: {integrity: sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==}
     peerDependencies:
@@ -7287,9 +7279,6 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
-
-  scheduler@0.25.0:
-    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -9465,7 +9454,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0
     optionalDependencies:
-      expo-router: 6.0.23(xyorhun2szkoyrq5vu2nbmpimm)
+      expo-router: 6.0.23(tdpl3vcdkdrtpi4u3mqw5upr3a)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -11245,13 +11234,13 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@12.9.0(jest@29.7.0(@types/node@25.3.5))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.0.0(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react-native@12.9.0(jest@29.7.0(@types/node@25.3.5))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       jest-matcher-utils: 29.7.0
       pretty-format: 29.7.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
-      react-test-renderer: 19.0.0(react@19.1.0)
+      react-test-renderer: 19.1.0(react@19.1.0)
       redent: 3.0.0
     optionalDependencies:
       jest: 29.7.0(@types/node@25.3.5)
@@ -11418,13 +11407,9 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
-  '@types/react-test-renderer@19.0.0':
+  '@types/react-test-renderer@19.1.0':
     dependencies:
-      '@types/react': 19.0.14
-
-  '@types/react@19.0.14':
-    dependencies:
-      csstype: 3.2.3
+      '@types/react': 19.1.17
 
   '@types/react@19.1.17':
     dependencies:
@@ -13319,7 +13304,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-router@6.0.23(xyorhun2szkoyrq5vu2nbmpimm):
+  expo-router@6.0.23(tdpl3vcdkdrtpi4u3mqw5upr3a):
     dependencies:
       '@expo/metro-runtime': 5.0.5(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       '@expo/schema-utils': 0.1.8
@@ -13352,7 +13337,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.2.5(react@19.1.0))(react@19.1.0)
     optionalDependencies:
-      '@testing-library/react-native': 12.9.0(jest@29.7.0(@types/node@25.3.5))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.0.0(react@19.1.0))(react@19.1.0)
+      '@testing-library/react-native': 12.9.0(jest@29.7.0(@types/node@25.3.5))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom: 19.2.5(react@19.1.0)
       react-native-reanimated: 4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
@@ -16425,12 +16410,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-test-renderer@19.0.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-is: 19.2.5
-      scheduler: 0.25.0
-
   react-test-renderer@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -16702,8 +16681,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-
-  scheduler@0.25.0: {}
 
   scheduler@0.26.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.39.0
-        version: 0.39.0
     devDependencies:
       tsx:
         specifier: ^4.7.0
@@ -453,27 +449,6 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
-      rehype-autolink-headings:
-        specifier: ^7.1.0
-        version: 7.1.0
-      rehype-slug:
-        specifier: ^6.0.0
-        version: 6.0.0
-      rehype-stringify:
-        specifier: ^10.0.1
-        version: 10.0.1
-      remark-parse:
-        specifier: ^11.0.0
-        version: 11.0.0
-      remark-rehype:
-        specifier: ^11.1.1
-        version: 11.1.2
-      unified:
-        specifier: ^11.0.5
-        version: 11.0.5
-      xss:
-        specifier: ^1.0.15
-        version: 1.0.15
       zod:
         specifier: ^3.23.0
         version: 3.25.76


### PR DESCRIPTION
## Summary
- Hoist `BYPASS_CALLERS` to module scope while preserving all 17 internal caller entries.
- Batch capture lookup in `GET /api/v1/ingest/uploads` to remove the per-row capture query.
- Remove unused markdown processing dependencies from `packages/workers` and orphaned `@anthropic-ai/sdk` from the root package.
- Log the Windows root `pnpm test:integration` script quirk as A129 and document the explicit local integration sequence.

## Verification
- `pnpm --filter @open-brain/core-api exec vitest run src/__tests__/rate-limit.test.ts src/__tests__/ingest-routes.test.ts`
- `pnpm --filter @open-brain/core-api build`
- `pnpm --filter @open-brain/workers build`
- `pnpm --filter @open-brain/workers test`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-brain/shared build`
- `pnpm --filter @open-brain/shared test`
- `pnpm --filter @open-brain/voice-capture build`
- `pnpm --filter @open-brain/voice-capture test`
- `docker compose -f docker-compose.test.yml up -d --wait; pnpm --filter @open-brain/core-api test:integration; docker compose -f docker-compose.test.yml down -v`

## Notes
- `pnpm --filter @open-brain/core-api exec tsc --noEmit` still stops at the known A106 baseline error in `entity-resolution.test.ts`; no touched-file TypeScript errors appeared before that failure.
- Root `pnpm test:integration` is tracked as A129 because PowerShell passes the package script's semicolon chain incorrectly on Windows.
