### PR TITLE
fix(core-api): pipeline_events.started_at → created_at (Phase A.2b)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10939,5 +10939,71 @@ Stop ~700 of 744 failed BullMQ jobs caused by t1_spark model name 404 (workers r
 No new decisions. Pre-existing D75 (add t1_spark) is amended: model id was wrong from the start; now corrected to `spark-llm`. A.2 bug is compound — needs a follow-up fix to the `pipeline_events` query.
 
 ### Action Items
-- **[NEW] A.2b:** Fix `getPipelineFlows()` pipeline_events query — `started_at` → `created_at` in both SELECT and ORDER BY; verify actual pipeline_events columns match the TypeScript interface fields.
-- A.5: After A.2b is resolved — clear failed-job backlog via Bull Board. Verify flows endpoint returns non-empty array.
+- **[CLOSED] A.2b:** Fixed in PR #202 — see Entry 132.
+- A.5: After A.2b deploy — clear failed-job backlog via Bull Board. Verify flows endpoint returns non-empty array.
+
+---
+
+### Entry 132 — Phase A.2b: pipeline_events.started_at → created_at follow-on fix (2026-05-09)
+
+**Date:** 2026-05-09
+**Environment:** laptop VM (development); affects core-api on homeserver
+**Tags:** `[deploy]` `[api]` `[debug]` `[database]`
+**Duration:** ~20 minutes
+
+### Objective
+
+Complete Phase A.2 — get `/api/v1/system/flows` returning real data. Entry 131 confirmed the `source_metadata` fix (captures query) but surfaced a second column-name bug in the same function's `pipeline_events` query.
+
+### Hypothesis
+
+`pipeline_events` schema has `created_at` (not `started_at`) as the timestamp column. Fixing the SELECT, ORDER BY, TS interface, and result mapping will eliminate the silent catch block swallow and allow the flows endpoint to return populated data.
+
+### Rollback plan
+
+`git revert <sha>` + `docker compose build core-api && docker compose up -d --no-deps core-api` on homeserver.
+
+### Pre-flight schema verification
+
+Actual `pipeline_events` columns (confirmed via `\d pipeline_events`):
+
+```
+id          uuid      NOT NULL  PK
+capture_id  uuid      NOT NULL  FK → captures(id) CASCADE
+stage       text      NOT NULL  CHECK constraint (12 valid values)
+status      text      NOT NULL  CHECK constraint (started/success/failed)
+duration_ms integer
+error       text
+metadata    jsonb
+created_at  timestamptz NOT NULL  DEFAULT now()
+```
+
+Verdict: `started_at` does NOT exist. `error` IS correct (not `error_message`). All other SELECT fields (`capture_id`, `stage`, `status`, `duration_ms`, `error`) are valid. Only `started_at` needs replacement with `created_at`. The `PipelineFlowEntry.stages` type also had `started_at: string | null` which needed updating.
+
+### Action
+
+4 changes to `packages/core-api/src/services/system-health.ts`:
+
+1. `PipelineFlowEntry.stages` interface: `started_at: string | null` → `created_at: string | null`
+2. `db.execute<{...}>` TS generic: `started_at: string | null` → `created_at: string | null`
+3. SQL SELECT: `started_at` → `created_at`; ORDER BY: `started_at ASC` → `created_at ASC`
+4. Result mapping push: `started_at: e.started_at` → `created_at: e.created_at`
+
+1 change to route-level test mock: stage object `started_at: '...'` → `created_at: '...'` (type alignment).
+
+Regression guard added to existing `reads source_metadata column` test in `getPipelineFlows()` describe block:
+- Asserts `capturedSqls[1]` (the pipeline_events query) contains `created_at`
+- Asserts `capturedSqls[1]` does NOT contain `started_at`
+
+### Test results
+
+```
+tsc --noEmit: clean (no output)
+pnpm --filter @open-brain/core-api test system-health: 39/39 PASS
+```
+
+### Result
+
+**Deploy date:** 2026-05-09 (TBD — see deploy section)
+**Homeserver HEAD:** TBD
+**Expected:** `curl http://localhost:3002/api/v1/system/flows | jq '.flows | length'` > 0

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10882,3 +10882,44 @@ Close 5 skipped test cases from Entry 143 test run:
 120 pass / 1 fail / 25 skip (was 115/1/30). Remaining 25 skips: 17 Slack (manual), 4 voice (iOS), 2 OBS (Grafana/Loki browser), 1 WD-03 (data present), 1 ADM-09 (origin-restricted).
 
 ---
+
+--- New session: 2026-05-09 — Remediation Phase A.1+A.2: t1_spark model name + source_metadata column typo ---
+
+## Entry 131 — Phase A.1+A.2: t1_spark model name + source_metadata column typo  [deploy] [config] [api] [debug] [decision]
+
+**Date:** 2026-05-09
+**Environment:** laptop (this VM); affects core-api + workers containers on homeserver
+**Duration:** TBD
+
+### Objective
+Stop ~700 of 744 failed BullMQ jobs caused by t1_spark model name 404 (workers requesting `qwen3.5-35b` but vLLM serves `spark-llm`). Also restore `/api/v1/system/flows` which silently returns `[]` due to a `metadata` vs `source_metadata` column typo in `getPipelineFlows()`.
+
+### Hypothesis
+- Changing `t1_spark.model` from `"qwen3.5-35b"` to `"spark-llm"` will eliminate the model-404 errors that cause entity extraction, enrichment, synthesis, and all other `t1_spark`-routed tasks to fail. Spark vLLM confirmed to serve model id `spark-llm` via pre-flight curl.
+- Fixing `metadata` → `source_metadata` in `getPipelineFlows()` SQL query + TS interface will stop the silent Postgres column-not-found error that the `catch` block swallows, returning `[]` and making the flows endpoint appear always empty.
+
+### Pre-flight verification
+- Spark model id: `curl http://spark.k4jda.net:8000/v1/models | jq -r '.data[].id'` → **`spark-llm`**
+- Confirmed: vLLM root is `Qwen/Qwen3.6-35B-A3B` served under alias `spark-llm`. Old config had `qwen3.5-35b` — mismatched at every step since Phase 4 (D75) when the tier was introduced.
+
+### Rollback plan
+`git revert <sha>` + `docker compose restart core-api workers` on homeserver. Config reload instant (no volume recreation needed). Failed jobs will need manual clearing via Bull Board — see Phase A.5.
+
+### Action
+1. `config/ai-routing.yaml`: `t1_spark.model` `qwen3.5-35b` → `spark-llm`. Updated inline comment to document the actual model: "Qwen3.6-35B-A3B served as `spark-llm` via vLLM".
+2. `packages/core-api/src/services/system-health.ts` `getPipelineFlows()`:
+   - TS interface field: `metadata` → `source_metadata`
+   - SQL SELECT: `metadata` → `source_metadata`
+   - Result mapping: `(r.metadata as Record<string, unknown>)?.trace_id` → `r.source_metadata?.trace_id`
+3. `packages/core-api/src/__tests__/system-health.test.ts`: Added `describe('getPipelineFlows()')` with two tests:
+   - Asserts SQL string contains `source_metadata` and NOT `"metadata"`; verifies `trace_id` correctly read from `source_metadata` field.
+   - Asserts empty array returned when DB throws (covers the silent-catch pattern).
+
+### Result
+TBD — fill in after deploy verification on homeserver.
+
+### Decision Log update
+No new decisions. Pre-existing D75 (add t1_spark) is amended: model id was wrong from the start; now corrected to `spark-llm`.
+
+### Action Items
+- A.5: After deploy — verify `docker logs --since 5m open-brain-workers | grep qwen3.5-35b | wc -l` = 0 and flows endpoint returns non-empty array. Clear failed-job backlog via Bull Board.

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10916,10 +10916,28 @@ Stop ~700 of 744 failed BullMQ jobs caused by t1_spark model name 404 (workers r
    - Asserts empty array returned when DB throws (covers the silent-catch pattern).
 
 ### Result
-TBD — fill in after deploy verification on homeserver.
+**Deploy date:** 2026-05-09  
+**Homeserver HEAD:** `b7dfd11` (squash merge of PR #201)  
+**Deploy method:** `git pull --ff-only origin main` + `docker compose build core-api` + `docker compose up -d --no-deps core-api` + `docker compose restart workers`  
+**Note:** `docker compose restart` alone reuses the existing image — the source fix only takes effect after `docker compose build` + `up`. Container rebuild was required.
+
+**A.1 — t1_spark model name (PASS):**
+- `docker logs --since 3m open-brain-workers | grep -c 'qwen3.5-35b'` → **0**
+- No model-404 errors in workers logs in the 3-minute post-restart window.
+- (No skill execution jobs fired in the window — expected, cron-driven. Absence of errors is the confirmation.)
+
+**A.2 — source_metadata column fix (PARTIAL PASS / NEW BUG FOUND):**
+- First query (`captures` SELECT with `source_metadata`) now executes correctly — `metadata` column-not-exist error is gone.
+- Second query (`pipeline_events` JOIN) fails: `column "started_at" does not exist`.
+- `pipeline_events` actual schema: columns are `created_at` (not `started_at`) and `metadata` (not `source_metadata`). The PR #201 fix only addressed the `captures` table's column name; the `pipeline_events` SELECT in `getPipelineFlows()` references two non-existent columns.
+- `/api/v1/system/flows` still returns `{"flows":[]}` due to the second `catch` swallowing the `started_at` error.
+- `grep -c 'column "metadata" does not exist'` in core-api logs → **0** (original bug is fixed; new bug surfaced).
+
+**Status:** A.1 fully resolved. A.2 partially resolved — one of two column bugs fixed. Second bug (`started_at` → `created_at` in pipeline_events query, and `error`/`started_at` SELECT fields vs actual schema) is a follow-on regression that was not in scope of PR #201 and was not caught by the unit test (test mocked the DB, not the real schema). STOPPING as instructed — surfacing to orchestrator. No rollback needed (system is functional, flows endpoint just remains empty as before).
 
 ### Decision Log update
-No new decisions. Pre-existing D75 (add t1_spark) is amended: model id was wrong from the start; now corrected to `spark-llm`.
+No new decisions. Pre-existing D75 (add t1_spark) is amended: model id was wrong from the start; now corrected to `spark-llm`. A.2 bug is compound — needs a follow-up fix to the `pipeline_events` query.
 
 ### Action Items
-- A.5: After deploy — verify `docker logs --since 5m open-brain-workers | grep qwen3.5-35b | wc -l` = 0 and flows endpoint returns non-empty array. Clear failed-job backlog via Bull Board.
+- **[NEW] A.2b:** Fix `getPipelineFlows()` pipeline_events query — `started_at` → `created_at` in both SELECT and ORDER BY; verify actual pipeline_events columns match the TypeScript interface fields.
+- A.5: After A.2b is resolved — clear failed-job backlog via Bull Board. Verify flows endpoint returns non-empty array.

--- a/config/ai-routing.yaml
+++ b/config/ai-routing.yaml
@@ -104,13 +104,13 @@ model_tiers:
     fallback: t1_spark
 
   t1_spark:
-    # DGX Spark -- GB10 GPU at spark.k4jda.net. 35B Qwen model via vLLM.
+    # DGX Spark -- GB10 GPU at spark.k4jda.net. Qwen3.6-35B-A3B served as `spark-llm` via vLLM.
     # Free, higher quality than Jetson, handles complex structured output.
     # OpenAI-compatible endpoint -- does NOT support Anthropic tool_use.
     # Best for: entity extraction (JSON mode), synthesis, wiki tasks, daily ops.
     # WARNING: 120s timeout -- some heavy completions take 30-60s on 35B model.
     provider: openai_compat
-    model: "qwen3.5-35b"
+    model: "spark-llm"
     base_url: "http://spark.k4jda.net:8000/v1"
     max_completion_tokens: 4096
     timeout_ms: 120000

--- a/packages/core-api/src/__tests__/system-health.test.ts
+++ b/packages/core-api/src/__tests__/system-health.test.ts
@@ -353,6 +353,12 @@ describe('SystemHealthService', () => {
       expect(capturesQuery).toContain('source_metadata')
       expect(capturesQuery).not.toContain('"metadata"')
 
+      // Regression guard: the pipeline_events query must use created_at (actual column),
+      // NOT started_at (which does not exist on pipeline_events and causes a silent [] return).
+      const eventsQuery = capturedSqls[1] ?? ''
+      expect(eventsQuery).toContain('created_at')
+      expect(eventsQuery).not.toContain('started_at')
+
       // Verify the trace_id is correctly read from source_metadata
       expect(flows).toHaveLength(2)
       expect(flows[0].trace_id).toBe('tr-1')
@@ -503,7 +509,7 @@ describe('system-health routes', () => {
         trace_id: 'trace-abc',
         pipeline_status: 'complete',
         created_at: '2026-05-01T12:00:00Z',
-        stages: [{ stage: 'embed', status: 'success', duration_ms: 80, error: null, started_at: '2026-05-01T12:00:01Z' }],
+        stages: [{ stage: 'embed', status: 'success', duration_ms: 80, error: null, created_at: '2026-05-01T12:00:01Z' }],
       },
     ]
     vi.spyOn(service, 'getPipelineFlows').mockResolvedValue(mockFlows)

--- a/packages/core-api/src/__tests__/system-health.test.ts
+++ b/packages/core-api/src/__tests__/system-health.test.ts
@@ -319,6 +319,56 @@ describe('SystemHealthService', () => {
     })
   })
 
+  describe('getPipelineFlows()', () => {
+    it('reads source_metadata column (not metadata) in SQL query', async () => {
+      // Regression test for column typo: getPipelineFlows() must query
+      // source_metadata (the actual schema column), not metadata (which does not exist).
+      // A wrong column name causes Postgres to throw, which the catch block swallows
+      // silently, returning [] and making /api/v1/system/flows appear always empty.
+      const capturedSqls: string[] = []
+      const db = {
+        execute: vi.fn().mockImplementation((sqlTag: { queryChunks?: unknown[] }) => {
+          // Drizzle sql`` tags have a queryChunks array; stringify to inspect the SQL text
+          const raw = JSON.stringify(sqlTag)
+          capturedSqls.push(raw)
+          // First call: captures query — return two rows
+          if (capturedSqls.length === 1) {
+            return Promise.resolve({
+              rows: [
+                { id: 'cap-1', pipeline_status: 'complete', created_at: '2026-05-09T00:00:00Z', source_metadata: { trace_id: 'tr-1' } },
+                { id: 'cap-2', pipeline_status: 'failed',   created_at: '2026-05-09T00:01:00Z', source_metadata: null },
+              ],
+            })
+          }
+          // Second call: pipeline_events query
+          return Promise.resolve({ rows: [] })
+        }),
+      }
+      const service = new SystemHealthService(db as any, DEFAULT_REDIS_CONNECTION, DEFAULT_REDIS_URL)
+
+      const flows = await service.getPipelineFlows(10)
+
+      // The SQL for the captures query must reference source_metadata, not metadata
+      const capturesQuery = capturedSqls[0] ?? ''
+      expect(capturesQuery).toContain('source_metadata')
+      expect(capturesQuery).not.toContain('"metadata"')
+
+      // Verify the trace_id is correctly read from source_metadata
+      expect(flows).toHaveLength(2)
+      expect(flows[0].trace_id).toBe('tr-1')
+      expect(flows[1].trace_id).toBeNull()
+    })
+
+    it('returns empty array when database throws', async () => {
+      const db = { execute: vi.fn().mockRejectedValue(new Error('column metadata does not exist')) }
+      const service = new SystemHealthService(db as any, DEFAULT_REDIS_CONNECTION, DEFAULT_REDIS_URL)
+
+      const flows = await service.getPipelineFlows()
+
+      expect(flows).toEqual([])
+    })
+  })
+
   describe('overall status derivation', () => {
     it('unhealthy overrides everything', async () => {
       // Redis critical + queue normal → unhealthy

--- a/packages/core-api/src/services/system-health.ts
+++ b/packages/core-api/src/services/system-health.ts
@@ -112,7 +112,7 @@ export interface PipelineFlowEntry {
     status: string
     duration_ms: number | null
     error: string | null
-    started_at: string | null
+    created_at: string | null
   }>
 }
 
@@ -447,12 +447,12 @@ export class SystemHealthService {
         status: string
         duration_ms: number | null
         error: string | null
-        started_at: string | null
+        created_at: string | null
       }>(sql`
-        SELECT capture_id, stage, status, duration_ms, error, started_at
+        SELECT capture_id, stage, status, duration_ms, error, created_at
         FROM pipeline_events
         WHERE capture_id = ANY(${captureIds})
-        ORDER BY started_at ASC
+        ORDER BY created_at ASC
       `)
 
       // Group events by capture_id
@@ -464,7 +464,7 @@ export class SystemHealthService {
           status: e.status,
           duration_ms: e.duration_ms,
           error: e.error,
-          started_at: e.started_at,
+          created_at: e.created_at,
         })
       }
 

--- a/packages/core-api/src/services/system-health.ts
+++ b/packages/core-api/src/services/system-health.ts
@@ -428,9 +428,9 @@ export class SystemHealthService {
         id: string
         pipeline_status: string
         created_at: string
-        metadata: Record<string, unknown> | null
+        source_metadata: Record<string, unknown> | null
       }>(sql`
-        SELECT id, pipeline_status, created_at, metadata
+        SELECT id, pipeline_status, created_at, source_metadata
         FROM captures
         WHERE pipeline_status IN ('processing', 'pending', 'partial', 'complete', 'failed')
         ORDER BY created_at DESC
@@ -470,7 +470,7 @@ export class SystemHealthService {
 
       return rows.rows.map(r => ({
         capture_id: r.id,
-        trace_id: (r.metadata as Record<string, unknown>)?.trace_id as string | null ?? null,
+        trace_id: r.source_metadata?.trace_id as string | null ?? null,
         pipeline_status: r.pipeline_status,
         created_at: r.created_at,
         stages: eventMap.get(r.id) ?? [],


### PR DESCRIPTION
## Summary

Follow-on to #201. Second column-name typo in `getPipelineFlows()`.

- PR #201 fixed `captures.metadata → source_metadata` but the same function has a second `db.execute` against `pipeline_events` that referenced `started_at` (does not exist; actual column is `created_at`). Drizzle's catch block was swallowing the Postgres error and returning `[]` silently, so post-#201 deploy verification still showed empty `/api/v1/system/flows`.
- Schema pre-flight confirmed: `pipeline_events` has `created_at` (timestamptz), not `started_at`. All other SELECT fields (`capture_id`, `stage`, `status`, `duration_ms`, `error`) were correct.
- `PipelineFlowEntry.stages` interface updated to match (`started_at → created_at`).
- Regression guard added: second `db.execute` SQL assertion now checks `created_at` present, `started_at` absent.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 39/39 system-health unit tests pass
- [ ] CI green (Integration tests gate)
- [ ] Post-merge deploy + restart
- [ ] Verify: `curl http://localhost:3002/api/v1/system/flows | jq '.flows | length'` > 0

Refs #200