### PR TITLE
chore: A71 — add memory_consolidation task_routing key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,6 @@ After any non-trivial finding (container startup failure, networking quirk, pipe
 - OpenAI `gpt-5.4` uses `max_completion_tokens` (not `max_tokens`, rejected 400). **No `extra_body`** (vLLM-specific, rejected 400).
 - `createLiteLLMClient()` returns `null` when API key is empty — callers must check and disable LLM features (core-api governance engine pattern).
 - **`callClaude` removed in P02b.** All LLM skills + `extract-entities` use `LLMGatewayService.completeByTask()`; `litellmClient` is a test-mock injection point only. Do not reintroduce direct Anthropic SDK in skills — add a `task_routing` entry instead.
-- `memory-consolidation` routes via `'search_synthesis'` task key (A71 pending) — real key `'memory_consolidation'` doesn't exist in `ai-routing.yaml` yet. Do not "fix" in a drive-by edit.
 - Skills must resolve model aliases from `configService.get('ai').models[alias]` before dispatching to OpenAI. Same pattern as `extract-entities.ts`.
 - Classification tasks route to `t1_jetson` by default (6 tasks: intent, capture, brain_view, voice, confidence, question_detection). Fallback: `t1_jetson → t1_fast → t2_quality`.
 - `openai_compat` tiers: gateway creates per-tier OpenAI SDK clients from tier `base_url`. `ollama` keeps the constructor-injected client (preserves test mock compatibility).

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10517,3 +10517,35 @@ Workers integration tests run against `docker-compose.test.yml`.
 | D-136-2 | Report 0012, 0028, 0030 as separate findings; do NOT patch in this PR | One PR per concern. 0012 is a SQL function (lower risk — function already deployed to homeserver; missing from fresh-init only). 0028/0030 are tables that Python/TS access on production but aren't tested in workers integration suite. Separating prevents scope creep. |
 
 **Outcome:** COMPLETE. PR #184 merged as squash commit `dff5127` to main (2026-05-07). Workers integration tests: 14 passed / 2 skipped, exit 0 both before and after merge. Workers unit tests: 51 files / 1021 passed. tsc: exit 0. All CI checks green (Integration tests, build-and-test, Validate init-schema.sql, Python checks, GitGuardian). Separate findings (0012 spreading_activation, 0028 lab_results, 0030 briefs missing from init-schema.sql) logged for future PRs.
+
+---
+
+### Entry 137 — A71: add memory_consolidation task_routing key to ai-routing.yaml [config] [skills] [decision]
+**Date:** 2026-05-07
+**Environment:** ubuntu-vm (`/home/davistroy/dev/personal/open-brain`), branch `chore/a71-memory-consolidation-task-key` off `main` at `8d709c8`.
+**Objective:** Close A71 — add `memory_consolidation` task routing key to `config/ai-routing.yaml` pointing at `t1_spark`, update `packages/workers/src/skills/memory-consolidation.ts` to use the real key, remove the TODO comment, update the corresponding test assertion, and clean up all stale documentation references (CLAUDE.md placeholder bullet, OPEN_ITEMS.md A71 row, MEMORY.md stale reference).
+**Hypothesis:** The `memory-consolidation` skill is a Sunday 4 AM batch synthesis job — `t1_spark` (DGX Spark 35B, free tier, 4096-token output, 120s timeout) is appropriate and consistent with neighboring synthesis tasks (`search_synthesis`, `wiki_synthesis`, `daily_sweep`, etc.). Changing the task key is a one-line routing change with no behavioral difference — both `search_synthesis` and `memory_consolidation` route to `t1_spark`. Success: workers test on the changed file exits 0; full workers suite exits 0; `tsc --noEmit` exits 0.
+**Rollback plan:** `git revert` the PR squash commit. No runtime impact beyond restoring the `search_synthesis` routing (both keys target `t1_spark`). No data migration.
+
+**Cost-field verification:** `t1_spark` at `config/ai-routing.yaml` lines 106–119 declares `cost_per_1k_input: 0` and `cost_per_1k_output: 0` (explicit zeros, canonical per CLAUDE.md). No tier-side edits needed.
+
+**Uncontroversial call sites (DO NOT CHANGE):**
+- `packages/workers/src/skills/entity-brief.ts` — `ENTITY_BRIEF_TASK = 'search_synthesis'` is intentional reuse (decision D116), separate from A71.
+- `packages/workers/src/__tests__/entity-brief.test.ts:497` — mirrors D116, no change.
+
+**Files changed:**
+1. `config/ai-routing.yaml` — added `memory_consolidation: t1_spark` entry in CONSTRAINT CLASS: ROUTINE TASKS block.
+2. `packages/workers/src/skills/memory-consolidation.ts` — changed `'search_synthesis'` → `'memory_consolidation'` in `completeByTask()` call; removed TODO A71 comment.
+3. `packages/workers/src/__tests__/memory-consolidation.test.ts` — updated test name and `toBe` assertion to match new key.
+4. `CLAUDE.md` — removed stale "memory-consolidation routes via 'search_synthesis' task key (A71 pending)" bullet.
+5. `OPEN_ITEMS.md` — removed A71 row; decremented operational count 8 → 7; updated cross-plan notes.
+6. `~/.claude/projects/.../memory/MEMORY.md` — removed stale A71 pending reference (if present).
+
+**Decision Log:**
+
+| # | Decision | Rationale |
+|---|---|---|
+| D-137-1 | Route `memory_consolidation` to `t1_spark` | Batch Sunday skill, no user waiting, free tier sufficient. Matches `search_synthesis`, `wiki_synthesis`, `daily_sweep` neighbors in the same constraint class. Spark 35B handles multi-document synthesis well at 4096-token output budget. |
+| D-137-2 | Do not change `ENTITY_BRIEF_TASK = 'search_synthesis'` | Decision D116 explicitly retained that key as intentional reuse; A71 scope is memory-consolidation only. |
+
+**Outcome:** (to be filled after PR merge)

--- a/OPEN_ITEMS.md
+++ b/OPEN_ITEMS.md
@@ -68,7 +68,6 @@ From [IMPLEMENTATION_PLAN-ARCH-REVIEW.md §Deferred Items](IMPLEMENTATION_PLAN-A
 
 | ID | Description | Class | Trigger to address |
 |---|---|---|---|
-| A71 | memory-consolidation task key (`'search_synthesis'` placeholder; real key `'memory_consolidation'` not in `ai-routing.yaml`) | Operational | ~1 hr filler work |
 | A107 | `strictLimiter` double-registered on `/captures` (halves effective rate-limit budget) | Operational | Phase 5 D candidate |
 | A110 | Settings `GET` has no whitelist gate — non-whitelisted key returns 404 instead of 400 | Operational | Future scope |
 | A111 | `email_allowlist` has no array validator in `SETTINGS_VALIDATORS` | Operational | With A110 |
@@ -82,7 +81,7 @@ From [IMPLEMENTATION_PLAN-ARCH-REVIEW.md §Deferred Items](IMPLEMENTATION_PLAN-A
 | A106 | TS2502 in `entity-resolution.test.ts:345` | Pre-existing baseline | Out of scope |
 | A120 | TS2345 in `MPill.test.tsx` + `TabBar.test.tsx` (React 19 / react-test-renderer drift) | Pre-existing baseline | Separate PR |
 
-**Operational items (8):** A71, A107, A110, A111, A113, A114, A129, A130 — real follow-ups that should land in future plans.
+**Operational items (7):** A107, A110, A111, A113, A114, A129, A130 — real follow-ups that should land in future plans.
 **Pre-existing baselines (5):** A128, A116, A117, A106, A120 — long-term debt; do not bundle into operational work. (A125 closed via this PR; A127 closed via PR #179; A126 closed via Phase 8b.)
 
 ---
@@ -104,7 +103,7 @@ From [IMPLEMENTATION_PLAN-ARCH-REVIEW.md §Deferred Items](IMPLEMENTATION_PLAN-A
 
 | Risk | Detail |
 |---|---|
-| **A71 (memory-consolidation task key)** | Standalone — Phase 2 (PR #181) shipped without adding an F-ID for memory-consolidation; A71 remains an independent ~1 hr config edit. |
+| **A71 CLOSED** | Closed via PR (2026-05-07) — `memory_consolidation` task key added to `ai-routing.yaml`; `memory-consolidation.ts` updated to use real key. |
 | **A125 CLOSED ↔ workers integration tests** | `capture_associations` (migration 0011) added to `init-schema.sql` and `setup.ts` supplement removed. See PR #184 (2026-05-07). |
 | **A128 (TanStack Query hooks extraction) ↔ A130 (ESLint 9 + flat-config migration)** | Both touch the web-next package. A130 migrates lint config; A128 restructures hooks. Sequence A130 first if both pick up — flat-config rules may surface lint errors that A128's restructure should respect. |
 | **P23 (cognitive memory tuning) ↔ A107 (strictLimiter double-reg)** | P23 measures live search behavior; A107 affects rate-limit effective budget — fix A107 before P23 starts to keep measurement clean. |

--- a/config/ai-routing.yaml
+++ b/config/ai-routing.yaml
@@ -235,6 +235,7 @@ task_routing:
   drift_monitoring: t1_spark      # Detects semantic drift in wiki pages vs recent captures
   email_daily_digest: t1_spark    # Canonical name for email-classify synthesis (replaces stray 'synthesis' key)
   brief_refinement: t1_spark      # HTML transform for brief refinement — moderate reasoning, free tier sufficient
+  memory_consolidation: t1_spark  # Sunday batch consolidation — merges duplicate captures, free tier sufficient
 
   # ===================================================================
   # CONSTRAINT CLASS: QUALITY-CRITICAL (paid -- Anthropic Sonnet)

--- a/packages/workers/src/__tests__/memory-consolidation.test.ts
+++ b/packages/workers/src/__tests__/memory-consolidation.test.ts
@@ -228,13 +228,13 @@ describe('MemoryConsolidationSkill', () => {
   // ----------------------------------------------------------
 
   describe('execute — via LLMGateway', () => {
-    it('calls completeByTask with search_synthesis task key when gateway injected', async () => {
+    it('calls completeByTask with memory_consolidation task key when gateway injected', async () => {
       const { skill, gateway } = makeSkillWithGateway()
       await skill.execute()
 
       const spy = vi.mocked(gateway.completeByTask)
       expect(spy).toHaveBeenCalledOnce()
-      expect(spy.mock.calls[0][1]).toBe('search_synthesis')
+      expect(spy.mock.calls[0][1]).toBe('memory_consolidation')
     })
 
     it('returns MemoryConsolidationResult with shouldMerge=true and newCaptureId when LLM says merge', async () => {

--- a/packages/workers/src/skills/memory-consolidation.ts
+++ b/packages/workers/src/skills/memory-consolidation.ts
@@ -345,8 +345,7 @@ export class MemoryConsolidationSkill extends LLMSkill<MemoryConsolidationOption
 
     // Prefer LLMGatewayService (task-based tier routing with audit log)
     if (this.llmGateway) {
-      // TODO A71: rename task key to 'memory_consolidation' once ai-routing.yaml entry is added
-      const raw = await this.llmGateway.completeByTask(prompt, 'search_synthesis', {
+      const raw = await this.llmGateway.completeByTask(prompt, 'memory_consolidation', {
         temperature: 0.2,
         maxTokens: 2048,
       })


### PR DESCRIPTION
## Summary

Closes A71. The `memory-consolidation` skill was routing LLM calls via the `search_synthesis` task key as a placeholder because `memory_consolidation` did not exist in `config/ai-routing.yaml`. This PR adds the real key and wires everything up.

- **`config/ai-routing.yaml`** — added `memory_consolidation: t1_spark` in the CONSTRAINT CLASS: ROUTINE TASKS block alongside `search_synthesis`, `wiki_synthesis`, `daily_sweep`, etc. t1_spark is the correct tier: Sunday 4 AM batch skill, free DGX Spark 35B, no user waiting.
- **`packages/workers/src/skills/memory-consolidation.ts`** — changed `completeByTask(prompt, 'search_synthesis', ...)` → `completeByTask(prompt, 'memory_consolidation', ...)`. Removed TODO A71 comment.
- **`packages/workers/src/__tests__/memory-consolidation.test.ts`** — updated test name and `toBe` assertion to match new key.
- **`CLAUDE.md`** — removed stale placeholder bullet ("memory-consolidation routes via 'search_synthesis' task key (A71 pending)").
- **`OPEN_ITEMS.md`** — removed A71 row; decremented operational count 8→7; updated cross-plan notes.
- **`LAB_NOTEBOOK.md`** — Entry 137 (pre-commit, per operational rules).

Cost-field check: `t1_spark` declares `cost_per_1k_input: 0` / `cost_per_1k_output: 0` (explicit zeros). No tier-side changes needed.

`entity-brief.ts` intentionally retains `ENTITY_BRIEF_TASK = 'search_synthesis'` (decision D116) — not touched.

## Test plan

- [x] `pnpm --filter @open-brain/workers test src/__tests__/memory-consolidation.test.ts` — 12/12 passed
- [x] `CI=1 pnpm --filter @open-brain/workers test` — 51 files / 1021 tests passed
- [x] `pnpm -r exec tsc --noEmit` — exit 0
- [x] `pnpm --filter @open-brain/core-api test` — 67 files / 1163 tests passed
- [ ] CI: Integration tests (core-api + real DB) — awaiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)