### PR TITLE
chore: post-remediation phase 4 — workers coverage gate + CI integration step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,13 @@ jobs:
           TEST_REDIS_URL: redis://localhost:6381
           NODE_ENV: test
 
+      - name: Run workers integration tests
+        run: pnpm --filter @open-brain/workers exec vitest run --config vitest.config.integration.ts
+        env:
+          TEST_POSTGRES_URL: postgresql://openbrain_test:test_password@localhost:5433/openbrain_test
+          TEST_REDIS_URL: redis://localhost:6381
+          NODE_ENV: test
+
       - name: Dump service logs on failure
         if: failure()
         run: docker compose -f docker-compose.test.yml logs --no-color

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10415,3 +10415,57 @@ Code comment explaining intentional placeholder; not a functional regression.
 | D-Phase3-1 | Pin `@types/node` to `^22.0.0` in core-api + voice-capture (matching web-next baseline) | Aligns dev type defs with Node 22 LTS runtime; eliminates spurious type drift between packages; surfaced zero tsc errors. |
 | D-Phase3-2 | Defer `eslint-config-next ^16.2.4` to a separate plan/PR (A130) | The bump implicitly requires ESLint 8 → 9 + flat-config migration; loading the v16 config under ESLint 8 hits a circular-JSON crash. Out of Phase 3's S–M scope; same escalation pattern as 3.1's >5-error rule. |
 | D-Phase3-3 | Use `CI=1 pnpm -r test` on this VM (not plain `pnpm -r test`) | Per Entry 132: at least one package's test command is watch-mode-sensitive outside CI; CI=1 makes vitest force-exit on completion (matches GitHub Actions). |
