### PR TITLE
feat(web-next): Phase G.1 Batch 4 — TanStack Query hooks (admin, email) — closes #177

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -10887,6 +10887,36 @@ Close 5 skipped test cases from Entry 143 test run:
 
 --- New session: 2026-05-09 — Phase G.1 TanStack Query hooks (A128) ---
 
+## Entry 151 — Phase G.1 Batch 4: TanStack Query hooks — admin, email (2026-05-09)  [web] [refactor]
+
+**Date:** 2026-05-09
+**Environment:** open-brain-remediation worktree; branch feat/phase-g1-batch-4
+**Duration:** ~20 min
+
+**Objective:** Final batch — create hook files for 2 remaining mutation-only domains. Migrate 3 consumers. Completes Phase G.1 (GitHub issue #177 / A128). Refs #177.
+
+**Rollback plan:** `git revert` — no DB or infra changes.
+
+**Hooks created:**
+- `lib/api/admin.hooks.ts` — `useArchiveSlackChannel` (invalidates `['slack-channels']`), `useClearQueue` (no cache invalidation — page reloads on success)
+- `lib/api/email.hooks.ts` — `useSendEmailDraft` (invalidates `['email-drafts']`), `useRejectEmailDraft` (invalidates `['email-drafts']`); exports `EMAIL_DRAFTS_QUERY_KEY`
+
+**Consumers migrated (3):**
+- `components/slack/ChannelTable.tsx` — `useMutation`+`useQueryClient`+`adminApi` → `useArchiveSlackChannel`; toast/local-state update moved to `mutate()` callbacks (v5 pattern: no `onMutate` in MutateOptions)
+- `components/system/QueuesTab.tsx` — `useMutation`+`adminQueuesApi` → `useClearQueue`; toast/reload moved to `mutate()` callbacks with `{ name, state }` variables shape
+- `components/email/EmailTabs.tsx` — 2×`useMutation`+`useQueryClient`+`emailApi` → `useSendEmailDraft`+`useRejectEmailDraft`; `setSendingId`/`setRejectingId` called before `mutate()` (replaces v5-incompatible `onMutate`); optimistic local-state update + toast in per-call callbacks
+
+**VoiceSection fully migrated:** Batch 3 rebase onto main (post-Batch-2 merge) resolved conflict — VoiceSection now uses both `useIntegrations` (config.hooks) + `useVoiceSessions`/`useActiveVoiceSessions` (voice.hooks). `useQuery` import removed entirely.
+
+**Key decisions:**
+- `useClearQueue` receives `{ name, state }` variables (not just `name`) — same shape as `adminQueuesApi.clear(name, state)`. Callers hardcode `state: 'failed'` at the call site.
+- Email mutation hooks do cache invalidation at the hook level; EmailTabs also does local-state optimistic update in per-call `onSuccess` for immediate UX update without waiting for re-fetch.
+- `EMAIL_DRAFTS_QUERY_KEY = ['email-drafts']` exported from email.hooks.ts matches the invalidation key already used inline in the prior consumers.
+
+**Result:** tsc --noEmit clean. 118/118 tests pass.
+
+---
+
 ## Entry 150 — Phase G.1 Batch 3: TanStack Query hooks — commitments, config, synthesize, service-health, email-settings (2026-05-09)  [web] [refactor]
 
 **Date:** 2026-05-09

--- a/packages/web-next/components/email/EmailTabs.tsx
+++ b/packages/web-next/components/email/EmailTabs.tsx
@@ -22,7 +22,6 @@
  */
 
 import { useState, useMemo } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   Inbox,
@@ -35,7 +34,8 @@ import {
 import { EmptyState, Input } from '@/components/design-system';
 import { DraftCard } from './DraftCard';
 import { ThreadView } from './ThreadView';
-import { emailApi, type EmailDraft } from '@/lib/api-client';
+import { useSendEmailDraft, useRejectEmailDraft } from '@/lib/api/email.hooks';
+import type { EmailDraft } from '@/lib/api-client';
 import type { Capture } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
@@ -386,8 +386,6 @@ function FilterBar({
 // ---------------------------------------------------------------------------
 
 export function EmailTabs({ initialCaptures, initialDrafts }: EmailTabsProps) {
-  const queryClient = useQueryClient();
-
   // Tab state
   const [activeTab, setActiveTab] = useState<TabId>('inbound');
 
@@ -412,56 +410,10 @@ export function EmailTabs({ initialCaptures, initialDrafts }: EmailTabsProps) {
   }
 
   // ---- Send mutation ----
-  const sendMutation = useMutation({
-    mutationFn: (id: string) => emailApi.send(id),
-    onMutate: (id) => {
-      setSendingId(id);
-    },
-    onSuccess: (result) => {
-      // Optimistic update: replace draft with updated status
-      setDrafts((prev) =>
-        prev.map((d) =>
-          d.id === result.id
-            ? { ...d, status: result.status, sent_at: result.sent_at }
-            : d,
-        ),
-      );
-      toast.success('Email sent successfully');
-      queryClient.invalidateQueries({ queryKey: ['email-drafts'] });
-    },
-    onError: (err, id) => {
-      console.error('[EmailTabs] send failed for draft:', id, err);
-      toast.error('Failed to send email — please try again.');
-    },
-    onSettled: () => {
-      setSendingId(null);
-    },
-  });
+  const sendMutation = useSendEmailDraft();
 
   // ---- Reject mutation ----
-  const rejectMutation = useMutation({
-    mutationFn: (id: string) => emailApi.reject(id),
-    onMutate: (id) => {
-      setRejectingId(id);
-    },
-    onSuccess: (result) => {
-      // Optimistic update: replace draft status with 'rejected'
-      setDrafts((prev) =>
-        prev.map((d) =>
-          d.id === result.id ? { ...d, status: result.status } : d,
-        ),
-      );
-      toast.success('Draft rejected');
-      queryClient.invalidateQueries({ queryKey: ['email-drafts'] });
-    },
-    onError: (err, id) => {
-      console.error('[EmailTabs] reject failed for draft:', id, err);
-      toast.error('Failed to reject draft — please try again.');
-    },
-    onSettled: () => {
-      setRejectingId(null);
-    },
-  });
+  const rejectMutation = useRejectEmailDraft();
 
   // Tab definitions with dynamic counts
   const pendingDraftCount = drafts.filter(
@@ -553,8 +505,44 @@ export function EmailTabs({ initialCaptures, initialDrafts }: EmailTabsProps) {
         {activeTab === 'drafts' && (
           <DraftsPanel
             drafts={drafts}
-            onSend={(id) => sendMutation.mutate(id)}
-            onReject={(id) => rejectMutation.mutate(id)}
+            onSend={(id) => {
+              setSendingId(id);
+              sendMutation.mutate(id, {
+                onSuccess: (result) => {
+                  setDrafts((prev) =>
+                    prev.map((d) =>
+                      d.id === result.id
+                        ? { ...d, status: result.status, sent_at: result.sent_at }
+                        : d,
+                    ),
+                  );
+                  toast.success('Email sent successfully');
+                },
+                onError: (err) => {
+                  console.error('[EmailTabs] send failed for draft:', id, err);
+                  toast.error('Failed to send email — please try again.');
+                },
+                onSettled: () => setSendingId(null),
+              });
+            }}
+            onReject={(id) => {
+              setRejectingId(id);
+              rejectMutation.mutate(id, {
+                onSuccess: (result) => {
+                  setDrafts((prev) =>
+                    prev.map((d) =>
+                      d.id === result.id ? { ...d, status: result.status } : d,
+                    ),
+                  );
+                  toast.success('Draft rejected');
+                },
+                onError: (err) => {
+                  console.error('[EmailTabs] reject failed for draft:', id, err);
+                  toast.error('Failed to reject draft — please try again.');
+                },
+                onSettled: () => setRejectingId(null),
+              });
+            }}
             sendingId={sendingId}
             rejectingId={rejectingId}
           />

--- a/packages/web-next/components/slack/ChannelTable.tsx
+++ b/packages/web-next/components/slack/ChannelTable.tsx
@@ -15,7 +15,6 @@
  */
 
 import { useState, useMemo, useCallback, useRef } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import * as Dialog from '@radix-ui/react-dialog';
 import {
@@ -30,7 +29,8 @@ import {
   X,
 } from 'lucide-react';
 import { Card, Button, EmptyState } from '@/components/design-system';
-import { adminApi, type SlackChannel } from '@/lib/api-client';
+import { useArchiveSlackChannel } from '@/lib/api/admin.hooks';
+import type { SlackChannel } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -291,8 +291,6 @@ function ArchiveModal({ channel, onClose, onConfirm, isLoading }: ArchiveModalPr
 // ---------------------------------------------------------------------------
 
 export function ChannelTable({ initialChannels }: ChannelTableProps) {
-  const queryClient = useQueryClient();
-
   // Local channel list — starts from server-prefetched data
   const [channels, setChannels] = useState<SlackChannel[]>(initialChannels);
 
@@ -316,25 +314,25 @@ export function ChannelTable({ initialChannels }: ChannelTableProps) {
   }
 
   // Archive mutation
-  const archiveMutation = useMutation({
-    mutationFn: (id: string) => adminApi.archiveSlackChannel(id),
-    onSuccess: (_result, id) => {
-      setChannels((prev) =>
-        prev.map((ch) => (ch.id === id ? { ...ch, is_archived: true } : ch)),
-      );
-      toast.success(`#${archiveTarget?.name ?? id} archived`);
-      setArchiveTarget(null);
-      queryClient.invalidateQueries({ queryKey: ['slack-channels'] });
-    },
-    onError: (err, id) => {
-      console.error('[ChannelTable] archive failed for channel:', id, err);
-      toast.error('Failed to archive channel — please try again.');
-    },
-  });
+  const archiveMutation = useArchiveSlackChannel();
 
   const handleArchiveConfirm = useCallback(
-    (id: string) => archiveMutation.mutate(id),
-    [archiveMutation],
+    (id: string) => {
+      archiveMutation.mutate(id, {
+        onSuccess: () => {
+          setChannels((prev) =>
+            prev.map((ch) => (ch.id === id ? { ...ch, is_archived: true } : ch)),
+          );
+          toast.success(`#${archiveTarget?.name ?? id} archived`);
+          setArchiveTarget(null);
+        },
+        onError: (err) => {
+          console.error('[ChannelTable] archive failed for channel:', id, err);
+          toast.error('Failed to archive channel — please try again.');
+        },
+      });
+    },
+    [archiveMutation, archiveTarget],
   );
 
   // Filtered + sorted channels

--- a/packages/web-next/components/system/QueuesTab.tsx
+++ b/packages/web-next/components/system/QueuesTab.tsx
@@ -16,11 +16,11 @@
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Trash2, AlertTriangle } from 'lucide-react';
 import { Button, StatusDot } from '@/components/design-system';
-import { adminQueuesApi, type QueueStats } from '@/lib/api-client';
+import { useClearQueue } from '@/lib/api/admin.hooks';
+import type { QueueStats } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -44,21 +44,7 @@ interface QueueRowProps {
 
 function QueueRow({ queue }: QueueRowProps) {
   const [confirming, setConfirming] = useState(false);
-
-  const clearMutation = useMutation({
-    mutationFn: () => adminQueuesApi.clear(queue.name, 'failed'),
-    onSuccess: (result) => {
-      toast.success(`Cleared ${result.cleared_count} failed job${result.cleared_count !== 1 ? 's' : ''} from ${queue.name}`);
-      setConfirming(false);
-      // Reload to refresh server-side counts
-      setTimeout(() => window.location.reload(), 800);
-    },
-    onError: (err: unknown) => {
-      const message = err instanceof Error ? err.message : 'Clear failed';
-      toast.error(`Failed to clear queue: ${message}`);
-      setConfirming(false);
-    },
-  });
+  const clearMutation = useClearQueue();
 
   return (
     <>
@@ -136,7 +122,25 @@ function QueueRow({ queue }: QueueRowProps) {
                 <Button
                   variant="primary"
                   size="sm"
-                  onClick={() => clearMutation.mutate()}
+                  onClick={() =>
+                    clearMutation.mutate(
+                      { name: queue.name, state: 'failed' },
+                      {
+                        onSuccess: (result) => {
+                          toast.success(
+                            `Cleared ${result.cleared_count} failed job${result.cleared_count !== 1 ? 's' : ''} from ${queue.name}`,
+                          );
+                          setConfirming(false);
+                          setTimeout(() => window.location.reload(), 800);
+                        },
+                        onError: (err: unknown) => {
+                          const message = err instanceof Error ? err.message : 'Clear failed';
+                          toast.error(`Failed to clear queue: ${message}`);
+                          setConfirming(false);
+                        },
+                      },
+                    )
+                  }
                   disabled={clearMutation.isPending}
                   className="bg-amber-600 border-amber-600 hover:bg-amber-700"
                 >

--- a/packages/web-next/lib/api/admin.hooks.ts
+++ b/packages/web-next/lib/api/admin.hooks.ts
@@ -1,0 +1,68 @@
+'use client';
+
+/**
+ * Admin domain hooks — TanStack Query mutations for admin operations.
+ *
+ * Covers:
+ *   - Slack channel archive (ChannelTable)
+ *   - BullMQ queue clear (QueuesTab)
+ *
+ * These are mutation-only hooks. No queries — admin list data is server-fetched
+ * (RSC prefetch) and managed with local state by the consumers.
+ *
+ * NOTE: These hooks are intentionally NOT exported from lib/api/index.ts —
+ * hooks must stay client-component-only; the barrel is imported in RSC contexts.
+ * Consumers import directly: import { useArchiveSlackChannel } from '@/lib/api/admin.hooks'
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { adminApi, adminQueuesApi } from '@/lib/api-client';
+import type { ClearableState } from '@/lib/api/admin';
+
+// ---------------------------------------------------------------------------
+// useArchiveSlackChannel — archive a Slack channel by ID
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutation to archive a Slack channel.
+ * POST /api/v1/admin/slack/channels/:id/archive → SlackArchiveResult
+ *
+ * On success: invalidates ['slack-channels'] so any queries or RSC revalidations
+ * pick up the archived state.
+ *
+ * Consumer (ChannelTable) does its own local-state optimistic update and toast
+ * in onSuccess/onError callbacks passed to mutate().
+ */
+export function useArchiveSlackChannel() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => adminApi.archiveSlackChannel(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['slack-channels'] });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useClearQueue — clear failed (or other) jobs from a BullMQ queue
+// ---------------------------------------------------------------------------
+
+interface ClearQueueVariables {
+  name: string;
+  state?: ClearableState;
+}
+
+/**
+ * Mutation to clear jobs in a given state from a BullMQ queue.
+ * POST /api/v1/admin/queues/:name/clear { state } → QueueClearResult
+ *
+ * Default state: 'failed' (matches adminQueuesApi.clear default).
+ * Consumer (QueuesTab) handles toast + page reload in mutation callbacks.
+ */
+export function useClearQueue() {
+  return useMutation({
+    mutationFn: ({ name, state = 'failed' }: ClearQueueVariables) =>
+      adminQueuesApi.clear(name, state),
+  });
+}

--- a/packages/web-next/lib/api/email.hooks.ts
+++ b/packages/web-next/lib/api/email.hooks.ts
@@ -1,0 +1,69 @@
+'use client';
+
+/**
+ * Email drafts domain hooks — TanStack Query mutations for email draft actions.
+ *
+ * Covers:
+ *   - Send an email draft (EmailTabs / DraftCard)
+ *   - Reject an email draft (EmailTabs / DraftCard)
+ *
+ * These are mutation-only hooks. No queries — the email drafts list is
+ * server-prefetched (RSC) and managed with local state by EmailTabs.
+ *
+ * NOTE: These hooks are intentionally NOT exported from lib/api/index.ts —
+ * hooks must stay client-component-only; the barrel is imported in RSC contexts.
+ * Consumers import directly: import { useSendEmailDraft } from '@/lib/api/email.hooks'
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { emailApi } from '@/lib/api-client';
+
+// ---------------------------------------------------------------------------
+// Query key constants (shared with any future useQuery for email drafts)
+// ---------------------------------------------------------------------------
+
+export const EMAIL_DRAFTS_QUERY_KEY = ['email-drafts'] as const;
+
+// ---------------------------------------------------------------------------
+// useSendEmailDraft — approve and send an email draft
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutation to approve and send an email draft.
+ * POST /api/v1/email/drafts/:id/send → { id, status, sent_at }
+ *
+ * On success: invalidates ['email-drafts'] so any query-based consumers refresh.
+ * EmailTabs also does local-state optimistic update in its onSuccess callback.
+ */
+export function useSendEmailDraft() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => emailApi.send(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: EMAIL_DRAFTS_QUERY_KEY });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useRejectEmailDraft — reject and discard an email draft
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutation to reject an email draft.
+ * DELETE /api/v1/email/drafts/:id → { id, status }
+ *
+ * On success: invalidates ['email-drafts'] so any query-based consumers refresh.
+ * EmailTabs also does local-state optimistic update in its onSuccess callback.
+ */
+export function useRejectEmailDraft() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => emailApi.reject(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: EMAIL_DRAFTS_QUERY_KEY });
+    },
+  });
+}


### PR DESCRIPTION
## Phase G.1 Batch 4 — TanStack Query hooks: admin, email domains

Final batch. Completes Phase G.1 (GitHub issue #177 / A128).

### New hook files

| File | Hooks |
|------|-------|
| `lib/api/admin.hooks.ts` | `useArchiveSlackChannel`, `useClearQueue` |
| `lib/api/email.hooks.ts` | `useSendEmailDraft`, `useRejectEmailDraft`, `EMAIL_DRAFTS_QUERY_KEY` |

### Consumers migrated (3)

| Component | Before | After |
|-----------|--------|-------|
| `components/slack/ChannelTable.tsx` | `useMutation` + `adminApi.archiveSlackChannel` | `useArchiveSlackChannel` |
| `components/system/QueuesTab.tsx` | `useMutation` + `adminQueuesApi.clear` | `useClearQueue` |
| `components/email/EmailTabs.tsx` | 2× `useMutation` + `emailApi.send/reject` | `useSendEmailDraft` + `useRejectEmailDraft` |

### VoiceSection fully migrated

During Batch 3 rebase (after Batch 2 merged), VoiceSection's merge conflict was resolved to use both `useIntegrations` (config.hooks) + `useVoiceSessions`/`useActiveVoiceSessions` (voice.hooks). No inline `useQuery` remains.

### Phase G.1 complete — all 4 batches

| Batch | PR | Domains | Hooks | Consumers |
|-------|----|---------|-------|-----------|
| 1 | #211 | captures, search, briefs, intelligence, settings, entities | 25 | 15 |
| 2 | #212 | system-health, mcp-activity, wiki, ingest, voice, skills | 14 | 8 |
| 3 | #213 | commitments, config, synthesize, service-health, email-settings | 13 | 12 |
| 4 | #214 | admin, email | 4 | 3 |

### Verification

- `tsc --noEmit`: clean
- `vitest run`: 118/118 pass
- Lab notebook: Entry 151

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)