### PR TITLE
fix(workers): TS2502 in entity-resolution.test.ts (Phase E.2)

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,7 @@
 # Implementation Plan: Consolidate LLM Model Assignments into ai-routing.yaml
 
+**Status: COMPLETE (verified 2026-05-09 via Phase E.1 audit)**
+
 **Date:** 2026-04-21
 **Scope:** Move all hardcoded LLM model references into `config/ai-routing.yaml`, add comprehensive documentation
 **Risk:** Low — plumbing changes only, no behavior change for existing features
@@ -23,7 +25,7 @@
 - [x] `wiki_lint`, `monthly_reflection` entries present in task_routing
 - [x] `wiki_ingest` points to `t1_fast` (Anthropic tier)
 - [x] `models.intent` entry present
-- [ ] ConfigService loads without error (run unit tests)
+- [x] ConfigService loads without error (run unit tests)
 
 ### 1.2 Wire configService to wiki-ingest skill
 
@@ -44,7 +46,7 @@
 - [x] No hardcoded model string in wiki-ingest.ts
 - [x] `resolveTaskModel()` called in constructor
 - [x] ModelResolverError thrown if no configService and no opts.model
-- [ ] Existing wiki-ingest tests pass (may need mock configService updates)
+- [x] Existing wiki-ingest tests pass (may need mock configService updates)
 
 ### 1.3 Wire configService to wiki-lint skill
 
@@ -59,7 +61,7 @@
 **Acceptance:**
 - [x] No hardcoded model string in wiki-lint.ts
 - [x] Old model ID `claude-sonnet-4-5-20250929` removed from codebase
-- [ ] Existing tests pass
+- [x] Existing tests pass
 
 ### 1.4 Wire configService to monthly-reflection skill
 
@@ -73,7 +75,7 @@
 **Acceptance:**
 - [x] No hardcoded model string in monthly-reflection.ts
 - [x] Old model ID `claude-sonnet-4-5-20250929` removed from codebase
-- [ ] Existing tests pass
+- [x] Existing tests pass
 
 ### 1.5 Pass configService to agent skills in skill-execution worker
 
@@ -106,7 +108,7 @@
 
 **Acceptance:**
 - [x] All worker tests pass: `pnpm --filter @open-brain/workers test`
-- [ ] All core-api tests pass: `pnpm --filter @open-brain/core-api test`
+- [x] All core-api tests pass: `pnpm --filter @open-brain/core-api test`
 - [x] TypeScript clean: `pnpm --filter @open-brain/workers exec tsc --noEmit`
 
 ---
@@ -141,12 +143,12 @@
 
 ## Verification Checklist (run after all phases)
 
-- [ ] `pnpm --filter @open-brain/workers test` — all tests pass
-- [ ] `pnpm --filter @open-brain/core-api test` — all tests pass
-- [ ] `pnpm --filter @open-brain/workers exec tsc --noEmit` — TypeScript clean
-- [ ] `grep -rn 'claude-sonnet-4-5-20250929\|claude-haiku-4-5-20251001' packages/workers/src/skills/` returns zero hits (no hardcoded models remain)
-- [ ] `grep -n 'models.intent\|gpt-5.4' config/ai-routing.yaml` confirms intent model present
-- [ ] Local startup test: workers process connects and logs resolved models at INFO level
+- [x] `pnpm --filter @open-brain/workers test` — all tests pass (1021/1021)
+- [x] `pnpm --filter @open-brain/core-api test` — all tests pass (1180/1180)
+- [x] `pnpm --filter @open-brain/workers exec tsc --noEmit` — TypeScript clean
+- [x] `grep -rn 'claude-sonnet-4-5-20250929\|claude-haiku-4-5-20251001' packages/workers/src/skills/` — zero functional hits (two JSDoc comment examples in wiki-ingest.ts; no runtime defaults)
+- [x] `grep -n 'models.intent\|gpt-5.4' config/ai-routing.yaml` — intent model present (line 51: `intent: "gpt-5.4"`)
+- [ ] Local startup test: workers process connects and logs resolved models at INFO level (skipped — deployment-side verification, not CI-verifiable locally)
 
 ---
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -11123,3 +11123,27 @@ After fixes, re-ran grep. Remaining class (b) hits in `components/` are all in h
 | # | Action | Priority |
 |---|--------|----------|
 | A83 | Prop-lift `now` to RSC parents for remaining 17 class-(b) components (EmailTabs, ChannelTable, ProviderTabs, FlowsTab, SkillsTab, OverviewTab, TimelineEntry, TimelineClient, SkillCard, etc.) | LOW — TZ fix reduces blast radius; these are cosmetic time-display offsets, not data integrity issues |
+
+---
+
+### Entry 147 — Phase E.2: TS2502 in entity-resolution.test.ts (2026-05-09)
+
+**Date:** 2026-05-09
+**Environment:** laptop VM (investigation only — no deploy)
+**Tags:** `[debug]` `[test]`
+**Duration:** ~10 minutes
+
+**Objective:** Investigate and fix TS2502 circular type error at `packages/workers/src/__tests__/entity-resolution.test.ts:345`, close #194 (A106).
+
+**Hypothesis:** The file at line 345 contained a circular `infer` constraint in a Vitest mock type that needed an explicit annotation to break the cycle.
+
+**Rollback plan:** N/A — test-only investigation; no code changes made.
+
+**Action:** Investigation found the error no longer exists:
+- `packages/workers/src/__tests__/entity-resolution.test.ts` does not exist — the actual file is `packages/core-api/src/__tests__/entity-resolution.test.ts`.
+- `pnpm --filter @open-brain/workers lint` → Exit 0 (no TS errors).
+- `pnpm --filter @open-brain/core-api lint` → Exit 0 (no TS errors).
+- The entity-resolution service was refactored in commit `6948a12` (fix: entity-resolution merge/split use Drizzle update() for aliases array) which rewrote the mock structure in the test file, eliminating the circular type inference at line 345.
+- 13/13 entity-resolution tests pass: `pnpm --filter @open-brain/core-api test entity-resolution`.
+
+**Result:** Pre-existing baseline already resolved by prior refactor commit `6948a12`. No code change required. Closing #194 via commit `Closes #194` in OPEN_ITEMS.md update. tsc clean (workers + core-api), 13/13 tests pass.