+
+--- New session: 2026-05-07 — Post-remediation Phase 4 workers test rigor ---
+
+### Entry 135 — Post-Remediation Phase 4: workers coverage thresholds + CI integration step [testing] [config] [decision]
+**Date:** 2026-05-07
+**Environment:** ubuntu-vm (`/home/davistroy/dev/personal/open-brain`), branch `chore/workers-test-rigor` off `main` at `2bdfcc0`. Orchestrated by Opus; mechanical work delegated to Haiku/Sonnet subagents per user directive.
+**Objective:** Execute Phase 4 of `IMPLEMENTATION_PLAN-POST-REMEDIATION.md` — add coverage thresholds to `packages/workers/vitest.config.ts` (matching core-api's pattern but pinned to the measured floor, not 80%) AND wire the workers integration test suite into the CI `integration-test` job so the gate is enforced. Both ship together.
+**Hypothesis:** Workers test coverage is high enough that pinning to the measured floor adds rigor without forcing a same-PR coverage uplift. Adding the workers integration step to the existing `integration-test` job (which already starts the test compose stack) reuses infrastructure and inherits the existing required-status-check gate ("Integration tests (core-api + real DB)") without changing branch protection. Success criteria per plan acceptance: workers coverage gate active and exit 0; workers integration tests run green in the same CI job that's already required; branch protection still requires the integration-test job; lab notebook captures U2 (measured baseline) + U3 (integration config existence/contents).
+**Rollback plan:** `git revert` the Phase 4 commit; `pnpm install` is a no-op (no dep changes). CI workflow change reverts cleanly with the file edit. No runtime impact (test infrastructure only).
+**Duration:** target 45–90 min (subagent dispatch overhead included).
+
+**U2 / U3 resolutions (decision gates — to be filled by subagents):**
+- **U2 (4.1 measurement):** No prior workers coverage measurement. Subagent A to run `pnpm --filter @open-brain/workers test -- --coverage` and report `lines%` / `functions%`. Threshold pinned to the floor (safer; same pattern as core-api Phase 4 of arch-review).
+- **U3 (4.3 config existence):** Plan asks to verify or create `packages/workers/vitest.config.integration.ts`. Subagent B to check for existence + run integration tests locally against `docker-compose.test.yml`.
+
+**Orchestration plan:**
+- Wave 1 (parallel — investigation + measurement, 3 subagents):
+  - Agent A (Haiku, general-purpose): 4.1 — coverage baseline measurement.
+  - Agent B (Sonnet, general-purpose): 4.3 — verify/create integration config + run tests.
+  - Agent C (Haiku, general-purpose): 4.5 — branch protection audit via gh API.
+- Wave 2 (parallel — edits using Wave 1 outputs, 2 subagents, both Sonnet):
+  - Agent D: 4.2 — edit `packages/workers/vitest.config.ts` with measured floor.
+  - Agent E: 4.4 — add workers integration step to `.github/workflows/ci.yml`.
+- Wave 3 (orchestrator): final DoD verification, commit, push, PR, watch, merge.
+
+**Execution log:**
+
+**Wave 1 (3 parallel subagents):**
+- **Agent A (Haiku, 4.1):** Ran `pnpm --filter @open-brain/workers test -- --coverage` after adding `@vitest/coverage-v8@^1.6.1` to workers devDependencies. Result: 51 test files / 1021 tests passing in 43.59 s. Coverage — Statements 78.79%, Branches 83.38%, Functions 81.59%, Lines 78.79%. **U2 resolved:** floor(lines)=78, floor(functions)=81; pinned to floor (safer; matches arch-review Phase 4 pattern).
+- **Agent B (Sonnet, 4.3):** `packages/workers/vitest.config.integration.ts` already exists with the correct shape (mirrors core-api: `pool: 'forks'` + `singleFork: true`, hookTimeout/testTimeout 30_000, `include: ['src/__tests__/integration/**/*.test.ts']`). All 3 plan-expected test files present. **U3 resolved:** no config changes needed. However, two real bugs blocked green: (a) `pipeline.test.ts:140-145` had a stale DAG-children assertion (expected 2 children: `embed-capture`, `extract-entities`; actual is 3 — `extract-commitments` was added per F46 in Phase 2 docs but never reflected in the test); (b) `setup.ts` only applies `init-schema.sql`, which is missing the `capture_associations` table (migration 0011 — A125 partial closure: PR #178 added 0025 CHECKs but not 0011's table). Fixed both: corrected the assertion to length 3 with sorted child queues `['embed-capture', 'extract-commitments', 'extract-entities']`; added an A125-supplement block to `setup.ts` that applies `packages/shared/drizzle/0011_capture_associations.sql` after `init-schema.sql`, with an inline comment "Remove this supplement once A125 is resolved." Final result: 3 files, 14 passed, 2 skipped (gated within their own test bodies), 0 failed; `docker compose down -v` clean.
+- **Agent C (Haiku, 4.5):** `gh api repos/davistroy/open-brain/branches/main/protection --jq '.required_status_checks.contexts'` returned `["Integration tests (core-api + real DB)"]`. Confirmed required, no other contexts; `gh auth status` confirmed admin push as `davistroy`. **No branch-protection change needed:** the new workers integration step inherits the existing required gate by being part of the same `integration-test` job.
+
+**Wave 2 (2 parallel subagents):**
+- **Agent D (Sonnet, 4.2):** Edited `packages/workers/vitest.config.ts` `test.coverage` block from `{ reporter: ['text', 'json-summary'] }` to the canonical shape: `provider: 'v8'`, `reporter: ['text', 'lcov', 'json-summary']`, `include: ['src/**/*.ts']`, `exclude: ['src/index.ts', 'src/main.ts', 'src/__tests__/**']`, `thresholds: { lines: 78, functions: 81 }`. Forks-pool config preserved (`pool: 'forks'`, `minForks: 1`, `maxForks: 4`, both timeouts `30_000`). `pnpm --filter @open-brain/workers test -- --coverage` exit 0; actual coverage exceeded floors (lines 80.05% ≥ 78, functions 83.47% ≥ 81). Build exit 0.
+- **Agent E (Sonnet, 4.4):** Edited `.github/workflows/ci.yml` adding step "Run workers integration tests" inside the existing `integration-test` job, after "Run integration tests" (line 207), before "Dump service logs on failure". Command: `pnpm --filter @open-brain/workers exec vitest run --config vitest.config.integration.ts`. Env vars match the existing core-api integration step exactly: `TEST_POSTGRES_URL=postgresql://openbrain_test:test_password@localhost:5433/openbrain_test`, `TEST_REDIS_URL=redis://localhost:6381`, `NODE_ENV=test`. Reuses already-running compose stack — no new services, no new compose-up step. YAML still parses cleanly.
+
+**Wave 3 — final DoD verification (Haiku subagent):**
+
+| Check | Exit | Notes |
+|---|---|---|
+| `pnpm install --frozen-lockfile` | 0 | Lockfile consistent post `@vitest/coverage-v8` add |
+| `pnpm -r exec tsc --noEmit` | 0 | No shared rebuild needed |
+| `pnpm -r build` | 0 | All 5 TS packages built; core-api DTS 17.4 s longest |
+| `CI=1 pnpm -r test` | 0 | 1163 core-api + 980+ workers + others, all green |
+
+**Decision Log:**
+
+| # | Decision | Rationale |
+|---|---|---|
+| D-Phase4-1 | Pin workers thresholds to measured floor (78 lines, 81 functions), not 80% | Same pattern as core-api Phase 4 of arch-review remediation. Adds rigor without forcing same-PR coverage uplift; raise incrementally in follow-ups. |
+| D-Phase4-2 | Bundle two test fixes (pipeline.test.ts assertion drift + setup.ts A125 supplement) into Phase 4 PR | Both gate the integration tests from running green in CI. Without them, the very CI step Phase 4.4 wires would fail. Documenting both inline (commit + lab notebook) preserves traceability; A125 supplement carries an explicit removal comment so it goes away when A125 fully closes. |
+| D-Phase4-3 | Reuse the existing `integration-test` job for the workers step (no new job, no `continue-on-error`) | Reuses already-running compose stack, inherits the existing required-status-check gate ("Integration tests (core-api + real DB)") without changing branch protection. Same pattern as the core-api integration step that's been required since arch-review Phase 5b. |
+
+**Outcome:** All 5 Phase 4 acceptance items satisfied. PR to follow with the 7-file change set.

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -36,6 +36,7 @@
     "@types/nodemailer": "^6.4.23",
     "@types/pdf-parse": "^1.1.5",
     "@types/pg": "^8.18.0",
+    "@vitest/coverage-v8": "^1.6.1",
     "pg": "^8.20.0",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",

--- a/packages/workers/src/__tests__/integration/pipeline.test.ts
+++ b/packages/workers/src/__tests__/integration/pipeline.test.ts
@@ -140,9 +140,9 @@ describe('Pipeline Flow', () => {
     const flowArg = flowProducer.add.mock.calls[0][0]
     expect(flowArg.name).toBe('ingest-root')
     expect(flowArg.data.captureId).toBe(captureId)
-    expect(flowArg.children).toHaveLength(2)
+    expect(flowArg.children).toHaveLength(3)
     const childQueues = flowArg.children.map((c: any) => c.queueName).sort()
-    expect(childQueues).toEqual(['embed-capture', 'extract-entities'])
+    expect(childQueues).toEqual(['embed-capture', 'extract-commitments', 'extract-entities'])
   })
 
   it('processes embed stage independently and advances to complete', async () => {

--- a/packages/workers/src/__tests__/integration/setup.ts
+++ b/packages/workers/src/__tests__/integration/setup.ts
@@ -55,17 +55,31 @@ function resolveInitSchemaPath(): string {
   return join(__dirname, '..', '..', '..', '..', '..', 'scripts', 'init-schema.sql')
 }
 
+/** Resolve a drizzle migration SQL path relative to repo root. */
+function resolveDrizzleMigrationPath(filename: string): string {
+  return join(__dirname, '..', '..', '..', '..', '..', 'packages', 'shared', 'drizzle', filename)
+}
+
 /**
  * Apply the full schema DDL to the test database.
  * Uses a raw pg Pool (not Drizzle) so we can execute multi-statement SQL.
+ *
+ * init-schema.sql is the primary source (all tables up to 0031), but
+ * capture_associations is absent from it (tracked as A125). Apply migration
+ * 0011 as a supplement so access-stats-e2e tests can use the table.
+ * Remove this supplement once A125 is resolved and init-schema.sql is patched.
  */
 async function applySchema(connectionString: string): Promise<void> {
   const schemaPath = resolveInitSchemaPath()
   const schemaSql = readFileSync(schemaPath, 'utf8')
 
+  // A125 supplement: capture_associations (migration 0011) absent from init-schema.sql
+  const captureAssocSql = readFileSync(resolveDrizzleMigrationPath('0011_capture_associations.sql'), 'utf8')
+
   const pool = new Pool({ connectionString })
   try {
     await pool.query(schemaSql)
+    await pool.query(captureAssocSql)
   } finally {
     await pool.end()
   }

--- a/packages/workers/vitest.config.ts
+++ b/packages/workers/vitest.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     hookTimeout: 30_000,
     testTimeout: 30_000,
     coverage: {
-      reporter: ['text', 'json-summary'],
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'json-summary'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/index.ts', 'src/main.ts', 'src/__tests__/**'],
+      thresholds: { lines: 78, functions: 81 },
     },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
       '@types/pg':
         specifier: ^8.18.0
         version: 8.18.0
+      '@vitest/coverage-v8':
+        specifier: ^1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@25.3.5)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0))
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -3005,6 +3008,7 @@ packages:
 
   '@testing-library/react-native@12.9.0':
     resolution: {integrity: sha512-wIn/lB1FjV2N4Q7i9PWVRck3Ehwq5pkhAef5X5/bmQ78J/NoOsGbVY2/DG5Y9Lxw+RfE+GvSEh/fe5Tz6sKSvw==}
+    deprecated: React Native Testing Library v12 is no longer maintained. Please upgrade to v13 or v14.
     peerDependencies:
       jest: '>=28.0.0'
       react: '>=16.8.0'
@@ -3249,6 +3253,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -8001,14 +8006,17 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -11644,6 +11652,25 @@ snapshots:
       strip-literal: 2.1.1
       test-exclude: 6.0.0
       vitest: 1.6.1(@types/node@22.19.17)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@25.3.5)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      test-exclude: 6.0.0
+      vitest: 1.6.1(@types/node@25.3.5)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Phase 4 of `IMPLEMENTATION_PLAN-POST-REMEDIATION.md` — wires the workers test suite into the same rigor + CI bar as core-api. Coverage thresholds and integration-test CI step ship together (thresholds without CI = unenforced; CI without thresholds = empty rigor).

## Acceptance status (all 5 items complete)

| Item | Status |
|---|---|
| 4.1 — Workers coverage baseline (U2) | ✅ Lines 78.79% / Functions 81.59% (1021 tests / 51 files, all passing) |
| 4.2 — Coverage thresholds in `vitest.config.ts` | ✅ `{ lines: 78, functions: 81 }` pinned to the floor; forks-pool config preserved |
| 4.3 — `vitest.config.integration.ts` (U3) | ✅ Already correct — mirrors core-api shape |
| 4.4 — Workers integration step in `ci.yml` | ✅ Added inside existing `integration-test` job; inherits the required gate |
| 4.5 — Branch protection audit | ✅ `"Integration tests (core-api + real DB)"` already required; no change needed |

## What's in the diff

| File | Why |
|---|---|
| `packages/workers/vitest.config.ts` | Add v8 coverage provider + thresholds (4.2) |
| `packages/workers/package.json` + `pnpm-lock.yaml` | `@vitest/coverage-v8@^1.6.1` dev dep (required for v8 provider) |
| `.github/workflows/ci.yml` | New `Run workers integration tests` step inside existing `integration-test` job (4.4) |
| `packages/workers/src/__tests__/integration/pipeline.test.ts` | Bundled fix: stale DAG assertion (expected 2 children but `extract-commitments` was added per F46) |
| `packages/workers/src/__tests__/integration/setup.ts` | Bundled fix: A125 supplement — applies migration 0011 (`capture_associations`) because `init-schema.sql` lacks it; PR #178 only patched 0025 CHECKs |
| `LAB_NOTEBOOK.md` | Entry 135 — orchestration log + Decision Log + DoD evidence |

The two bundled fixes are pre-existing bugs that block the new CI step from running green. Both carry traceability comments. The setup.ts A125 supplement explicitly says "Remove this supplement once A125 is resolved."

## DoD verification (local, CI parity)

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `pnpm -r exec tsc --noEmit` | exit 0 |
| `pnpm -r build` | exit 0 |
| `CI=1 pnpm -r test` | exit 0 (1163 core-api + 980+ workers + others) |
| Workers coverage run | exit 0 (actual 80.05% lines / 83.47% functions clearing floors) |
| Workers integration tests vs. `docker-compose.test.yml` | exit 0 (14 passed, 2 skipped) |

## Test plan

- [ ] CI: `Integration tests (core-api + real DB)` — required gate; new workers step is part of this job.
- [ ] CI: `build-and-test` — exercises the lockfile + `@vitest/coverage-v8` install.
- [ ] After merge: `gh run list --workflow=ci.yml --limit 5` should show ≥4/5 green.

## Followups

- **A125 partial closure** — PR #178 patched CHECK constraints but not the `capture_associations` table. Setup.ts supplement is the temporary bridge; full A125 closure should add migration 0011 (and any other missing tables) to `init-schema.sql` directly.
- After merge: `OPEN_ITEMS.md` post-remediation row drops to 0 pending items + 1 escalation (A130 ESLint 9 migration). Plan effectively closes.

Plan: `IMPLEMENTATION_PLAN-POST-REMEDIATION.md` Phase 4 (Set D — F2, F8).
Lab notebook: Entry 135.
Orchestration: 6 subagents (Haiku/Sonnet) across 3 waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)