### PR TITLE
fix(core-api): t1_spark model name + source_metadata column typo (Phase A.1+A.2)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10882,3 +10882,44 @@ Close 5 skipped test cases from Entry 143 test run:
 120 pass / 1 fail / 25 skip (was 115/1/30). Remaining 25 skips: 17 Slack (manual), 4 voice (iOS), 2 OBS (Grafana/Loki browser), 1 WD-03 (data present), 1 ADM-09 (origin-restricted).
 
 ---
+
+--- New session: 2026-05-09 — Remediation Phase A.1+A.2: t1_spark model name + source_metadata column typo ---
+
+## Entry 131 — Phase A.1+A.2: t1_spark model name + source_metadata column typo  [deploy] [config] [api] [debug] [decision]
+
+**Date:** 2026-05-09
+**Environment:** laptop (this VM); affects core-api + workers containers on homeserver
+**Duration:** TBD
+
+### Objective
+Stop ~700 of 744 failed BullMQ jobs caused by t1_spark model name 404 (workers requesting `qwen3.5-35b` but vLLM serves `spark-llm`). Also restore `/api/v1/system/flows` which silently returns `[]` due to a `metadata` vs `source_metadata` column typo in `getPipelineFlows()`.
+
+### Hypothesis
+- Changing `t1_spark.model` from `"qwen3.5-35b"` to `"spark-llm"` will eliminate the model-404 errors that cause entity extraction, enrichment, synthesis, and all other `t1_spark`-routed tasks to fail. Spark vLLM confirmed to serve model id `spark-llm` via pre-flight curl.
+- Fixing `metadata` → `source_metadata` in `getPipelineFlows()` SQL query + TS interface will stop the silent Postgres column-not-found error that the `catch` block swallows, returning `[]` and making the flows endpoint appear always empty.
+
+### Pre-flight verification
+- Spark model id: `curl http://spark.k4jda.net:8000/v1/models | jq -r '.data[].id'` → **`spark-llm`**
+- Confirmed: vLLM root is `Qwen/Qwen3.6-35B-A3B` served under alias `spark-llm`. Old config had `qwen3.5-35b` — mismatched at every step since Phase 4 (D75) when the tier was introduced.
+
+### Rollback plan
+`git revert <sha>` + `docker compose restart core-api workers` on homeserver. Config reload instant (no volume recreation needed). Failed jobs will need manual clearing via Bull Board — see Phase A.5.
+
+### Action
+1. `config/ai-routing.yaml`: `t1_spark.model` `qwen3.5-35b` → `spark-llm`. Updated inline comment to document the actual model: "Qwen3.6-35B-A3B served as `spark-llm` via vLLM".
+2. `packages/core-api/src/services/system-health.ts` `getPipelineFlows()`:
+   - TS interface field: `metadata` → `source_metadata`
+   - SQL SELECT: `metadata` → `source_metadata`
+   - Result mapping: `(r.metadata as Record<string, unknown>)?.trace_id` → `r.source_metadata?.trace_id`
+3. `packages/core-api/src/__tests__/system-health.test.ts`: Added `describe('getPipelineFlows()')` with two tests:
+   - Asserts SQL string contains `source_metadata` and NOT `"metadata"`; verifies `trace_id` correctly read from `source_metadata` field.
+   - Asserts empty array returned when DB throws (covers the silent-catch pattern).
+
+### Result
+TBD — fill in after deploy verification on homeserver.
+
+### Decision Log update
+No new decisions. Pre-existing D75 (add t1_spark) is amended: model id was wrong from the start; now corrected to `spark-llm`.
+
+### Action Items
+- A.5: After deploy — verify `docker logs --since 5m open-brain-workers | grep qwen3.5-35b | wc -l` = 0 and flows endpoint returns non-empty array. Clear failed-job backlog via Bull Board.

--- a/config/ai-routing.yaml
+++ b/config/ai-routing.yaml
@@ -104,13 +104,13 @@ model_tiers:
     fallback: t1_spark
 
   t1_spark:
-    # DGX Spark -- GB10 GPU at spark.k4jda.net. 35B Qwen model via vLLM.
+    # DGX Spark -- GB10 GPU at spark.k4jda.net. Qwen3.6-35B-A3B served as `spark-llm` via vLLM.
     # Free, higher quality than Jetson, handles complex structured output.
     # OpenAI-compatible endpoint -- does NOT support Anthropic tool_use.
     # Best for: entity extraction (JSON mode), synthesis, wiki tasks, daily ops.
     # WARNING: 120s timeout -- some heavy completions take 30-60s on 35B model.
     provider: openai_compat
-    model: "qwen3.5-35b"
+    model: "spark-llm"
     base_url: "http://spark.k4jda.net:8000/v1"
     max_completion_tokens: 4096
     timeout_ms: 120000