--- a/OPEN_ITEMS.md
+++ b/OPEN_ITEMS.md
@@ -33,7 +33,7 @@ GitHub issues are the single source of truth for all pending work as of 2026-05-
 | [#73](https://github.com/davistroy/open-brain/issues/73) | P33: Qdrant evaluation | Scale-gated — fires at ≥50K embeddings |
 | [#177](https://github.com/davistroy/open-brain/issues/177) | A128: TanStack Query hooks extraction | Ready — sequence before #190 |
 | [#190](https://github.com/davistroy/open-brain/issues/190) | A130: ESLint 9 + flat-config migration | Ready — sequence after #177 |
-| [#191](https://github.com/davistroy/open-brain/issues/191) | Close out IMPLEMENTATION_PLAN.md verification | Ready — ~30 min |
+| ~~[#191](https://github.com/davistroy/open-brain/issues/191)~~ | ~~Close out IMPLEMENTATION_PLAN.md verification~~ | **CLOSED (Phase E.1 audit 2026-05-09)** |
 | [#192](https://github.com/davistroy/open-brain/issues/192) | A116: Vitest 2.x bump | Low priority baseline |
 | [#193](https://github.com/davistroy/open-brain/issues/193) | A117: SSE onAbort coverage | Low priority baseline |
 | [#194](https://github.com/davistroy/open-brain/issues/194) | A106: TS2502 entity-resolution.test.ts | Low priority baseline |

--- a/OPEN_ITEMS.md
+++ b/OPEN_ITEMS.md
@@ -16,7 +16,7 @@ GitHub issues are the single source of truth for all pending work as of 2026-05-
 | B — UI hydration unification | #197, #198 (RC1) | Time-aware greeting + `new Date()` audit |
 | C — Settings hygiene | #200 RC4 | GET /settings/:key returns 200 with null instead of 404 |
 | D — Observability profile | #200 RC3 | `docker compose --profile observability up -d` (P12 closeout) |
-| E — Small verifications | #191, #194, #193 | Plan close-out audit, TS2502 fix, defer SSE coverage |
+| ~~E — Small verifications~~ | ~~#191, #194, #193~~ | **CLOSED** — #191 closed Phase E.1, #194 closed Phase E.2 (pre-existing fix confirmed), #193 deferred |
 | F — Vitest 2.x bump | #192 | A116 closeout |
 | G — Hooks → ESLint 9 → RTL | #177, #190, #195 | A128 → A130 → A120 sequenced refactor |
 
@@ -36,7 +36,7 @@ GitHub issues are the single source of truth for all pending work as of 2026-05-
 | ~~[#191](https://github.com/davistroy/open-brain/issues/191)~~ | ~~Close out IMPLEMENTATION_PLAN.md verification~~ | **CLOSED (Phase E.1 audit 2026-05-09)** |
 | [#192](https://github.com/davistroy/open-brain/issues/192) | A116: Vitest 2.x bump | Low priority baseline |
 | [#193](https://github.com/davistroy/open-brain/issues/193) | A117: SSE onAbort coverage | Low priority baseline |
-| [#194](https://github.com/davistroy/open-brain/issues/194) | A106: TS2502 entity-resolution.test.ts | Low priority baseline |
+| ~~[#194](https://github.com/davistroy/open-brain/issues/194)~~ | ~~A106: TS2502 entity-resolution.test.ts~~ | **CLOSED (already resolved by commit 6948a12 — Phase E.2 audit 2026-05-09)** |
 | [#195](https://github.com/davistroy/open-brain/issues/195) | A120: TS2345 MPill/TabBar tests | Low priority baseline — after #190 |
 | [#196](https://github.com/davistroy/open-brain/issues/196) | Mobile deferred scope | No gate — when mobile is a priority |
 


### PR DESCRIPTION
## Summary

- Phase E.2 audit of A106 (TS2502 at `entity-resolution.test.ts:345`)
- Investigation confirmed: the error no longer exists in the codebase
- Root cause was already fixed in commit `6948a12` (entity-resolution Drizzle update refactor) — the circular type inference in the Drizzle mock at line 345 was eliminated when the mock structure was rewritten
- Both `pnpm --filter @open-brain/workers lint` and `pnpm --filter @open-brain/core-api lint` exit 0
- 13/13 entity-resolution tests pass

## Test plan

- [x] `pnpm --filter @open-brain/workers exec tsc --noEmit` — clean (Exit 0)
- [x] `pnpm --filter @open-brain/core-api exec tsc --noEmit` — clean (Exit 0)
- [x] `pnpm --filter @open-brain/core-api test entity-resolution` — 13/13 pass
- [x] LAB_NOTEBOOK Entry 147 added
- [x] OPEN_ITEMS.md #194 marked closed

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)