### PR TITLE
feat(api,web): settings GET 404→200 with null payload (Phase C)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10885,6 +10885,26 @@ Close 5 skipped test cases from Entry 143 test run:
 
 ---
 
+--- New session: 2026-05-09 — Remediation Phase C: settings GET 404→200 noise elimination ---
+
+## Entry 146 — Phase C: settings GET 404→200 (2026-05-09)  [api] [web] [decision]
+
+**Date:** 2026-05-09
+**Environment:** laptop VM; affects core-api + web-next containers on homeserver
+**Duration:** TBD
+
+**Objective:** Eliminate ~6 NotFoundError stack traces per dashboard load (issue #200 RC4). Every fresh dashboard load fires GET /api/v1/settings/:key for each whitelisted-but-unset key (autonomy_level, ingest_voice_min_duration, entity_confidence_threshold, etc.). The route threw NotFoundError for missing rows, producing stack-trace log noise even though the frontend already had `.catch(() => default)` workarounds.
+
+**Hypothesis:** Changing GET semantic from 404 → 200 with `{key, value: null, updated_at: null}` matches the frontend's existing assumption (missing = use default). Frontend `.catch()` plumbing can be removed and replaced with `data?.value ?? DEFAULTS[key]` reads. Test A110 regression (missing-row → 404) must be updated in lockstep. Observable but non-breaking: API consumers that check for 404 will need updating, but there are none except the removed `.catch()` wrappers.
+
+**Rollback plan:** `git revert <sha>` — no schema changes, no migrations.
+
+**Action:** Route change in `packages/core-api/src/routes/settings.ts` (2 lines); test update in `settings-routes.test.ts` (update 2 existing + add 1 new); frontend cleanup in `IngestFiltersSection.tsx` + `EntityExtractionSection.tsx` (drop `.catch()`, add `DEFAULTS` const, read `DEFAULTS.key` instead of inline literals).
+
+**Result:** TBD — pending deploy and log verification.
+
+---
+
 --- New session: 2026-05-09 — Remediation Phase A.1+A.2: t1_spark model name + source_metadata column typo ---
 
 ## Entry 131 — Phase A.1+A.2: t1_spark model name + source_metadata column typo  [deploy] [config] [api] [debug] [decision]

--- a/packages/core-api/src/__tests__/settings-routes.test.ts
+++ b/packages/core-api/src/__tests__/settings-routes.test.ts
@@ -7,7 +7,7 @@
  *
  * Per CLAUDE.md, `app_settings` is a generic key/value store. The route
  * enforces:
- *   - VALID_SETTINGS_KEYS whitelist on PUT (404 path on GET when row missing)
+ *   - VALID_SETTINGS_KEYS whitelist on PUT (200+null payload on GET when row missing — Phase C)
  *   - Type-specific validators (autonomy_level, auto_response_threshold,
  *     auto_response_staleness_days, monitored_channels)
  *   - JSONB roundtrip preservation (value passed through to upsert as-is)
@@ -108,19 +108,21 @@ describe('GET /api/v1/settings/:key', () => {
     })
   })
 