--- a/packages/core-api/src/__tests__/system-health.test.ts
+++ b/packages/core-api/src/__tests__/system-health.test.ts
@@ -319,6 +319,56 @@ describe('SystemHealthService', () => {
     })
   })
 
+  describe('getPipelineFlows()', () => {
+    it('reads source_metadata column (not metadata) in SQL query', async () => {
+      // Regression test for column typo: getPipelineFlows() must query
+      // source_metadata (the actual schema column), not metadata (which does not exist).
+      // A wrong column name causes Postgres to throw, which the catch block swallows
+      // silently, returning [] and making /api/v1/system/flows appear always empty.
+      const capturedSqls: string[] = []
+      const db = {
+        execute: vi.fn().mockImplementation((sqlTag: { queryChunks?: unknown[] }) => {
+          // Drizzle sql`` tags have a queryChunks array; stringify to inspect the SQL text
+          const raw = JSON.stringify(sqlTag)
+          capturedSqls.push(raw)
+          // First call: captures query — return two rows
+          if (capturedSqls.length === 1) {
+            return Promise.resolve({
+              rows: [
+                { id: 'cap-1', pipeline_status: 'complete', created_at: '2026-05-09T00:00:00Z', source_metadata: { trace_id: 'tr-1' } },
+                { id: 'cap-2', pipeline_status: 'failed',   created_at: '2026-05-09T00:01:00Z', source_metadata: null },
+              ],
+            })
+          }
+          // Second call: pipeline_events query
+          return Promise.resolve({ rows: [] })
+        }),
+      }
+      const service = new SystemHealthService(db as any, DEFAULT_REDIS_CONNECTION, DEFAULT_REDIS_URL)
+
+      const flows = await service.getPipelineFlows(10)
+
+      // The SQL for the captures query must reference source_metadata, not metadata
+      const capturesQuery = capturedSqls[0] ?? ''
+      expect(capturesQuery).toContain('source_metadata')
+      expect(capturesQuery).not.toContain('"metadata"')
+
+      // Verify the trace_id is correctly read from source_metadata
+      expect(flows).toHaveLength(2)
+      expect(flows[0].trace_id).toBe('tr-1')
+      expect(flows[1].trace_id).toBeNull()
+    })
+
+    it('returns empty array when database throws', async () => {
+      const db = { execute: vi.fn().mockRejectedValue(new Error('column metadata does not exist')) }
+      const service = new SystemHealthService(db as any, DEFAULT_REDIS_CONNECTION, DEFAULT_REDIS_URL)
+
+      const flows = await service.getPipelineFlows()
+
+      expect(flows).toEqual([])
+    })
+  })
+
   describe('overall status derivation', () => {
     it('unhealthy overrides everything', async () => {
       // Redis critical + queue normal → unhealthy

--- a/packages/core-api/src/services/system-health.ts
+++ b/packages/core-api/src/services/system-health.ts
@@ -428,9 +428,9 @@ export class SystemHealthService {
         id: string
         pipeline_status: string
         created_at: string
-        metadata: Record<string, unknown> | null
+        source_metadata: Record<string, unknown> | null
       }>(sql`
-        SELECT id, pipeline_status, created_at, metadata
+        SELECT id, pipeline_status, created_at, source_metadata
         FROM captures
         WHERE pipeline_status IN ('processing', 'pending', 'partial', 'complete', 'failed')
         ORDER BY created_at DESC
@@ -470,7 +470,7 @@ export class SystemHealthService {
 
       return rows.rows.map(r => ({
         capture_id: r.id,
-        trace_id: (r.metadata as Record<string, unknown>)?.trace_id as string | null ?? null,
+        trace_id: r.source_metadata?.trace_id as string | null ?? null,
         pipeline_status: r.pipeline_status,
         created_at: r.created_at,
         stages: eventMap.get(r.id) ?? [],


### PR DESCRIPTION
## Summary
- Resolves the bulk of #200's 744 failed jobs (model name 404)
- Fixes silent-fail in /api/v1/system/flows (column typo)

## Context
- Phase A.1 + A.2 of `IMPLEMENTATION_PLAN-2026-05-09-REMEDIATION.md`
- Verified Spark vLLM model id via curl before edit
- Regression test added for column reference

## Test plan
- [ ] CI green (workers + core-api tests)
- [ ] Post-merge deploy: `docker compose restart core-api workers` on homeserver
- [ ] Verify: `docker logs --since 5m open-brain-workers | grep qwen3.5-35b | wc -l` returns 0
- [ ] Verify: `curl -s https://brain.troy-davis.com/api/v1/system/flows | jq '. | length'` > 0
- [ ] Verify: failed-jobs cleanup (Phase A.5) clears the queue backlog

Refs #200