### PR TITLE
chore(mobile): RTL migration for MPill/TabBar tests (Phase G.3, A120)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -11415,6 +11415,26 @@ After fixes, re-ran grep. Remaining class (b) hits in `components/` are all in h
 
 --- New session: 2026-05-09 — Phase G.2: ESLint 9 + flat-config migration ---
 
+## Entry 153 — Phase G.3: RTL migration for MPill/TabBar tests (2026-05-09)  [test] [mobile] [decision]
+
+**Date:** 2026-05-09
+**Environment:** laptop VM; affects packages/mobile only
+**Duration:** ~30 min
+
+**Objective:** Migrate `packages/mobile/__tests__/components/MPill.test.tsx` and `TabBar.test.tsx` from `react-test-renderer` to `@testing-library/react-native`. Closes #195 (A120).
+
+**Findings:**
+- Files live in `packages/mobile`, not `packages/web-next` as stated in issue #195 title — no TS2345 errors were active (current `@types/react-test-renderer@^19.1.0` matches React 19.1.0). The actual problem was noisy `act()` and deprecation warnings from `react-test-renderer`.
+- RNTL's `render()` uses `react-test-renderer` under the hood (peer dep). The deprecation warning (`react-test-renderer is deprecated`) still fires through RNTL — this is RNTL's own issue, not ours. The previous `act()` environment mismatch warning is eliminated.
+- RNTL's `detectHostComponentNames()` requires `TextInput`, `Image`, `Switch`, `ScrollView`, `Modal` from the react-native mock — the original minimal mock was missing these. Added them as string literals.
+- RNTL's `getByText` query calls `StyleSheet.flatten` internally — added it to the mock: `(style) => Array.isArray(style) ? Object.assign({}, ...style) : style ?? {}`.
+- For structural assertions (`findAllByType` by string type — 'View', 'Pressable', 'Mic', etc.), `UNSAFE_getAllByType` can't be used because it expects `React.ComponentType`, not strings. Kept `toJSON()` + custom walk helpers for these assertions.
+- `@types/react-test-renderer` removed from devDependencies (no longer imported directly). `react-test-renderer` kept as RNTL peer dep requirement.
+
+**Result:** 24 tests pass, tsc clean, `@types/react-test-renderer` dependency dropped.
+
+---
+
 ## Entry 152 — Phase G.2: ESLint 9 + flat-config migration (2026-05-09)  [web] [config] [decision]
 
 **Date:** 2026-05-09

--- a/OPEN_ITEMS.md
+++ b/OPEN_ITEMS.md
@@ -8,7 +8,7 @@ GitHub issues are the single source of truth for all pending work as of 2026-05-
 
 ## Active master plan
 
-**[IMPLEMENTATION_PLAN-2026-05-09-REMEDIATION.md](IMPLEMENTATION_PLAN-2026-05-09-REMEDIATION.md)** — 11-issue cohesive remediation, 7 phases (A–G), ~14–18 h effort, sequenced by interaction dependencies.
+**[IMPLEMENTATION_PLAN-2026-05-09-REMEDIATION.md](IMPLEMENTATION_PLAN-2026-05-09-REMEDIATION.md)** — 11-issue cohesive remediation, 7 phases (A–G). **Status: COMPLETE (2026-05-09)**
 
 | Phase | Closes | Brief |
 |---|---|---|
