### PR TITLE
feat(web-next): Phase G.1 Batch 2 — TanStack Query hooks (system-health, mcp-activity, wiki, ingest, voice, skills)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10923,6 +10923,38 @@ Close 5 skipped test cases from Entry 143 test run:
 - `useSearch` preserves `staleTime: 30_000` so EntityFacets and SearchResults share the same cache entry (no duplicate fetch).
 - `useSetting` preserves `staleTime: 60_000` convention from all settings consumers.
 
+---
+
+## Entry 149 — Phase G.1 Batch 2: TanStack Query hooks — system-health, mcp-activity, wiki, ingest, voice + skills (2026-05-09)  [web] [refactor]
+
+**Date:** 2026-05-09
+**Environment:** open-brain-remediation worktree; branch feat/phase-g1-batch-2
+**Duration:** ~30 min
+
+**Objective:** Create TanStack Query hook files for 5 mid-traffic API domains + skills (pulled forward from Batch 4 because WikiSection requires it). Migrate inline `useQuery`/`useMutation` in 8 components. Refs #177 (A128).
+
+**Hypothesis:** Identical to Batch 1 — fewer inline queries in components, stable query key hierarchy.
+
+**Rollback plan:** `git revert` — no DB or infra changes.
+
+**Hooks created:**
+- `lib/api/system-health.hooks.ts` — `useSystemHealthSnapshot`, `useSystemFlows`, `useSystemInfrastructure`
+- `lib/api/mcp-activity.hooks.ts` — `useMcpActivity` (with initialData + custom staleTime)
+- `lib/api/wiki.hooks.ts` — `useWikiPages`, `useWikiPage`, `useWikiRecentChanges`, `useWikiLintReport`, `useWikiStats`, `useWikiSearch`, `useTriggerWikiLint`, `useTriggerWikiResynthesize`
+- `lib/api/ingest.hooks.ts` — `useIngestUploads`, `useIngestUpload`, `useUploadFile`, `useReprocessUpload`, `useIngestProcessNow` + exports `INGEST_UPLOADS_QUERY_KEY`
+- `lib/api/voice.hooks.ts` — `useVoiceSessions`, `useActiveVoiceSessions`, `useVoiceSession`
+- `lib/api/skills.hooks.ts` — `useSkillsList`, `useTriggerSkill`, `useUpdateSkillSchedule` (pulled forward — needed by WikiSection migration)
+
+**Consumers migrated (8):**
+- `components/system/McpActivityTab.tsx` — `useQuery` → `useMcpActivity`
+- `components/settings/WikiSection.tsx` — 3×`useQuery` → `useWikiStats` + `useSystemHealthSnapshot` + `useSkillsList`
+- `components/ingest/RecentUploads.tsx` — `useQuery`+`useMutation` → `useIngestUploads`+`useReprocessUpload`; re-exports `INGEST_UPLOADS_QUERY_KEY`
+- `components/voice/VoiceConversationsClient.tsx` — `useQuery` → `useActiveVoiceSessions`
+- `components/voice/SessionList.tsx` — 2×`useQuery` → `useVoiceSessions`+`useActiveVoiceSessions`
+- `components/voice/SessionDetail.tsx` — `useQuery` (session) → `useVoiceSession`; kept inline `useQuery` for LinkedCaptures batch-fetch
+- `components/settings/VoiceSection.tsx` — 2×`useQuery` (voice) → `useVoiceSessions`+`useActiveVoiceSessions`; left configApi `useQuery` inline (Batch 4)
+- `components/system/SkillsTab.tsx` — 2×`useMutation` → `useTriggerSkill`+`useUpdateSkillSchedule`
+
 **Result:** tsc --noEmit clean. 118/118 tests pass.
 
 ---

--- a/packages/web-next/components/ingest/RecentUploads.tsx
+++ b/packages/web-next/components/ingest/RecentUploads.tsx
@@ -11,15 +11,15 @@
  *                            pending → processing → failed  (terminal failure)
  */
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { RefreshCw, FileText, Loader2, AlertCircle } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button, Pill, EmptyState } from '@/components/design-system';
-import { ingestApi } from '@/lib/api-client';
+import { useIngestUploads, useReprocessUpload, INGEST_UPLOADS_QUERY_KEY } from '@/lib/api/ingest.hooks';
 import type { FileUploadStatus, ListUploadsResponse } from '@/lib/api-client';
 import { toast } from 'sonner';
 
