### PR TITLE
feat(web-next): Phase G.1 Batch 1 — TanStack Query hooks (captures, search, briefs, intelligence, settings, entities)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10885,6 +10885,48 @@ Close 5 skipped test cases from Entry 143 test run:
 
 ---
 
+--- New session: 2026-05-09 — Phase G.1 TanStack Query hooks (A128) ---
+
+## Entry 148 — Phase G.1 Batch 1: TanStack Query hooks — captures, search, briefs, intelligence, settings, entities (2026-05-09)  [web] [refactor]
+
+**Date:** 2026-05-09
+**Environment:** open-brain-remediation worktree; branch feat/phase-g1-batch-1
+**Duration:** ~45 min
+
+**Objective:** Create TanStack Query hook files for 6 high-traffic API domains. Migrate inline `useQuery`/`useMutation` constructions in components to use the new hooks. Refs #177 (A128).
+
+**Hypothesis:** Eliminates duplicated queryKey strings and inline queryFn lambdas. Components become thinner. No behaviour change — same query keys, same staleTime values.
+
+**Rollback plan:** `git revert` the batch commit — no DB or infra changes.
+
+**Hooks created:**
+- `lib/api/captures.hooks.ts` — `useCaptures`, `useCapture`, `useCreateCapture`
+- `lib/api/search.hooks.ts` — `useSearch` (shared query key between SearchResults + EntityFacets)
+- `lib/api/briefs.hooks.ts` — `useBriefs`, `useBrief`, `usePatchBriefRead`, `useDismissBrief`, `useRefineBrief`
+- `lib/api/intelligence.hooks.ts` — `useIntelligenceSummary`, `useConnectionsLatest`, `useDriftLatest`, `useUnresolvedQuestions`, `useTriggerIntelligence`
+- `lib/api/settings.hooks.ts` — `useSetting`, `usePutSetting`
+- `lib/api/entities.hooks.ts` — `useEntities`, `useEntity`, `useEntityCaptures`, `useEntityRelated`, `useEntityMentionsTimeline`, `useMergeEntity`, `useAskEntity`, `useGenerateEntityBrief`
+
+**Consumers migrated (7):**
+- `components/search/SearchResults.tsx` — `useQuery` → `useSearch`
+- `components/search/EntityFacets.tsx` — `useQuery` → `useSearch`
+- `components/dashboard/QuickCapture.tsx` — `useMutation` → `useCreateCapture`
+- `components/briefs/BriefHero.tsx` — `useMutation` → `useDismissBrief`
+- `components/briefs/BriefSources.tsx` — `useMutation` → `useRefineBrief`
+- `components/entity/entity-detail-client.tsx` — `useMutation` → `useGenerateEntityBrief`
+- `components/settings/EntityExtractionSection.tsx` — 3×`useQuery` + `useMutation` → `useSetting` × 3 + `usePutSetting`
+- `components/settings/IngestFiltersSection.tsx` — 4×`useQuery` + `useMutation` → `useSetting` × 4 + `usePutSetting`
+
+**Key decisions:**
+- Hooks NOT exported via `lib/api/index.ts` barrel — hook files import `@tanstack/react-query` which must stay client-component-only; barrel has no 'use client' directive and is imported from RSC pages. Consumers import directly from `@/lib/api/<domain>.hooks`.
+- `onMutate` is not a valid key in TanStack Query v5 `MutateOptions` — loading toasts moved to the click handler immediately before `mutate()`.
+- `useSearch` preserves `staleTime: 30_000` so EntityFacets and SearchResults share the same cache entry (no duplicate fetch).
+- `useSetting` preserves `staleTime: 60_000` convention from all settings consumers.
+
+**Result:** tsc --noEmit clean. 118/118 tests pass.
+
+---
+
 --- New session: 2026-05-09 — Remediation Phase F: Vitest 2.x bump ---
 
 ## Entry 147 — Phase F: Vitest 2.x bump (2026-05-09)  [test] [config] [decision]