-  it('returns 404 NotFoundError when whitelisted key has no row in DB', async () => {
+  it('returns 200 with null payload when whitelisted key has no row in DB', async () => {
+    // Phase C: missing-row is no longer a 404. Route returns 200 with null value
+    // so frontend can read data?.value ?? DEFAULT cleanly without .catch() plumbing.
     const { app } = buildApp({ selectRows: [] })
 
     const { status, body } = await testJson(app, '/api/v1/settings/autonomy_level')
 
-    expect(status).toBe(404)
-    expect((body as { code?: string }).code).toBe('NOT_FOUND')
+    expect(status).toBe(200)
+    expect(body).toEqual({ key: 'autonomy_level', value: null, updated_at: null })
   })
 
   it('returns 400 ValidationError for non-whitelisted key (A110)', async () => {
-    // A110: GET now enforces VALID_SETTINGS_KEYS whitelist — non-whitelisted key
-    // returns 400 + VALIDATION_ERROR rather than falling through to DB and
-    // returning 404. Error message matches the PUT endpoint's pattern exactly.
+    // A110: GET enforces VALID_SETTINGS_KEYS whitelist — non-whitelisted key
+    // returns 400 + VALIDATION_ERROR rather than falling through to DB.
+    // Error message matches the PUT endpoint's pattern exactly.
     const { app, select } = buildApp({ selectRows: [] })
 
     const { status, body } = await testJson(app, '/api/v1/settings/totally_made_up_key')
@@ -132,16 +134,16 @@ describe('GET /api/v1/settings/:key', () => {
     expect(select).not.toHaveBeenCalled()
   })
 
-  it('returns 404 when whitelisted key has no row in DB (A110 regression)', async () => {
-    // Whitelisted key with no DB row must still return 404 (not 400).
-    // This confirms the whitelist gate fires before the DB query but that
-    // a valid key with a missing row still reaches NotFoundError normally.
+  it('returns 200 with null payload for whitelisted-but-unset key (Phase C RC4)', async () => {
+    // Phase C: whitelisted-but-unset key returns {key, value: null, updated_at: null}.
+    // This confirms the whitelist gate fires before the DB query and that
+    // a valid key with a missing row returns the null-payload shape, not 404.
     const { app } = buildApp({ selectRows: [] })
 
     const { status, body } = await testJson(app, '/api/v1/settings/user_profile')
 
-    expect(status).toBe(404)
-    expect((body as { code?: string }).code).toBe('NOT_FOUND')
+    expect(status).toBe(200)
+    expect(body).toEqual({ key: 'user_profile', value: null, updated_at: null })
   })
 })
 

--- a/packages/core-api/src/routes/settings.ts
+++ b/packages/core-api/src/routes/settings.ts
@@ -2,7 +2,6 @@ import type { Hono } from 'hono'
 import { eq } from 'drizzle-orm'
 import type { Database } from '@open-brain/shared'
 import {
-  NotFoundError,
   ValidationError,
   app_settings,
   AUTONOMY_LEVELS,
@@ -78,7 +77,7 @@ export function registerSettingsRoutes(app: Hono, db: Database): void {
     }
     const rows = await db.select().from(app_settings).where(eq(app_settings.key, key))
     if (rows.length === 0) {
-      throw new NotFoundError(`Setting not found: ${key}`)
+      return c.json({ key, value: null, updated_at: null })
     }
     return c.json({ key: rows[0].key, value: rows[0].value, updated_at: rows[0].updated_at })
   })

--- a/packages/web-next/components/settings/EntityExtractionSection.tsx
+++ b/packages/web-next/components/settings/EntityExtractionSection.tsx
@@ -161,6 +161,17 @@ const TOGGLE_SETTINGS = [
   },
 ] as const;
 
+/**
+ * Default values for entity extraction settings.
+ * API returns {value: null} for whitelisted-but-unset keys (Phase C);
+ * components read `data?.value ?? DEFAULTS[key]` instead of .catch() plumbing.
+ */
+const DEFAULTS = {
+  entity_extract_locations: true,
+  entity_extract_monetary: false,
+  entity_confidence_threshold: 0.7,
+} as const;
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -170,34 +181,19 @@ export function EntityExtractionSection() {
 
   const locationQuery = useQuery({
     queryKey: ['settings', 'entity_extract_locations'],
-    queryFn: () =>
-      settingsApi.get('entity_extract_locations').catch(() => ({
-        key: 'entity_extract_locations',
-        value: TOGGLE_SETTINGS[0].defaultValue,
-        updated_at: null,
-      })),
+    queryFn: () => settingsApi.get('entity_extract_locations'),
     staleTime: 60_000,
   });
 
   const monetaryQuery = useQuery({
     queryKey: ['settings', 'entity_extract_monetary'],
-    queryFn: () =>
-      settingsApi.get('entity_extract_monetary').catch(() => ({
-        key: 'entity_extract_monetary',
-        value: TOGGLE_SETTINGS[1].defaultValue,
-        updated_at: null,
-      })),
+    queryFn: () => settingsApi.get('entity_extract_monetary'),
     staleTime: 60_000,
   });
 
   const confidenceQuery = useQuery({
     queryKey: ['settings', 'entity_confidence_threshold'],
-    queryFn: () =>
-      settingsApi.get('entity_confidence_threshold').catch(() => ({
-        key: 'entity_confidence_threshold',
-        value: 0.7,
-        updated_at: null,
-      })),
+    queryFn: () => settingsApi.get('entity_confidence_threshold'),
     staleTime: 60_000,
   });
 
@@ -225,17 +221,17 @@ export function EntityExtractionSection() {
   const locationChecked =
     typeof locationQuery.data?.value === 'boolean'
       ? locationQuery.data.value
-      : TOGGLE_SETTINGS[0].defaultValue;
+      : DEFAULTS.entity_extract_locations;
 
   const monetaryChecked =
     typeof monetaryQuery.data?.value === 'boolean'
       ? monetaryQuery.data.value
-      : TOGGLE_SETTINGS[1].defaultValue;
+      : DEFAULTS.entity_extract_monetary;
 
   const confidenceValue =
     typeof confidenceQuery.data?.value === 'number'
       ? confidenceQuery.data.value
-      : 0.7;
+      : DEFAULTS.entity_confidence_threshold;
 
   return (
     <Card

--- a/packages/web-next/components/settings/IngestFiltersSection.tsx
+++ b/packages/web-next/components/settings/IngestFiltersSection.tsx
@@ -160,6 +160,18 @@ const TOGGLE_SETTINGS = [
   },
 ] as const;
 
+/**
+ * Default values for ingest filter settings.
+ * API returns {value: null} for whitelisted-but-unset keys (Phase C);
+ * components read `data?.value ?? DEFAULTS[key]` instead of .catch() plumbing.
+ */
+const DEFAULTS = {
+  ingest_skip_automated_emails: true,
+  ingest_skip_low_signal_slack: true,
+  ingest_capture_bare_calendar: false,
+  ingest_voice_min_duration: 5,
+} as const;
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -172,24 +184,14 @@ export function IngestFiltersSection() {
     // eslint-disable-next-line react-hooks/rules-of-hooks -- stable array, safe
     useQuery({
       queryKey: ['settings', cfg.key],
-      queryFn: () =>
-        settingsApi.get(cfg.key).catch(() => ({
-          key: cfg.key,
-          value: cfg.defaultValue,
-          updated_at: null,
-        })),
+      queryFn: () => settingsApi.get(cfg.key),
       staleTime: 60_000,
     }),
   );
 
   const voiceDurationQuery = useQuery({
     queryKey: ['settings', 'ingest_voice_min_duration'],
-    queryFn: () =>
-      settingsApi.get('ingest_voice_min_duration').catch(() => ({
-        key: 'ingest_voice_min_duration',
-        value: 5,
-        updated_at: null,
-      })),
+    queryFn: () => settingsApi.get('ingest_voice_min_duration'),
     staleTime: 60_000,
   });
 
@@ -243,7 +245,7 @@ export function IngestFiltersSection() {
           value={
             typeof voiceDurationQuery.data?.value === 'number'
               ? voiceDurationQuery.data.value
-              : 5
+              : DEFAULTS.ingest_voice_min_duration
           }
           min={0}
           max={300}


### PR DESCRIPTION
## Summary
Eliminates settings 404 log-noise from #200 RC4 by aligning route semantic with frontend's existing 'missing → default' assumption.

- core-api: `GET /api/v1/settings/:key` returns 200 with null body when whitelisted-but-unset
- test A110 updated; new test for null-payload shape
- web-next: drop `.catch()` workarounds in IngestFiltersSection + EntityExtractionSection

## Test plan
- [ ] CI green (Integration tests gate)
- [ ] Post-merge deploy of both core-api + web-next
- [ ] Verify: `curl -s https://brain.troy-davis.com/api/v1/settings/ingest_voice_min_duration | jq '.value'` returns `null` (not 404)
- [ ] Verify: 1 minute of dashboard load → 0 'Setting not found' errors in core-api logs

Refs #200