@@ -37,11 +37,28 @@ GitHub issues are the single source of truth for all pending work as of 2026-05-
 | [#192](https://github.com/davistroy/open-brain/issues/192) | A116: Vitest 2.x bump | Low priority baseline |
 | [#193](https://github.com/davistroy/open-brain/issues/193) | A117: SSE onAbort coverage | Low priority baseline |
 | ~~[#194](https://github.com/davistroy/open-brain/issues/194)~~ | ~~A106: TS2502 entity-resolution.test.ts~~ | **CLOSED (already resolved by commit 6948a12 — Phase E.2 audit 2026-05-09)** |
-| [#195](https://github.com/davistroy/open-brain/issues/195) | A120: TS2345 MPill/TabBar tests | Low priority baseline — after #190 |
+| ~~[#195](https://github.com/davistroy/open-brain/issues/195)~~ | ~~A120: RTL migration MPill/TabBar tests~~ | CLOSED — Phase G.3, PR #216 (2026-05-09) |
 | [#196](https://github.com/davistroy/open-brain/issues/196) | Mobile deferred scope | No gate — when mobile is a priority |
 | [#204](https://github.com/davistroy/open-brain/issues/204) | monthly-reflection: 6.5M-token context blowup | Bug — discovered during Phase A.5 |
 | [#205](https://github.com/davistroy/open-brain/issues/205) | Stale BullMQ repeat-job keys for removed skills | Bug — discovered during Phase A.5 |
 | [#207](https://github.com/davistroy/open-brain/issues/207) | A83: 17 cosmetic hydration risks (new Date/Date.now) | Tech debt — deferred, low priority |
+
+---
+
+## Recently closed (2026-05-09 remediation session)
+
+| # | Title | Closed by |
+|---|-------|-----------|
+| #191 | LLM model consolidation verification | Phase E.1 audit |
+| #194 | TS2502 entity-resolution (A106) | Phase E.2 audit (pre-existing fix confirmed) |
+| #197 | Greeting bug + hydration | PR #206 |
+| #198 | React #418 hydration (CORS) | PR #206 |
+| #199 | Slack DMs | Manual: Slack admin toggle |
+| #200 | 744 failed jobs | PRs #201, #202, #203 |
+| #192 | Vitest 2.x bump (A116) | PR #210 |
+| #177 | TanStack Query hooks (A128) | PRs #211–#214 |
+| #190 | ESLint 9 + flat-config (A130) | PR #215 |
+| #195 | RTL migration MPill/TabBar (A120) | PR #216 |
 
 ---
 

--- a/packages/mobile/__tests__/components/MPill.test.tsx
+++ b/packages/mobile/__tests__/components/MPill.test.tsx
@@ -1,16 +1,24 @@
 import React from 'react';
-import { create, act, ReactTestRenderer } from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 // Mock react-native with enough fidelity for component rendering.
+// Additional host components (TextInput, Image, Switch, ScrollView, Modal) are
+// required by @testing-library/react-native's host-component-name detection.
 jest.mock('react-native', () => {
   const R = require('react');
   return {
     View: 'View',
     Text: 'Text',
+    TextInput: 'TextInput',
+    Image: 'Image',
+    Switch: 'Switch',
+    ScrollView: 'ScrollView',
+    Modal: 'Modal',
     Pressable: ({ children, ...rest }: any) =>
       R.createElement('Pressable', rest, children),
     StyleSheet: {
       create: (styles: any) => styles,
+      flatten: (style: any) => (Array.isArray(style) ? Object.assign({}, ...style) : style ?? {}),
       hairlineWidth: 0.5,
     },
     Platform: { OS: 'ios', select: (obj: any) => obj.ios },
@@ -20,24 +28,6 @@ jest.mock('react-native', () => {
 
 // Must import after mocks are set up
 const { MPill } = require('../../src/components/primitives/MPill');
-
-function findAllText(tree: any): string[] {
-  const results: string[] = [];
-  function walk(node: any) {
-    if (!node) return;
-    if (typeof node === 'string') {
-      results.push(node);
-      return;
-    }
-    if (node.children) {
-      for (const child of node.children) {
-        walk(child);
-      }
-    }
-  }
-  walk(tree);
-  return results;
-}
 
 function findAllByType(tree: any, type: string): any[] {
   const results: any[] = [];
@@ -56,51 +46,28 @@ function findAllByType(tree: any, type: string): any[] {
 
 describe('MPill', () => {
   test('renders text content with default neutral tone', () => {
-    let renderer: ReactTestRenderer;
-    act(() => {
-      renderer = create(React.createElement(MPill, {}, 'Decision'));
-    });
-    const tree = renderer!.toJSON();
-    const texts = findAllText(tree);
-    expect(texts).toContain('Decision');
+    const { getByText } = render(React.createElement(MPill, {}, 'Decision'));
+    expect(getByText('Decision')).toBeTruthy();
   });
 
   test('renders with accent tone', () => {
-    let renderer: ReactTestRenderer;
-    act(() => {
-      renderer = create(React.createElement(MPill, { tone: 'accent' }, 'Important'));
-    });
-    const tree = renderer!.toJSON();
-    const texts = findAllText(tree);
-    expect(texts).toContain('Important');
+    const { getByText } = render(React.createElement(MPill, { tone: 'accent' }, 'Important'));
+    expect(getByText('Important')).toBeTruthy();
   });
 
   test('renders with success tone', () => {
-    let renderer: ReactTestRenderer;
-    act(() => {
-      renderer = create(React.createElement(MPill, { tone: 'success' }, 'Complete'));
-    });
-    const tree = renderer!.toJSON();
-    const texts = findAllText(tree);
-    expect(texts).toContain('Complete');
+    const { getByText } = render(React.createElement(MPill, { tone: 'success' }, 'Complete'));
+    expect(getByText('Complete')).toBeTruthy();
   });
 
   test('renders with warn tone', () => {
-    let renderer: ReactTestRenderer;
-    act(() => {
-      renderer = create(React.createElement(MPill, { tone: 'warn' }, 'Blocked'));
-    });
-    const tree = renderer!.toJSON();
-    const texts = findAllText(tree);
-    expect(texts).toContain('Blocked');
+    const { getByText } = render(React.createElement(MPill, { tone: 'warn' }, 'Blocked'));
+    expect(getByText('Blocked')).toBeTruthy();
   });
 
   test('pill has a View root with Text child', () => {
-    let renderer: ReactTestRenderer;
-    act(() => {
-      renderer = create(React.createElement(MPill, {}, 'Test'));
-    });
-    const tree = renderer!.toJSON() as any;
+    const { toJSON } = render(React.createElement(MPill, {}, 'Test'));
+    const tree = toJSON() as any;
     // Root should be a View (pill container)
     expect(tree.type).toBe('View');
     // Should contain a Text element

--- a/packages/mobile/__tests__/components/TabBar.test.tsx
+++ b/packages/mobile/__tests__/components/TabBar.test.tsx
@@ -1,18 +1,26 @@
 import React from 'react';
-import { create, act, ReactTestRenderer } from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 // Mock react-native with enough fidelity for component rendering.
 // jest.mock factories cannot reference outer-scope variables, so we use
 // require() inside each factory for React references.
+// Additional host components (TextInput, Image, Switch, ScrollView, Modal) are
+// required by @testing-library/react-native's host-component-name detection.
 jest.mock('react-native', () => {
   const R = require('react');
   return {
     View: 'View',
     Text: 'Text',
+    TextInput: 'TextInput',
+    Image: 'Image',
+    Switch: 'Switch',
+    ScrollView: 'ScrollView',
+    Modal: 'Modal',
     Pressable: ({ children, accessibilityRole, ...rest }: any) =>
       R.createElement('Pressable', { accessibilityRole, ...rest }, children),
     StyleSheet: {
       create: (styles: any) => styles,
+      flatten: (style: any) => (Array.isArray(style) ? Object.assign({}, ...style) : style ?? {}),
       hairlineWidth: 0.5,
     },
     Platform: { OS: 'ios', select: (obj: any) => obj.ios },
@@ -71,62 +79,40 @@ function findAllByType(tree: any, type: string): any[] {
   return results;
 }
 
-function findAllText(tree: any): string[] {
-  const results: string[] = [];
-  function walk(node: any) {
-    if (!node) return;
-    if (typeof node === 'string') {
-      results.push(node);
-      return;
-    }
-    if (node.children) {
-      for (const child of node.children) {
-        walk(child);
-      }
-    }
-  }
-  walk(tree);
-  return results;
-}
-
 describe('TabBar', () => {
-  let renderer: ReactTestRenderer;
-
-  beforeEach(() => {
-    act(() => {
-      renderer = create(
-        React.createElement(TabBar, {
-          state: mockState,
-          descriptors: mockDescriptors,
-          navigation: mockNavigation,
-        }),
-      );
-    });
-  });
+  function renderTabBar() {
+    return render(
+      React.createElement(TabBar, {
+        state: mockState,
+        descriptors: mockDescriptors,
+        navigation: mockNavigation,
+      }),
+    );
+  }
 
   test('renders 4 tab Pressable elements', () => {
-    const tree = renderer.toJSON();
+    const { toJSON } = renderTabBar();
+    const tree = toJSON();
     const pressables = findAllByType(tree, 'Pressable');
     expect(pressables.length).toBe(4);
   });
 
   test('renders HOME label', () => {
-    const tree = renderer.toJSON();
-    const texts = findAllText(tree);
-    expect(texts).toContain('HOME');
+    const { getByText } = renderTabBar();
+    expect(getByText('HOME')).toBeTruthy();
   });
 
   test('renders all tab labels', () => {
-    const tree = renderer.toJSON();
-    const texts = findAllText(tree);
-    expect(texts).toContain('HOME');
-    expect(texts).toContain('BRIEFS');
-    expect(texts).toContain('BOARD');
-    expect(texts).toContain('LIBRARY');
+    const { getByText } = renderTabBar();
+    expect(getByText('HOME')).toBeTruthy();
+    expect(getByText('BRIEFS')).toBeTruthy();
+    expect(getByText('BOARD')).toBeTruthy();
+    expect(getByText('LIBRARY')).toBeTruthy();
   });
 
   test('renders icon components for each tab', () => {
-    const tree = renderer.toJSON();
+    const { toJSON } = renderTabBar();
+    const tree = toJSON();
     const mics = findAllByType(tree, 'Mic');
     const newspapers = findAllByType(tree, 'Newspaper');
     const squarePens = findAllByType(tree, 'SquarePen');

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -37,7 +37,6 @@
     "@testing-library/react-native": "^12.9.0",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.1.17",
-    "@types/react-test-renderer": "^19.1.0",
     "jest": "^29.7.0",
     "jest-expo": "~54.0.17",
     "react-test-renderer": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,6 @@ importers:
       '@types/react':
         specifier: ~19.1.17
         version: 19.1.17
-      '@types/react-test-renderer':
-        specifier: ^19.1.0
-        version: 19.1.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.19.17)
@@ -3179,9 +3176,6 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
-
-  '@types/react-test-renderer@19.1.0':
-    resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
   '@types/react@19.1.17':
     resolution: {integrity: sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==}
@@ -11479,10 +11473,6 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
-  '@types/react-test-renderer@19.1.0':
-    dependencies:
-      '@types/react': 19.1.17
-
   '@types/react@19.1.17':
     dependencies:
       csstype: 3.2.3
@@ -11749,14 +11739,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.31.1)(terser@5.46.0))':
+  '@vitest/mocker@2.1.9(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@25.3.5)(lightningcss@1.31.1)(terser@5.46.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.4(@types/node@22.19.17)(typescript@5.9.3)
-      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.31.1)(terser@5.46.0)
+      vite: 5.4.21(@types/node@25.3.5)(lightningcss@1.31.1)(terser@5.46.0)
 
   '@vitest/mocker@2.1.9(msw@2.13.4(@types/node@25.3.5)(typescript@5.9.3))(vite@5.4.21(@types/node@25.3.5)(lightningcss@1.31.1)(terser@5.46.0))':
     dependencies:
@@ -17672,7 +17662,7 @@ snapshots:
   vitest@2.1.9(@types/node@22.19.17)(jsdom@24.1.3)(lightningcss@1.31.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.31.1)(terser@5.46.0))
+      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@25.3.5)(lightningcss@1.31.1)(terser@5.46.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -17708,7 +17698,7 @@ snapshots:
   vitest@2.1.9(@types/node@22.19.17)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.31.1)(terser@5.46.0))
+      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@25.3.5)(lightningcss@1.31.1)(terser@5.46.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9


### PR DESCRIPTION
## Summary

- Migrate `packages/mobile/__tests__/components/MPill.test.tsx` and `TabBar.test.tsx` from `react-test-renderer` (direct API) to `@testing-library/react-native`
- Augment the react-native jest mock with host components required by RNTL's `detectHostComponentNames` (`TextInput`, `Image`, `Switch`, `ScrollView`, `Modal`) and `StyleSheet.flatten`
- Drop `@types/react-test-renderer` devDependency — no longer imported directly; `react-test-renderer` itself stays as RNTL peer dep
- Text assertions migrated to `getByText()`; structural assertions (`View` root type, `Pressable` count, icon type counts) keep `toJSON()` + walk helpers since mocked elements are string literals (not `React.ComponentType`)
- 24 tests pass, `tsc --noEmit` clean, `@types/react-test-renderer` dependency removed

Note: The `react-test-renderer is deprecated` console warning still fires through RNTL's own internals — this is RNTL's issue with React 19, not ours. The previous `act()` environment mismatch warning is eliminated.

## Test plan

- [x] `pnpm --filter @open-brain/mobile test` — 24 pass
- [x] `pnpm --filter @open-brain/mobile lint` (tsc --noEmit) — clean
- [x] `@types/react-test-renderer` no longer in `packages/mobile/package.json`

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)