--- a/packages/web-next/components/briefs/BriefHero.tsx
+++ b/packages/web-next/components/briefs/BriefHero.tsx
@@ -2,12 +2,12 @@
 
 import Link from 'next/link';
 import { ArrowRight, Play } from 'lucide-react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/design-system';
 import { briefsApi } from '@/lib/api-client';
+import { useDismissBrief } from '@/lib/api/briefs.hooks';
 import { useAudioPlayer } from '@/components/audio/AudioPlayer';
 import type { Brief } from '@/lib/types';
 
@@ -32,22 +32,10 @@ const HERO_ITEMS = [
  */
 export function BriefHero({ brief }: BriefHeroProps) {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const audioPlayer = useAudioPlayer();
   const [isLoadingAudio, setIsLoadingAudio] = useState(false);
 
-  const dismissMutation = useMutation({
-    mutationFn: () => briefsApi.dismiss(brief.id),
-    onSuccess: () => {
-      toast('Brief dismissed');
-      // Invalidate briefs list so the RSC re-fetches without this brief as hero
-      queryClient.invalidateQueries({ queryKey: ['briefs'] });
-      router.refresh();
-    },
-    onError: () => {
-      toast.error('Could not dismiss brief — please try again.');
-    },
-  });
+  const dismissMutation = useDismissBrief();
 
   async function handleListen() {
     if (isLoadingAudio) return;
@@ -107,7 +95,17 @@ export function BriefHero({ brief }: BriefHeroProps) {
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => dismissMutation.mutate()}
+            onClick={() =>
+              dismissMutation.mutate(brief.id, {
+                onSuccess: () => {
+                  toast('Brief dismissed');
+                  router.refresh();
+                },
+                onError: () => {
+                  toast.error('Could not dismiss brief — please try again.');
+                },
+              })
+            }
             disabled={dismissMutation.isPending}
           >
             {dismissMutation.isPending ? 'Dismissing…' : 'Dismiss'}

--- a/packages/web-next/components/briefs/BriefSources.tsx
+++ b/packages/web-next/components/briefs/BriefSources.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 import { Card, Eyebrow } from '@/components/design-system';
-import { briefsApi } from '@/lib/api-client';
+import { useRefineBrief } from '@/lib/api/briefs.hooks';
 import type { BriefSource } from '@/lib/types';
 
 interface BriefSourcesProps {
@@ -27,22 +26,7 @@ interface BriefSourcesProps {
  * 'use client' — useMutation + toast require client context.
  */
 export function BriefSources({ briefId, sources, sourceTotal, refineOptions }: BriefSourcesProps) {
-  const refineMutation = useMutation({
-    mutationFn: (instruction: string) => briefsApi.refine(briefId, instruction),
-    onMutate: (instruction: string) => {
-      toast.loading(`Refining: ${instruction}…`, { id: `refine-${briefId}` });
-    },
-    onSuccess: () => {
-      toast.success('Refinement queued — brief will update when ready', {
-        id: `refine-${briefId}`,
-      });
-    },
-    onError: (err) => {
-      const message =
-        err instanceof Error ? err.message : 'Refinement failed — please try again.';
-      toast.error(message, { id: `refine-${briefId}` });
-    },
-  });
+  const refineMutation = useRefineBrief();
 
   return (
     <aside className="sticky top-[22px] flex flex-col gap-[16px]">
@@ -102,13 +86,31 @@ export function BriefSources({ briefId, sources, sourceTotal, refineOptions }: B
         <div className="flex flex-col gap-[6px] mt-[8px]">
           {refineOptions.map((option, i) => {
             const isPending =
-              refineMutation.isPending && refineMutation.variables === option;
+              refineMutation.isPending &&
+              refineMutation.variables?.instruction === option;
             return (
               <button
                 key={i}
                 type="button"
                 disabled={refineMutation.isPending}
-                onClick={() => refineMutation.mutate(option)}
+                onClick={() => {
+                  toast.loading(`Refining: ${option}…`, { id: `refine-${briefId}` });
+                  refineMutation.mutate(
+                    { id: briefId, instruction: option },
+                    {
+                      onSuccess: () => {
+                        toast.success('Refinement queued — brief will update when ready', {
+                          id: `refine-${briefId}`,
+                        });
+                      },
+                      onError: (err) => {
+                        const message =
+                          err instanceof Error ? err.message : 'Refinement failed — please try again.';
+                        toast.error(message, { id: `refine-${briefId}` });
+                      },
+                    },
+                  );
+                }}
                 className={[
                   'text-left bg-transparent border-none p-0 py-[4px]',
                   'text-[12.5px] font-light text-text-body',

--- a/packages/web-next/components/dashboard/QuickCapture.tsx
+++ b/packages/web-next/components/dashboard/QuickCapture.tsx
@@ -2,11 +2,10 @@
 
 import { useState } from 'react';
 import { Edit3, Mic, FileUp, Link } from 'lucide-react';
-import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { Button } from '@/components/design-system';
-import { capturesApi } from '@/lib/api-client';
+import { useCreateCapture } from '@/lib/api/captures.hooks';
 import type { CaptureType } from '@/lib/types';
 
 type QuickType = 'note' | 'voice' | 'upload' | 'link';
@@ -36,30 +35,31 @@ export function QuickCapture() {
   const [text, setText] = useState('');
   const router = useRouter();
 
-  const mutation = useMutation({
-    mutationFn: () =>
-      capturesApi.create({
+  const mutation = useCreateCapture();
+
+  function handleCapture() {
+    if (!text.trim()) return;
+    mutation.mutate(
+      {
         content: text.trim(),
         capture_type: toCaptureType(activeType),
         brain_view: 'personal',
         source: 'api',
-      }),
-    onSuccess: () => {
-      setText('');
-      toast('Captured');
-      // Refresh the RSC page so StatStrip + RecentCaptures re-fetch.
-      router.refresh();
-    },
-    onError: (err) => {
-      const message =
-        err instanceof Error ? err.message : 'Failed to capture — please try again.';
-      toast.error(message);
-    },
-  });
-
-  function handleCapture() {
-    if (!text.trim()) return;
-    mutation.mutate();
+      },
+      {
+        onSuccess: () => {
+          setText('');
+          toast('Captured');
+          // Refresh the RSC page so StatStrip + RecentCaptures re-fetch.
+          router.refresh();
+        },
+        onError: (err) => {
+          const message =
+            err instanceof Error ? err.message : 'Failed to capture — please try again.';
+          toast.error(message);
+        },
+      },
+    );
   }
 
   return (

--- a/packages/web-next/components/entity/entity-detail-client.tsx
+++ b/packages/web-next/components/entity/entity-detail-client.tsx
@@ -2,12 +2,11 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { EntityHeader } from './entity-header';
 import { AskAIModal } from './ask-ai-modal';
 import { MergeEntityModal } from './merge-entity-modal';
-import { entitiesApi } from '@/lib/api-client';
+import { useGenerateEntityBrief } from '@/lib/api/entities.hooks';
 import { SseClient } from '@/lib/sse-client';
 import type { EntityDetail } from '@/lib/types';
 
@@ -31,22 +30,7 @@ export function EntityDetailClient({ entity }: EntityDetailClientProps) {
   // Track a pending brief job so the SSE handler can match entity_id.
   const pendingBriefRef = useRef<boolean>(false);
 
-  const briefMutation = useMutation({
-    mutationFn: () => entitiesApi.brief(entity.id),
-    onMutate: () => {
-      pendingBriefRef.current = true;
-      toast.loading('Generating dossier…', { id: 'entity-brief' });
-    },
-    onSuccess: () => {
-      // Toast stays as "loading" until SSE brief_created arrives or we get an error.
-      // If SSE never arrives the toast will persist — acceptable for M3.
-    },
-    onError: () => {
-      pendingBriefRef.current = false;
-      toast.dismiss('entity-brief');
-      toast.error('Brief generation failed — please try again.');
-    },
-  });
+  const briefMutation = useGenerateEntityBrief();
 
   // Listen for brief_created SSE events. When the entity_id matches, navigate.
   useEffect(() => {
@@ -94,7 +78,17 @@ export function EntityDetailClient({ entity }: EntityDetailClientProps) {
         entity={entity}
         onAskAI={() => setAskOpen(true)}
         onMerge={() => setMergeOpen(true)}
-        onGenerateBrief={() => briefMutation.mutate()}
+        onGenerateBrief={() => {
+          pendingBriefRef.current = true;
+          toast.loading('Generating dossier…', { id: 'entity-brief' });
+          briefMutation.mutate(entity.id, {
+            onError: () => {
+              pendingBriefRef.current = false;
+              toast.dismiss('entity-brief');
+              toast.error('Brief generation failed — please try again.');
+            },
+          });
+        }}
         isBriefPending={briefMutation.isPending}
       />
 

--- a/packages/web-next/components/search/EntityFacets.tsx
+++ b/packages/web-next/components/search/EntityFacets.tsx
@@ -12,9 +12,8 @@
  * Renders only when there are results with entities.
  */
 
-import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { searchApi } from '@/lib/api-client';
+import { useSearch } from '@/lib/api/search.hooks';
 import { Eyebrow } from '@/components/design-system/Eyebrow';
 
 interface EntityFacetsProps {
@@ -46,12 +45,7 @@ export function EntityFacets({ query }: EntityFacetsProps) {
   const router = useRouter();
 
   // Re-use the same query key as SearchResults — no duplicate fetch
-  const { data } = useQuery({
-    queryKey: ['search', query],
-    queryFn: () => searchApi.search({ q: query, hybrid: true, limit: 20 }),
-    enabled: Boolean(query.trim()),
-    staleTime: 30_000,
-  });
+  const { data } = useSearch({ q: query, hybrid: true, limit: 20 });
 
   const results = data?.results ?? [];
   const facets = extractEntityCounts(results);

--- a/packages/web-next/components/search/SearchResults.tsx
+++ b/packages/web-next/components/search/SearchResults.tsx
@@ -17,10 +17,9 @@
  * Refetch interval: none — user controls via URL changes.
  */
 
-import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { List, LayoutGrid } from 'lucide-react';
-import { searchApi } from '@/lib/api-client';
+import { useSearch } from '@/lib/api/search.hooks';
 import type { SearchResult } from '@/lib/types';
 import { ResultCard, GroupedResults } from './GroupedResults';
 
@@ -133,17 +132,7 @@ export function SearchResults({ query }: SearchResultsProps) {
     localStorage.setItem(LS_KEY, mode);
   }
 
-  const {
-    data,
-    isLoading,
-    isError,
-    error,
-  } = useQuery({
-    queryKey: ['search', query],
-    queryFn: () => searchApi.search({ q: query, hybrid: true, limit: 20 }),
-    enabled: Boolean(query.trim()),
-    staleTime: 30_000,
-  });
+  const { data, isLoading, isError, error } = useSearch({ q: query, hybrid: true, limit: 20 });
 
   if (isLoading) return <ResultSkeletons />;
 

--- a/packages/web-next/components/settings/EntityExtractionSection.tsx
+++ b/packages/web-next/components/settings/EntityExtractionSection.tsx
@@ -16,9 +16,8 @@
  * Client component (interactivity required).
  */
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card } from '@/components/design-system';
-import { settingsApi } from '@/lib/api-client';
+import { useSetting, usePutSetting } from '@/lib/api/settings.hooks';
 
 // ---------------------------------------------------------------------------
 // Toggle row
@@ -177,33 +176,10 @@ const DEFAULTS = {
 // ---------------------------------------------------------------------------
 
 export function EntityExtractionSection() {
-  const queryClient = useQueryClient();
-
-  const locationQuery = useQuery({
-    queryKey: ['settings', 'entity_extract_locations'],
-    queryFn: () => settingsApi.get('entity_extract_locations'),
-    staleTime: 60_000,
-  });
-
-  const monetaryQuery = useQuery({
-    queryKey: ['settings', 'entity_extract_monetary'],
-    queryFn: () => settingsApi.get('entity_extract_monetary'),
-    staleTime: 60_000,
-  });
-
-  const confidenceQuery = useQuery({
-    queryKey: ['settings', 'entity_confidence_threshold'],
-    queryFn: () => settingsApi.get('entity_confidence_threshold'),
-    staleTime: 60_000,
-  });
-
-  const putMutation = useMutation({
-    mutationFn: ({ key, value }: { key: string; value: unknown }) =>
-      settingsApi.put(key, value),
-    onSuccess: (result) => {
-      queryClient.setQueryData(['settings', result.key], result);
-    },
-  });
+  const locationQuery = useSetting('entity_extract_locations');
+  const monetaryQuery = useSetting('entity_extract_monetary');
+  const confidenceQuery = useSetting('entity_confidence_threshold');
+  const putMutation = usePutSetting();
 
   const handleToggle = (key: string, next: boolean) => {
     putMutation.mutate({ key, value: next });

--- a/packages/web-next/components/settings/IngestFiltersSection.tsx
+++ b/packages/web-next/components/settings/IngestFiltersSection.tsx
@@ -15,9 +15,8 @@
  * Client component (interactivity required).
  */
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card } from '@/components/design-system';
-import { settingsApi } from '@/lib/api-client';
+import { useSetting, usePutSetting } from '@/lib/api/settings.hooks';
 
 // ---------------------------------------------------------------------------
 // Toggle row types
@@ -177,31 +176,14 @@ const DEFAULTS = {
 // ---------------------------------------------------------------------------
 
 export function IngestFiltersSection() {
-  const queryClient = useQueryClient();
-
   // Fetch all toggle settings in parallel
   const toggleQueries = TOGGLE_SETTINGS.map((cfg) =>
     // eslint-disable-next-line react-hooks/rules-of-hooks -- stable array, safe
-    useQuery({
-      queryKey: ['settings', cfg.key],
-      queryFn: () => settingsApi.get(cfg.key),
-      staleTime: 60_000,
-    }),
+    useSetting(cfg.key),
   );
 
-  const voiceDurationQuery = useQuery({
-    queryKey: ['settings', 'ingest_voice_min_duration'],
-    queryFn: () => settingsApi.get('ingest_voice_min_duration'),
-    staleTime: 60_000,
-  });
-
-  const putMutation = useMutation({
-    mutationFn: ({ key, value }: { key: string; value: unknown }) =>
-      settingsApi.put(key, value),
-    onSuccess: (result) => {
-      queryClient.setQueryData(['settings', result.key], result);
-    },
-  });
+  const voiceDurationQuery = useSetting('ingest_voice_min_duration');
+  const putMutation = usePutSetting();
 
   const handleToggle = (key: string, next: boolean) => {
     putMutation.mutate({ key, value: next });

--- a/packages/web-next/lib/api/briefs.hooks.ts
+++ b/packages/web-next/lib/api/briefs.hooks.ts
@@ -1,0 +1,80 @@
+/**
+ * TanStack Query hooks — briefs domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['briefs', 'list', params?]  — paginated list
+ *   ['briefs', 'detail', id]     — full brief with body_html, TOC, sources
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { briefsApi } from './briefs'
+import type { BriefsListParams } from './briefs'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Paginated list of briefs. */
+export function useBriefs(params: BriefsListParams = {}) {
+  return useQuery({
+    queryKey: ['briefs', 'list', params],
+    queryFn: () => briefsApi.list(params),
+  })
+}
+
+/**
+ * Full brief detail including body_html, TOC, and sources.
+ * Skips fetch when id is falsy.
+ */
+export function useBrief(id: string) {
+  return useQuery({
+    queryKey: ['briefs', 'detail', id],
+    queryFn: () => briefsApi.get(id),
+    enabled: Boolean(id),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/** Mark a brief as read/unread. Invalidates the detail entry. */
+export function usePatchBriefRead() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, read }: { id: string; read: boolean }) =>
+      briefsApi.patchRead(id, read),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: ['briefs', 'detail', id] })
+      qc.invalidateQueries({ queryKey: ['briefs', 'list'] })
+    },
+  })
+}
+
+/** Soft-dismiss a brief without marking it read. Invalidates the list. */
+export function useDismissBrief() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => briefsApi.dismiss(id),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: ['briefs', 'detail', id] })
+      qc.invalidateQueries({ queryKey: ['briefs', 'list'] })
+    },
+  })
+}
+
+/**
+ * Request async refinement of a brief.
+ * Response arrives via SSE; this mutation only enqueues the job.
+ * Invalidates the detail so any polling consumer picks up the update.
+ */
+export function useRefineBrief() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, instruction }: { id: string; instruction: string }) =>
+      briefsApi.refine(id, instruction),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: ['briefs', 'detail', id] })
+    },
+  })
+}

--- a/packages/web-next/lib/api/captures.hooks.ts
+++ b/packages/web-next/lib/api/captures.hooks.ts
@@ -1,0 +1,53 @@
+/**
+ * TanStack Query hooks — captures domain (Phase G.1).
+ *
+ * Wraps `capturesApi` with standard query/mutation hooks so components
+ * avoid duplicating queryKey strings or inline queryFn lambdas.
+ *
+ * Query key hierarchy:
+ *   ['captures', 'list', params?]  — paginated list
+ *   ['captures', 'detail', id]     — single capture
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { capturesApi } from './captures'
+import type { CapturesListParams, CreateCapturePayload } from './captures'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Paginated list of captures. Enabled immediately; pass params to filter. */
+export function useCaptures(params: CapturesListParams = {}) {
+  return useQuery({
+    queryKey: ['captures', 'list', params],
+    queryFn: () => capturesApi.list(params),
+  })
+}
+
+/** Single capture by id. Skips fetch when id is falsy. */
+export function useCapture(id: string) {
+  return useQuery({
+    queryKey: ['captures', 'detail', id],
+    queryFn: () => capturesApi.get(id),
+    enabled: Boolean(id),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new capture.
+ * On success invalidates the list so any rendered list re-fetches.
+ */
+export function useCreateCapture() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: CreateCapturePayload) => capturesApi.create(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['captures', 'list'] })
+    },
+  })
+}

--- a/packages/web-next/lib/api/entities.hooks.ts
+++ b/packages/web-next/lib/api/entities.hooks.ts
@@ -1,0 +1,115 @@
+/**
+ * TanStack Query hooks — entities domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['entities', 'list', params?]                  — paginated entity list
+ *   ['entities', 'detail', id]                     — full entity detail
+ *   ['entities', 'captures', id, params?]          — captures linked to entity
+ *   ['entities', 'related', id, params?]           — co-mentioned entities
+ *   ['entities', 'mentions-timeline', id, params?] — mention count over time
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { entitiesApi } from './entities'
+import type { EntitiesListParams } from './entities'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Paginated entity list. */
+export function useEntities(params: EntitiesListParams = {}) {
+  return useQuery({
+    queryKey: ['entities', 'list', params],
+    queryFn: () => entitiesApi.list(params),
+  })
+}
+
+/** Full entity detail. Skips fetch when id is falsy. */
+export function useEntity(id: string) {
+  return useQuery({
+    queryKey: ['entities', 'detail', id],
+    queryFn: () => entitiesApi.get(id),
+    enabled: Boolean(id),
+  })
+}
+
+/** Captures linked to an entity. Skips fetch when id is falsy. */
+export function useEntityCaptures(
+  id: string,
+  params: { limit?: number; offset?: number } = {},
+) {
+  return useQuery({
+    queryKey: ['entities', 'captures', id, params],
+    queryFn: () => entitiesApi.captures(id, params),
+    enabled: Boolean(id),
+  })
+}
+
+/** Entities co-mentioned with the given entity. Skips fetch when id is falsy. */
+export function useEntityRelated(id: string, params: { limit?: number } = {}) {
+  return useQuery({
+    queryKey: ['entities', 'related', id, params],
+    queryFn: () => entitiesApi.related(id, params),
+    enabled: Boolean(id),
+  })
+}
+
+/** Mention-count time-series for an entity. Skips fetch when id is falsy. */
+export function useEntityMentionsTimeline(
+  id: string,
+  params: { window?: string; bucket?: string } = {},
+) {
+  return useQuery({
+    queryKey: ['entities', 'mentions-timeline', id, params],
+    queryFn: () => entitiesApi.mentionsTimeline(id, params),
+    enabled: Boolean(id),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge one entity into another.
+ * On success, invalidates the entity list and the detail for both entities.
+ */
+export function useMergeEntity() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ sourceId, targetId }: { sourceId: string; targetId: string }) =>
+      entitiesApi.merge(sourceId, targetId),
+    onSuccess: (_data, { sourceId, targetId }) => {
+      qc.invalidateQueries({ queryKey: ['entities', 'list'] })
+      qc.invalidateQueries({ queryKey: ['entities', 'detail', sourceId] })
+      qc.invalidateQueries({ queryKey: ['entities', 'detail', targetId] })
+    },
+  })
+}
+
+/**
+ * Ask an LLM question about a specific entity.
+ * No cache invalidation — responses are one-shot synthesis, not stored state.
+ */
+export function useAskEntity() {
+  return useMutation({
+    mutationFn: ({ id, question }: { id: string; question: string }) =>
+      entitiesApi.ask(id, question),
+  })
+}
+
+/**
+ * Enqueue entity-brief generation.
+ * Returns `{ job_id }` — result arrives async via SSE / polling.
+ * Invalidates the briefs list so the new brief appears when ready.
+ */
+export function useGenerateEntityBrief() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => entitiesApi.brief(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['briefs', 'list'] })
+    },
+  })
+}