-/** Exported so IngestClient can invalidate after upload and seed initialData. */
-export const INGEST_UPLOADS_QUERY_KEY = ['ingest', 'uploads'] as const;
+/** Re-export so IngestClient can invalidate after upload without importing hooks. */
+export { INGEST_UPLOADS_QUERY_KEY };
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -88,39 +88,22 @@ const REFRESH_INTERVAL_MS = 10_000; // 10s polling while any row is non-terminal
 
 export function RecentUploads({ activeUploadId, limit = 20, initialData }: RecentUploadsProps) {
   const queryClient = useQueryClient();
+  const { data, isLoading, isError, error } = useIngestUploads(
+    { limit },
+    {
+      initialData,
+      // Poll while there are in-progress rows (pending/processing)
+      refetchInterval: (query) => {
+        const uploads = query.state.data?.uploads ?? [];
+        const hasInProgress = uploads.some(
+          (u) => u.status === 'pending' || u.status === 'processing',
+        );
+        return hasInProgress ? REFRESH_INTERVAL_MS : false;
+      },
+    },
+  );
 
-  const { data, isLoading, isError, error } = useQuery({
-    queryKey: [...INGEST_UPLOADS_QUERY_KEY, limit],
-    queryFn: () => ingestApi.list({ limit }),
-    initialData,
-    // Poll while there are in-progress rows (pending/processing)
-    refetchInterval: (query) => {
-      const uploads = query.state.data?.uploads ?? [];
-      const hasInProgress = uploads.some(
-        (u) => u.status === 'pending' || u.status === 'processing',
-      );
-      return hasInProgress ? REFRESH_INTERVAL_MS : false;
-    },
-    staleTime: 5_000,
-  });
-
-  const reprocessMutation = useMutation({
-    mutationFn: (id: string) => ingestApi.process(id),
-    onSuccess: (_result, id) => {
-      toast.success('Reprocess queued', {
-        description: `Upload ${id.slice(0, 8)}… has been re-enqueued.`,
-        duration: 4000,
-      });
-      void queryClient.invalidateQueries({ queryKey: INGEST_UPLOADS_QUERY_KEY });
-    },
-    onError: (err, id) => {
-      const message = err instanceof Error ? err.message : 'Failed to reprocess';
-      toast.error('Reprocess failed', {
-        description: `${id.slice(0, 8)}… — ${message}`,
-        duration: 5000,
-      });
-    },
-  });
+  const reprocessMutation = useReprocessUpload();
 
   // ---------------------------------------------------------------------------
   // Loading state
@@ -243,7 +226,23 @@ export function RecentUploads({ activeUploadId, limit = 20, initialData }: Recen
                 </Pill>
                 {isFailed && (
                   <button
-                    onClick={() => reprocessMutation.mutate(upload.id)}
+                    onClick={() =>
+                      reprocessMutation.mutate(upload.id, {
+                        onSuccess: (_result, id) => {
+                          toast.success('Reprocess queued', {
+                            description: `Upload ${id.slice(0, 8)}… has been re-enqueued.`,
+                            duration: 4000,
+                          });
+                        },
+                        onError: (err, id) => {
+                          const message = err instanceof Error ? err.message : 'Failed to reprocess';
+                          toast.error('Reprocess failed', {
+                            description: `${id.slice(0, 8)}… — ${message}`,
+                            duration: 5000,
+                          });
+                        },
+                      })
+                    }
                     disabled={isReprocessing}
                     title="Retry processing"
                     className="text-[var(--color-text-body-secondary)] hover:text-[var(--color-book-cloth)] transition-colors disabled:opacity-50"

--- a/packages/web-next/components/settings/VoiceSection.tsx
+++ b/packages/web-next/components/settings/VoiceSection.tsx
@@ -36,7 +36,8 @@ import { useQuery } from '@tanstack/react-query';
 import { Mic, TriangleAlert } from 'lucide-react';
 import { Card } from '@/components/design-system/Card';
 import { StatusDot } from '@/components/design-system/StatusDot';
-import { configApi, voiceSessionApi } from '@/lib/api-client';
+import { configApi } from '@/lib/api-client';
+import { useVoiceSessions, useActiveVoiceSessions } from '@/lib/api/voice.hooks';
 import type { Integration } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
@@ -44,8 +45,6 @@ import type { Integration } from '@/lib/types';
 // ---------------------------------------------------------------------------
 
 const INTEGRATIONS_QUERY_KEY = ['config', 'integrations'] as const;
-const VOICE_SESSIONS_TOTAL_QUERY_KEY = ['voice', 'sessions', 'total'] as const;
-const VOICE_SESSIONS_ACTIVE_QUERY_KEY = ['voice', 'sessions', 'active'] as const;
 
 // ---------------------------------------------------------------------------
 // Status helpers
@@ -164,24 +163,10 @@ export function VoiceSection() {
   });
 
   // ── Fetch total session count (limit=1; we only need the total) ────────────
-  const {
-    data: sessionsListData,
-    isLoading: sessionsListLoading,
-  } = useQuery({
-    queryKey: VOICE_SESSIONS_TOTAL_QUERY_KEY,
-    queryFn: () => voiceSessionApi.list({ limit: 1 }),
-    staleTime: 30_000,
-  });
+  const { data: sessionsListData, isLoading: sessionsListLoading } = useVoiceSessions({ limit: 1 });
 
   // ── Fetch active sessions ──────────────────────────────────────────────────
-  const {
-    data: activeData,
-    isLoading: activeLoading,
-  } = useQuery({
-    queryKey: VOICE_SESSIONS_ACTIVE_QUERY_KEY,
-    queryFn: () => voiceSessionApi.active(),
-    staleTime: 30_000,
-  });
+  const { data: activeData, isLoading: activeLoading } = useActiveVoiceSessions();
 
   const isLoading = integrationsLoading || sessionsListLoading || activeLoading;
 

--- a/packages/web-next/components/settings/WikiSection.tsx
+++ b/packages/web-next/components/settings/WikiSection.tsx
@@ -26,20 +26,13 @@
  * - Auto-ingest badge: Enabled (default) / Disabled based on wiki-ingest/wiki-synthesis skill schedule.
  */
 
-import { useQuery } from '@tanstack/react-query';
 import { BookOpen, TriangleAlert } from 'lucide-react';
 import { Card } from '@/components/design-system/Card';
 import { StatusDot } from '@/components/design-system/StatusDot';
-import { wikiApi, systemHealthApi, skillsListApi } from '@/lib/api-client';
-import type { WikiStats, SystemHealthSnapshot, SkillRecord } from '@/lib/api-client';
-
-// ---------------------------------------------------------------------------
-// Query keys
-// ---------------------------------------------------------------------------
-
-const WIKI_STATS_QUERY_KEY  = ['wiki', 'stats'] as const;
-const SYSTEM_HEALTH_QUERY_KEY = ['system', 'health'] as const;
-const SKILLS_LIST_QUERY_KEY  = ['skills', 'list'] as const;
+import { useWikiStats } from '@/lib/api/wiki.hooks';
+import { useSystemHealthSnapshot } from '@/lib/api/system-health.hooks';
+import { useSkillsList } from '@/lib/api/skills.hooks';
+import type { SystemHealthSnapshot, SkillRecord } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -144,25 +137,13 @@ function AutoIngestBadge({ enabled }: { enabled: boolean }) {
 
 export function WikiSection() {
   // ── Wiki stats ────────────────────────────────────────────────────────────
-  const statsQuery = useQuery<WikiStats>({
-    queryKey: WIKI_STATS_QUERY_KEY,
-    queryFn: () => wikiApi.stats(),
-    staleTime: 60_000,
-  });
+  const statsQuery = useWikiStats();
 
   // ── System health snapshot (for repo URL + connection status) ─────────────
-  const healthQuery = useQuery<SystemHealthSnapshot>({
-    queryKey: SYSTEM_HEALTH_QUERY_KEY,
-    queryFn: () => systemHealthApi.snapshot(),
-    staleTime: 60_000,
-  });
+  const healthQuery = useSystemHealthSnapshot();
 
   // ── Skills list (for wiki-lint schedule and auto-ingest skill presence) ───
-  const skillsQuery = useQuery<{ skills: SkillRecord[] }>({
-    queryKey: SKILLS_LIST_QUERY_KEY,
-    queryFn: () => skillsListApi.list(),
-    staleTime: 120_000,
-  });
+  const skillsQuery = useSkillsList();
 
   const isLoading = statsQuery.isLoading || healthQuery.isLoading || skillsQuery.isLoading;
   const isError   = statsQuery.isError   || healthQuery.isError;

--- a/packages/web-next/components/system/McpActivityTab.tsx
+++ b/packages/web-next/components/system/McpActivityTab.tsx
@@ -14,10 +14,10 @@
  */
 
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { CheckCircle, XCircle, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button, StatusDot } from '@/components/design-system';
-import { mcpActivityApi, type McpActivityEntry, type ListEnvelope } from '@/lib/api-client';
+import { useMcpActivity } from '@/lib/api/mcp-activity.hooks';
+import type { McpActivityEntry, ListEnvelope } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -132,18 +132,10 @@ export function McpActivityTab({ initialData }: McpActivityTabProps) {
   const [offset, setOffset] = useState(0);
   const [toolFilter, setToolFilter] = useState('');
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['mcp-activity', offset, toolFilter],
-    queryFn: () =>
-      mcpActivityApi.list({
-        limit: PAGE_SIZE,
-        offset,
-        tool_name: toolFilter || undefined,
-      }),
-    // Use initial data for offset=0 with no filter
-    initialData: offset === 0 && !toolFilter ? initialData : undefined,
-    staleTime: 30_000,
-  });
+  const { data, isLoading, isError } = useMcpActivity(
+    { limit: PAGE_SIZE, offset, tool_name: toolFilter || undefined },
+    { initialData: offset === 0 && !toolFilter ? initialData : undefined },
+  );
 
   const items = data?.items ?? [];
   const total = data?.total ?? 0;

--- a/packages/web-next/components/system/SkillsTab.tsx
+++ b/packages/web-next/components/system/SkillsTab.tsx
@@ -15,11 +15,11 @@
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Play, Edit2, Check, X, Clock } from 'lucide-react';
 import { Button } from '@/components/design-system';
-import { skillsApi, skillsListApi, type SkillRecord } from '@/lib/api-client';
+import { useTriggerSkill, useUpdateSkillSchedule } from '@/lib/api/skills.hooks';
+import type { SkillRecord } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -56,31 +56,10 @@ function SkillRow({ skill }: SkillRowProps) {
   const [scheduleInput, setScheduleInput] = useState(skill.schedule ?? '');
 
   // Trigger mutation — fire-and-forget (202 queued)
-  const triggerMutation = useMutation({
-    mutationFn: () => skillsApi.trigger(skill.name),
-    onSuccess: (result) => {
-      toast.success(`Skill "${skill.name}" queued (job ${result.job_id})`);
-    },
-    onError: (err: unknown) => {
-      const message = err instanceof Error ? err.message : 'Trigger failed';
-      toast.error(`Failed to trigger "${skill.name}": ${message}`);
-    },
-  });
+  const triggerMutation = useTriggerSkill();
 
   // Schedule update mutation
-  const scheduleMutation = useMutation({
-    mutationFn: () => skillsListApi.updateSchedule(skill.name, scheduleInput.trim()),
-    onSuccess: (result) => {
-      toast.success(`Schedule updated: ${result.schedule}`);
-      setEditingSchedule(false);
-      // Reflect new schedule in the displayed row without a full reload
-      skill.schedule = result.schedule;
-    },
-    onError: (err: unknown) => {
-      const message = err instanceof Error ? err.message : 'Update failed';
-      toast.error(`Failed to update schedule: ${message}`);
-    },
-  });
+  const scheduleMutation = useUpdateSkillSchedule();
 
   function handleCancelEdit() {
     setScheduleInput(skill.schedule ?? '');
@@ -128,7 +107,20 @@ function SkillRow({ skill }: SkillRowProps) {
                 ].join(' ')}
                 autoFocus
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') scheduleMutation.mutate();
+                  if (e.key === 'Enter') scheduleMutation.mutate(
+                    { name: skill.name, schedule: scheduleInput.trim() },
+                    {
+                      onSuccess: (result) => {
+                        toast.success(`Schedule updated: ${result.schedule}`);
+                        setEditingSchedule(false);
+                        skill.schedule = result.schedule;
+                      },
+                      onError: (err: unknown) => {
+                        const message = err instanceof Error ? err.message : 'Update failed';
+                        toast.error(`Failed to update schedule: ${message}`);
+                      },
+                    },
+                  );
                   if (e.key === 'Escape') handleCancelEdit();
                 }}
               />
@@ -136,7 +128,20 @@ function SkillRow({ skill }: SkillRowProps) {
                 variant="primary"
                 size="sm"
                 icon={<Check size={11} strokeWidth={1.5} />}
-                onClick={() => scheduleMutation.mutate()}
+                onClick={() => scheduleMutation.mutate(
+                    { name: skill.name, schedule: scheduleInput.trim() },
+                    {
+                      onSuccess: (result) => {
+                        toast.success(`Schedule updated: ${result.schedule}`);
+                        setEditingSchedule(false);
+                        skill.schedule = result.schedule;
+                      },
+                      onError: (err: unknown) => {
+                        const message = err instanceof Error ? err.message : 'Update failed';
+                        toast.error(`Failed to update schedule: ${message}`);
+                      },
+                    },
+                  )}
                 disabled={scheduleMutation.isPending || !scheduleInput.trim()}
               >
                 {scheduleMutation.isPending ? 'Saving…' : 'Save'}
@@ -184,7 +189,20 @@ function SkillRow({ skill }: SkillRowProps) {
               variant="secondary"
               size="sm"
               icon={<Play size={11} strokeWidth={1.5} />}
-              onClick={() => triggerMutation.mutate()}
+              onClick={() =>
+                triggerMutation.mutate(
+                  { name: skill.name },
+                  {
+                    onSuccess: (result) => {
+                      toast.success(`Skill "${skill.name}" queued (job ${result.job_id})`);
+                    },
+                    onError: (err: unknown) => {
+                      const message = err instanceof Error ? err.message : 'Trigger failed';
+                      toast.error(`Failed to trigger "${skill.name}": ${message}`);
+                    },
+                  },
+                )
+              }
               disabled={triggerMutation.isPending}
               title={`Trigger ${skill.name} now`}
             >

--- a/packages/web-next/components/voice/SessionDetail.tsx
+++ b/packages/web-next/components/voice/SessionDetail.tsx
@@ -19,7 +19,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { Loader2, Mic2, User, Bot, FileText, Clock, Hash } from 'lucide-react';
-import { voiceSessionApi, capturesApi, type VoiceSession, type TranscriptTurn } from '@/lib/api-client';
+import { useVoiceSession } from '@/lib/api/voice.hooks';
+import { capturesApi, type VoiceSession, type TranscriptTurn } from '@/lib/api-client';
 import type { Capture } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
@@ -220,7 +221,7 @@ function LinkedCaptures({ captureIds }: LinkedCapturesProps) {
         </div>
       ) : (
         <div>
-          {(captures ?? []).map((capture) => (
+          {(captures ?? []).map((capture: Capture) => (
             <div
               key={capture.id}
               className="px-[18px] py-[10px] border-b border-cloud-light last:border-b-0"
@@ -258,14 +259,7 @@ interface SessionDetailProps {
 }
 
 export function SessionDetail({ sessionId, isActive = false }: SessionDetailProps) {
-  const { data: session, isLoading, isError, error } = useQuery<VoiceSession>({
-    queryKey: ['voice-session', sessionId],
-    queryFn: () => voiceSessionApi.get(sessionId),
-    // Poll every 10 seconds for live sessions; no polling for completed sessions
-    refetchInterval: isActive ? 10_000 : false,
-    refetchOnWindowFocus: isActive,
-    staleTime: isActive ? 0 : 60_000,
-  });
+  const { data: session, isLoading, isError, error } = useVoiceSession(sessionId, { isActive });
 
   if (isLoading) {
     return (

--- a/packages/web-next/components/voice/SessionList.tsx
+++ b/packages/web-next/components/voice/SessionList.tsx
@@ -18,10 +18,9 @@
  *   onSelect         — callback when a session row is clicked
  */
 
-import { useQuery } from '@tanstack/react-query';
 import { Mic, MicOff, Radio } from 'lucide-react';
-import { voiceSessionApi, type VoiceSession } from '@/lib/api-client';
-import type { ListEnvelope } from '@/lib/api-client';
+import { useVoiceSessions, useActiveVoiceSessions } from '@/lib/api/voice.hooks';
+import type { VoiceSession } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Formatting helpers
@@ -198,26 +197,13 @@ export function SessionList({
   onSelect,
 }: SessionListProps) {
   // Full session list — no polling needed; sessions only added, never mutated in-place
-  const { data: sessionsData } = useQuery<ListEnvelope<VoiceSession>>({
-    queryKey: ['voice-sessions'],
-    queryFn: () => voiceSessionApi.list({ limit: 100 }),
-    initialData: {
-      items: initialSessions,
-      total: initialTotal,
-      limit: 100,
-      offset: 0,
-    },
-    refetchOnWindowFocus: false,
-  });
+  const { data: sessionsData } = useVoiceSessions(
+    { limit: 100 },
+    { initialData: { items: initialSessions, total: initialTotal, limit: 100, offset: 0 } },
+  );
 
-  // Active sessions — polled every 10 seconds
-  const { data: activeData } = useQuery<{ items: VoiceSession[] }>({
-    queryKey: ['voice-sessions-active'],
-    queryFn: () => voiceSessionApi.active(),
-    initialData: { items: [] },
-    refetchInterval: 10_000,
-    refetchOnWindowFocus: true,
-  });
+  // Active sessions — polled every 10 seconds (shared key with VoiceConversationsClient)
+  const { data: activeData } = useActiveVoiceSessions();
 
   const sessions = sessionsData?.items ?? initialSessions;
   const activeSessions = activeData?.items ?? [];

--- a/packages/web-next/components/voice/VoiceConversationsClient.tsx
+++ b/packages/web-next/components/voice/VoiceConversationsClient.tsx
@@ -12,11 +12,10 @@
  */
 
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { SessionList } from './SessionList';
 import { SessionDetail } from './SessionDetail';
-import { voiceSessionApi, type VoiceSession } from '@/lib/api-client';
-import type { ListEnvelope } from '@/lib/api-client';
+import { useActiveVoiceSessions } from '@/lib/api/voice.hooks';
+import type { VoiceSession } from '@/lib/api-client';
 import { MicOff } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -38,13 +37,7 @@ export function VoiceConversationsClient({
   );
 
   // Poll for active sessions to determine the isActive flag for SessionDetail
-  const { data: activeData } = useQuery<{ items: VoiceSession[] }>({
-    queryKey: ['voice-sessions-active'],
-    queryFn: () => voiceSessionApi.active(),
-    initialData: { items: [] },
-    refetchInterval: 10_000,
-    refetchOnWindowFocus: true,
-  });
+  const { data: activeData } = useActiveVoiceSessions();
 
   const activeIds = new Set((activeData?.items ?? []).map((s) => s.id));
   const selectedIsActive = selectedId !== null && activeIds.has(selectedId);

--- a/packages/web-next/lib/api/ingest.hooks.ts
+++ b/packages/web-next/lib/api/ingest.hooks.ts
@@ -1,0 +1,97 @@
+/**
+ * TanStack Query hooks — ingest domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['ingest', 'uploads', limit?]   — paginated upload list (also exported as
+ *                                     INGEST_UPLOADS_QUERY_KEY for cross-component invalidation)
+ *   ['ingest', 'upload', id]        — single upload row
+ *
+ * `INGEST_UPLOADS_QUERY_KEY` is exported so IngestClient (upload handler) can
+ * invalidate the list after a successful upload without importing the full hook.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { ingestApi } from './ingest'
+import type { IngestListParams, IngestUploadOptions } from './ingest'
+
+/** Stable root key used for cross-component cache invalidation. */
+export const INGEST_UPLOADS_QUERY_KEY = ['ingest', 'uploads'] as const
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Paginated list of file uploads.
+ *
+ * Supports `initialData` for RSC pre-fetch and dynamic `refetchInterval`
+ * to poll while any upload is pending/processing.
+ */
+export function useIngestUploads(
+  params: IngestListParams = {},
+  options?: {
+    initialData?: Awaited<ReturnType<typeof ingestApi.list>>
+    refetchInterval?: number | false | ((query: { state: { data?: Awaited<ReturnType<typeof ingestApi.list>> } }) => number | false)
+  },
+) {
+  const { limit = 20, ...rest } = params
+  return useQuery({
+    queryKey: [...INGEST_UPLOADS_QUERY_KEY, limit],
+    queryFn: () => ingestApi.list({ limit, ...rest }),
+    initialData: options?.initialData,
+    refetchInterval: options?.refetchInterval,
+    staleTime: 5_000,
+  })
+}
+
+/** Single file upload row. Skips fetch when id is falsy. */
+export function useIngestUpload(id: string) {
+  return useQuery({
+    queryKey: ['ingest', 'upload', id],
+    queryFn: () => ingestApi.get(id),
+    enabled: Boolean(id),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload a file via multipart POST.
+ * On success, invalidates the uploads list.
+ */
+export function useUploadFile() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ file, opts = {} }: { file: File; opts?: IngestUploadOptions }) =>
+      ingestApi.upload(file, opts),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: INGEST_UPLOADS_QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * Re-enqueue a failed upload for reprocessing.
+ * On success, invalidates the uploads list.
+ */
+export function useReprocessUpload() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => ingestApi.process(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: INGEST_UPLOADS_QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * Trigger manual inbox scan (no upload required).
+ */
+export function useIngestProcessNow() {
+  return useMutation({
+    mutationFn: (source?: Parameters<typeof ingestApi.processNow>[0]) =>
+      ingestApi.processNow(source),
+  })
+}

--- a/packages/web-next/lib/api/mcp-activity.hooks.ts
+++ b/packages/web-next/lib/api/mcp-activity.hooks.ts
@@ -1,0 +1,39 @@
+/**
+ * TanStack Query hooks — mcp-activity domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['mcp-activity', offset, toolFilter]  — paginated activity log
+ *
+ * The McpActivityTab component paginates with offset + toolFilter state, so
+ * both are encoded in the query key so each page/filter combo is cached
+ * independently.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { mcpActivityApi } from './mcp-activity'
+import type { McpActivityListParams } from './mcp-activity'
+import type { ListEnvelope } from './core'
+import type { McpActivityEntry } from './mcp-activity'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Paginated MCP activity log.
+ *
+ * `staleTime: 30_000` matches the existing inline usage in McpActivityTab.
+ * `initialData` is forwarded for offset=0 / no-filter case (RSC pre-fetch).
+ */
+export function useMcpActivity(
+  params: McpActivityListParams = {},
+  options?: { initialData?: ListEnvelope<McpActivityEntry> },
+) {
+  const { limit, offset = 0, tool_name, client_id, since } = params
+  return useQuery({
+    queryKey: ['mcp-activity', offset, tool_name ?? ''],
+    queryFn: () => mcpActivityApi.list({ limit, offset, tool_name, client_id, since }),
+    initialData: options?.initialData,
+    staleTime: 30_000,
+  })
+}

--- a/packages/web-next/lib/api/skills.hooks.ts
+++ b/packages/web-next/lib/api/skills.hooks.ts
@@ -1,0 +1,49 @@
+/**
+ * TanStack Query hooks — skills domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['skills', 'list']         — full skill list with last-run metadata
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { skillsApi, skillsListApi } from './skills'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Full list of configured skills with last-run metadata.
+ * `staleTime: 120_000` — skills list changes infrequently (schedule edits only).
+ */
+export function useSkillsList() {
+  return useQuery({
+    queryKey: ['skills', 'list'],
+    queryFn: () => skillsListApi.list(),
+    staleTime: 120_000,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/** Manually trigger a skill by name. Fire-and-forget — no cache invalidation. */
+export function useTriggerSkill() {
+  return useMutation({
+    mutationFn: ({ name, params = {} }: { name: string; params?: Record<string, unknown> }) =>
+      skillsApi.trigger(name, params),
+  })
+}
+
+/** Update a skill's cron schedule. Invalidates the skills list on success. */
+export function useUpdateSkillSchedule() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ name, schedule }: { name: string; schedule: string }) =>
+      skillsListApi.updateSchedule(name, schedule),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['skills', 'list'] })
+    },
+  })
+}

--- a/packages/web-next/lib/api/system-health.hooks.ts
+++ b/packages/web-next/lib/api/system-health.hooks.ts
@@ -1,0 +1,45 @@
+/**
+ * TanStack Query hooks — system-health domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['system', 'health']          — full operational snapshot (queues, redis, spend, skills, wiki)
+ *   ['system', 'flows', limit?]   — recent pipeline flow entries
+ *   ['system', 'infrastructure']  — container health, backups, cost
+ *
+ * Note: WikiSection uses `['system', 'health']` as its query key for
+ * systemHealthApi.snapshot() — keep that key stable.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { systemHealthApi } from './system-health'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Full operational health snapshot. Skips automated refetch — manual refresh on system page. */
+export function useSystemHealthSnapshot() {
+  return useQuery({
+    queryKey: ['system', 'health'],
+    queryFn: () => systemHealthApi.snapshot(),
+    staleTime: 30_000,
+  })
+}
+
+/** Recent pipeline flow entries. */
+export function useSystemFlows(limit = 20) {
+  return useQuery({
+    queryKey: ['system', 'flows', limit],
+    queryFn: () => systemHealthApi.flows(limit),
+    staleTime: 30_000,
+  })
+}
+
+/** Infrastructure data — container health, backups, LLM cost. */
+export function useSystemInfrastructure() {
+  return useQuery({
+    queryKey: ['system', 'infrastructure'],
+    queryFn: () => systemHealthApi.infrastructure(),
+    staleTime: 30_000,
+  })
+}

--- a/packages/web-next/lib/api/voice.hooks.ts
+++ b/packages/web-next/lib/api/voice.hooks.ts
@@ -1,0 +1,60 @@
+/**
+ * TanStack Query hooks — voice domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['voice-sessions']          — paginated session list
+ *   ['voice-sessions-active']   — active sessions (no ended_at)
+ *   ['voice-session', id]       — single session with full transcript
+ *
+ * Note: VoiceConversationsClient, SessionList, SessionDetail, and
+ * VoiceSection all use these keys. Keep them stable — components share
+ * cache entries when using the same key.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { voiceSessionApi } from './voice'
+import type { VoiceSessionsListParams } from './voice'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Paginated voice session list.
+ * Supports `initialData` for RSC pre-fetch.
+ */
+export function useVoiceSessions(
+  params: VoiceSessionsListParams = {},
+  options?: { initialData?: Awaited<ReturnType<typeof voiceSessionApi.list>> },
+) {
+  return useQuery({
+    queryKey: ['voice-sessions'],
+    queryFn: () => voiceSessionApi.list(params),
+    initialData: options?.initialData,
+  })
+}
+
+/**
+ * Active voice sessions (no ended_at).
+ * Polled on the conversations page to detect live sessions.
+ */
+export function useActiveVoiceSessions() {
+  return useQuery({
+    queryKey: ['voice-sessions-active'],
+    queryFn: () => voiceSessionApi.active(),
+  })
+}
+
+/**
+ * Single voice session with full transcript.
+ * Skips fetch when id is falsy.
+ * Active sessions re-fetch every 10 seconds to pick up new transcript turns.
+ */
+export function useVoiceSession(id: string, options?: { isActive?: boolean }) {
+  return useQuery({
+    queryKey: ['voice-session', id],
+    queryFn: () => voiceSessionApi.get(id),
+    enabled: Boolean(id),
+    refetchInterval: options?.isActive ? 10_000 : false,
+  })
+}

--- a/packages/web-next/lib/api/wiki.hooks.ts
+++ b/packages/web-next/lib/api/wiki.hooks.ts
@@ -1,0 +1,107 @@
+/**
+ * TanStack Query hooks — wiki domain (Phase G.1).
+ *
+ * Query key hierarchy:
+ *   ['wiki', 'pages', params?]          — list of all wiki page metadata
+ *   ['wiki', 'page', slug]              — single page with content
+ *   ['wiki', 'recent-changes', limit?]  — recent git log entries
+ *   ['wiki', 'lint-report']             — structured lint results
+ *   ['wiki', 'stats']                   — aggregate wiki statistics
+ *   ['wiki', 'search', q]               — search results
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { wikiApi } from './wiki'
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** List all wiki pages with optional type/tag filters. */
+export function useWikiPages(params: { type?: string; tag?: string } = {}) {
+  return useQuery({
+    queryKey: ['wiki', 'pages', params],
+    queryFn: () => wikiApi.pages(params),
+    staleTime: 60_000,
+  })
+}
+
+/** Full wiki page (metadata + markdown content). Skips fetch when slug is falsy. */
+export function useWikiPage(slug: string) {
+  return useQuery({
+    queryKey: ['wiki', 'page', slug],
+    queryFn: () => wikiApi.page(slug),
+    enabled: Boolean(slug),
+    staleTime: 60_000,
+  })
+}
+
+/** Recent wiki git log entries. */
+export function useWikiRecentChanges(limit = 20) {
+  return useQuery({
+    queryKey: ['wiki', 'recent-changes', limit],
+    queryFn: () => wikiApi.recentChanges(limit),
+    staleTime: 60_000,
+  })
+}
+
+/** Structured lint report. `staleTime: 60_000` — lint runs are infrequent. */
+export function useWikiLintReport() {
+  return useQuery({
+    queryKey: ['wiki', 'lint-report'],
+    queryFn: () => wikiApi.lintReport(),
+    staleTime: 60_000,
+  })
+}
+
+/**
+ * Aggregate wiki statistics.
+ * WikiSection uses `['wiki', 'stats']` — keep this query key stable.
+ */
+export function useWikiStats() {
+  return useQuery({
+    queryKey: ['wiki', 'stats'],
+    queryFn: () => wikiApi.stats(),
+    staleTime: 60_000,
+  })
+}
+
+/** Wiki content search. Skips fetch when q is blank. */
+export function useWikiSearch(q: string) {
+  return useQuery({
+    queryKey: ['wiki', 'search', q],
+    queryFn: () => wikiApi.search(q),
+    enabled: Boolean(q?.trim()),
+    staleTime: 30_000,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/** Trigger a manual wiki lint job. Invalidates lint-report on success. */
+export function useTriggerWikiLint() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => wikiApi.triggerLint(),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['wiki', 'lint-report'] })
+    },
+  })
+}
+
+/** Trigger re-synthesis for a specific wiki page. Invalidates the page cache. */
+export function useTriggerWikiResynthesize() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (page_path: string) => wikiApi.triggerResynthesize(page_path),
+    onSuccess: (_data, page_path) => {
+      // Invalidate the specific page — slug may differ from path, invalidate all pages
+      qc.invalidateQueries({ queryKey: ['wiki', 'pages'] })
+      qc.invalidateQueries({ queryKey: ['wiki', 'page'] })
+      qc.invalidateQueries({ queryKey: ['wiki', 'stats'] })
+      void page_path // suppress unused-var lint
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Adds 6 hook files under `packages/web-next/lib/api/*.hooks.ts`
- Migrates 8 components from inline query/mutation constructions to the new hooks
- `skills.hooks.ts` pulled forward from Batch 4 — required by WikiSection migration

**Hooks added (25 total):** `useSystemHealthSnapshot`, `useSystemFlows`, `useSystemInfrastructure`, `useMcpActivity`, `useWikiPages`, `useWikiPage`, `useWikiRecentChanges`, `useWikiLintReport`, `useWikiStats`, `useWikiSearch`, `useTriggerWikiLint`, `useTriggerWikiResynthesize`, `useIngestUploads`, `useIngestUpload`, `useUploadFile`, `useReprocessUpload`, `useIngestProcessNow`, `useVoiceSessions`, `useActiveVoiceSessions`, `useVoiceSession`, `useSkillsList`, `useTriggerSkill`, `useUpdateSkillSchedule`

**Consumers migrated (8):** `McpActivityTab`, `WikiSection`, `RecentUploads`, `VoiceConversationsClient`, `SessionList`, `SessionDetail`, `VoiceSection`, `SkillsTab`

**Notes:**
- `INGEST_UPLOADS_QUERY_KEY` moved to `ingest.hooks.ts` but re-exported from `RecentUploads.tsx` for backward compat
- `SessionDetail.LinkedCaptures` keeps inline `useQuery` — it batch-fetches captures (not voice domain), one-off pattern
- `VoiceSection.configApi` query stays inline until Batch 4 `config.hooks.ts`

Refs #177 (A128)

## Test plan

- [x] `pnpm --filter @open-brain/web-next exec tsc --noEmit` — clean
- [x] `pnpm --filter @open-brain/web-next exec vitest run` — 118/118 pass
- [ ] CI: Integration tests (core-api + real DB)