--- a/packages/web-next/lib/api/intelligence.hooks.ts
+++ b/packages/web-next/lib/api/intelligence.hooks.ts
@@ -1,0 +1,69 @@
+/**
+ * TanStack Query hooks — intelligence domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['intelligence', 'summary']                 — connections + drift latest summary
+ *   ['intelligence', 'connections', 'latest']   — latest connections entry
+ *   ['intelligence', 'drift', 'latest']         — latest drift entry
+ *   ['intelligence', 'unresolved-questions']    — open questions list
+ */
+
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { intelligenceApi } from './intelligence'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Latest intelligence summary (connections + drift in one request). */
+export function useIntelligenceSummary() {
+  return useQuery({
+    queryKey: ['intelligence', 'summary'],
+    queryFn: () => intelligenceApi.summary(),
+  })
+}
+
+/** Latest daily-connections skill result. */
+export function useConnectionsLatest() {
+  return useQuery({
+    queryKey: ['intelligence', 'connections', 'latest'],
+    queryFn: () => intelligenceApi.connectionsLatest(),
+  })
+}
+
+/** Latest drift-monitor skill result. */
+export function useDriftLatest() {
+  return useQuery({
+    queryKey: ['intelligence', 'drift', 'latest'],
+    queryFn: () => intelligenceApi.driftLatest(),
+  })
+}
+
+/** Unresolved questions from captures. */
+export function useUnresolvedQuestions(limit = 5) {
+  return useQuery({
+    queryKey: ['intelligence', 'unresolved-questions', limit],
+    queryFn: () => intelligenceApi.unresolvedQuestions(limit),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Manually trigger an intelligence skill.
+ * Fire-and-forget — results arrive asynchronously via the skill queue.
+ * No cache invalidation here; callers poll or use SSE for updates.
+ */
+export function useTriggerIntelligence() {
+  return useMutation({
+    mutationFn: ({
+      skill,
+      overrides = {},
+    }: {
+      skill: 'daily-connections' | 'drift-monitor' | 'daily-sweep-skill'
+      overrides?: Record<string, unknown>
+    }) => intelligenceApi.trigger(skill, overrides),
+  })
+}

--- a/packages/web-next/lib/api/search.hooks.ts
+++ b/packages/web-next/lib/api/search.hooks.ts
@@ -1,0 +1,35 @@
+/**
+ * TanStack Query hooks — search domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['search', query]   — hybrid search results (shared between SearchResults + EntityFacets)
+ *
+ * Note: EntityFacets re-uses the SAME query key as SearchResults so results
+ * are served from cache without a duplicate network request. Keep the queryKey
+ * shape stable — components depend on it for cache-sharing.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { searchApi } from './search'
+import type { SearchParams } from './search'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Hybrid FTS + vector search.
+ *
+ * `staleTime: 30_000` matches the existing inline usage in SearchResults and
+ * EntityFacets — results stay fresh for 30s without re-fetching on focus.
+ *
+ * Skips the fetch when the query string is blank.
+ */
+export function useSearch(params: SearchParams) {
+  return useQuery({
+    queryKey: ['search', params.q],
+    queryFn: () => searchApi.search(params),
+    enabled: Boolean(params.q?.trim()),
+    staleTime: 30_000,
+  })
+}

--- a/packages/web-next/lib/api/settings.hooks.ts
+++ b/packages/web-next/lib/api/settings.hooks.ts
@@ -1,0 +1,51 @@
+/**
+ * TanStack Query hooks — settings domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['settings', key]   — single app_settings value by key
+ *
+ * Note: `staleTime: 60_000` is the existing convention across all settings
+ * consumers. Kept here so migrated components get identical cache behaviour
+ * without having to re-specify it.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { settingsApi } from './settings'
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a single setting by key.
+ * Skips the fetch when key is empty.
+ * Returns the typed `SettingEntry` (`{ key, value, updated_at }`).
+ */
+export function useSetting(key: string) {
+  return useQuery({
+    queryKey: ['settings', key],
+    queryFn: () => settingsApi.get(key),
+    enabled: Boolean(key),
+    staleTime: 60_000,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutation
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a setting value.
+ * On success, updates the cache entry for that key directly (no refetch needed)
+ * so the toggle/slider reflects the new value instantly.
+ */
+export function usePutSetting() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ key, value }: { key: string; value: unknown }) =>
+      settingsApi.put(key, value),
+    onSuccess: (result) => {
+      qc.setQueryData(['settings', result.key], result)
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Adds 6 hook files under `packages/web-next/lib/api/*.hooks.ts` wrapping existing fetch functions with `useQuery`/`useMutation` (TanStack Query v5)
- Migrates 8 components from inline query/mutation constructions to the new hooks
- Hook files are NOT re-exported via `index.ts` barrel — they import `@tanstack/react-query` which must stay client-component-only

**Hooks added (17):** `useCaptures`, `useCapture`, `useCreateCapture`, `useSearch`, `useBriefs`, `useBrief`, `usePatchBriefRead`, `useDismissBrief`, `useRefineBrief`, `useIntelligenceSummary`, `useConnectionsLatest`, `useDriftLatest`, `useUnresolvedQuestions`, `useTriggerIntelligence`, `useSetting`, `usePutSetting`, `useEntities`, `useEntity`, `useEntityCaptures`, `useEntityRelated`, `useEntityMentionsTimeline`, `useMergeEntity`, `useAskEntity`, `useGenerateEntityBrief`

**Consumers migrated (8):** `SearchResults`, `EntityFacets`, `QuickCapture`, `BriefHero`, `BriefSources`, `entity-detail-client`, `EntityExtractionSection`, `IngestFiltersSection`

Refs #177 (A128)

## Test plan

- [x] `pnpm --filter @open-brain/web-next exec tsc --noEmit` — clean
- [x] `pnpm --filter @open-brain/web-next exec vitest run` — 118/118 pass
- [ ] CI: Integration tests (core-api + real DB)
