### PR TITLE
Phase 4: Observability & deploy-pipeline hardening (arch-review CS-4)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -122,3 +122,20 @@ jobs:
             ghcr.io/davistroy/open-brain/ingest-sidecar:latest
           cache-from: type=gha,scope=ingest-sidecar
           cache-to: type=gha,mode=max,scope=ingest-sidecar
+
+      # ── web-next ────────────────────────────────────────────────────────────
+      # Build context is repo root — Next.js monorepo build requires pnpm workspace
+      # root. API_URL is baked at build time for server-side next.config.ts rewrites.
+      - name: Build and push web-next
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/web-next/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/davistroy/open-brain/web-next:sha-${{ steps.meta.outputs.sha }}
+            ghcr.io/davistroy/open-brain/web-next:latest
+          build-args: |
+            API_URL=http://core-api:3000
+          cache-from: type=gha,scope=web-next
+          cache-to: type=gha,mode=max,scope=web-next

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -107,10 +107,10 @@ Every work item below complies with these. Three are **flagged decisions** the o
 
 | # | Work item | Files | Acceptance criteria | Status |
 |---|-----------|-------|---------------------|--------|
-| 4.1 | **PLT-H2**: workers-staleness alerting | `config/prometheus/alerts/pipeline.yml`, `docker-compose.yml` | Prometheus rule fires when `time() - push_time_seconds{instance="workers"} > 1500` (25 min vs 15-min cadence) + an `absent()` rule on a keystone gauge; workers + slack-bot get `node -e 0`-class healthchecks, cloudflared a `/ready` probe. | PENDING |
-| 4.2 | **PLT-H1 (+PLT-RI-2)**: web-next CI image | `.github/workflows/build-images.yml` | build-images builds + pushes `ghcr.io/davistroy/open-brain/web-next` with `API_URL` build-arg; post-merge the GHCR tag exists and is current. | PENDING |
-| 4.3 | **PLT-H3 / SA-3**: Loki driver URL + runbook | `docker-compose.yml`, `docs/runbooks/observability.md` | compose Loki default points to a host-reachable URL (not daemon-unresolvable `loki:3100`); observability.md Step 6 no longer instructs the broken value; logs appear in Loki after `--force-recreate`. | PENDING |
-| 4.4 | **PE-L5**: non-blocking log driver | `docker-compose.yml` | shared `x-logging` anchor adds `mode: non-blocking` + `max-buffer-size`; a slow Loki no longer back-pressures container stdout. | PENDING |
+| 4.1 | **PLT-H2**: workers-staleness alerting | `config/prometheus/alerts/pipeline.yml`, `docker-compose.yml` | Prometheus rule fires when `time() - push_time_seconds{instance="workers"} > 1500` (25 min vs 15-min cadence) + an `absent()` rule on a keystone gauge; workers + slack-bot get `node -e 0`-class healthchecks, cloudflared a `/ready` probe. | COMPLETE 2026-06-15 (deploy pending) |
+| 4.2 | **PLT-H1 (+PLT-RI-2)**: web-next CI image | `.github/workflows/build-images.yml` | build-images builds + pushes `ghcr.io/davistroy/open-brain/web-next` with `API_URL` build-arg; post-merge the GHCR tag exists and is current. | COMPLETE 2026-06-15 (deploy pending) |
+| 4.3 | **PLT-H3 / SA-3**: Loki driver URL + runbook | `docker-compose.yml`, `docs/runbooks/observability.md` | compose Loki default points to a host-reachable URL (not daemon-unresolvable `loki:3100`); observability.md Step 6 no longer instructs the broken value; logs appear in Loki after `--force-recreate`. | COMPLETE 2026-06-15 (deploy pending) |
+| 4.4 | **PE-L5**: non-blocking log driver | `docker-compose.yml` | shared `x-logging` anchor adds `mode: non-blocking` + `max-buffer-size`; a slow Loki no longer back-pressures container stdout. | COMPLETE 2026-06-15 (deploy pending) |
 
 **DoD (runnable):** stop workers on a test basis → Pushover staleness alert fires within the window · `docker compose pull` retrieves a fresh web-next image · `{container_name="open-brain-core-api"}` shows recent lines in Grafana Loki explorer.
 

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -12217,3 +12217,27 @@ No need to duplicate; this entry just establishes the meta-state pointer.
 **Tags:** [pipeline] [api] [database] [test] [decision]
 **Environment:** ubuntu-vm (dev/test; migration 0032 + worker/core-api redeploy pending the batched homeserver deploy)
 **Duration:** ~30 min (4 parallel implementers + verification)
+
+--- New session: 2026-06-15 — Arch-review v3 Phase 4 (Alerting SPOF & deploy pipeline, CS-4) ---
+
+## Entry 169 — Phase 4: observability/deploy hardening — workers SPOF alerts, web-next CI image, Loki driver fix (2026-06-15)  [observability] [ci] [deploy] [config] [decision]
+
+**Objective:** IMPLEMENTATION_PLAN Phase 4 (CS-4): close the workers alerting SPOF (PLT-H2), build the production UI image in CI (PLT-H1), fix the silent-log-drop Loki driver URL (PLT-H3/SA-3), and stop log back-pressure (PE-L5). Finishes Wave 1.
+
+**Hypothesis:** config-only (no TS) → required CI checks pass trivially; `docker compose config` + prometheus/CI YAML validate. **Rollback:** revert PR. Pre-change SHA 44c9a7b.
+
+**Method:** 3 parallel sub-agents on disjoint files (prometheus rules / build-images.yml / observability.md) + orchestrator did the docker-compose coordination (one file).
+
+**Implemented:**
+- **PLT-H2** (High): new `config/prometheus/alerts/workers-staleness.yml` (auto-included via `alerts/*.yml` glob) — `PushgatewayStale` (`time() - push_time_seconds{job=open-brain,instance=workers} > 1500`, 5m) + `WorkersMetricsAbsent` (`absent(openbrain_container_healthy{job=open-brain})`, 10m), both critical. These detect the case where workers dies and every pushed gauge freezes at "healthy". Plus liveness healthchecks on **workers** + **slack-bot** (`node -e 'process.exit(0)'` — node images; real detection is the staleness rules since a wedged event loop still passes).
+- **PLT-H1** (High): `web-next` added to `.github/workflows/build-images.yml` (build-arg `API_URL=http://core-api:3000`) — was 7/8 images; GHCR `web-next:latest` will exist after the next main build (closes PLT-RI-2).
+- **PLT-H3/SA-3** (High) + **PE-L5** (Low): refactored all **13 identical** inline `logging:` blocks to a shared `x-logging: &default_logging` anchor with `loki-url` default → `http://localhost:3100/...` (daemon-reachable; `loki:3100` is NOT resolvable from the daemon-level driver — silent log drop) and `mode: non-blocking` + `max-buffer-size: 4m`. observability.md Step 6 rewritten to stop instructing the broken `loki:3100`.
+- **PLT-M6** (partial): cloudflared `command` += `--metrics 127.0.0.1:2000` (enables /ready + scrape); CMD healthcheck deferred (distroless image, no shell — external synthetic monitor covers tunnel liveness).
+
+**Verification:** `docker compose config` exit 0 (13 healthchecks, all logging localhost+non-blocking); prometheus + build-images YAML valid. No TS touched.
+
+**DEPLOY interaction (CRITICAL for the batched deploy):** Phase 2 binds Loki to 127.0.0.1:3100; Phase 4 sets the driver URL to localhost. So at deploy the homeserver `.env` `LOKI_URL` MUST become `http://localhost:3100/loki/api/v1/push` (the old external hostname stops working once Loki is loopback-only). `logging:` changes need `--force-recreate`. web-next image builds post-merge on main.
+
+**Tags:** [observability] [ci] [deploy] [config] [decision]
+**Environment:** ubuntu-vm (dev; homeserver deploy batched with Phases 2+3)
+**Duration:** ~30 min

--- a/config/prometheus/alerts/workers-staleness.yml
+++ b/config/prometheus/alerts/workers-staleness.yml
@@ -1,0 +1,81 @@
+# Prometheus alert rules — workers Pushgateway staleness
+# Metric source: Pushgateway auto-metric (job=open-brain, instance=workers)
+# Pushgateway retains the last pushed value forever — if workers dies, every
+# metric it pushed (container health, queue depth, etc.) stays frozen at its
+# last good value, causing all downstream alerts to appear healthy even though
+# the system is dark.
+#
+# Detection strategy:
+#   push_time_seconds{job="open-brain", instance="workers"} — Pushgateway
+#   automatically records the Unix timestamp of the most recent push for each
+#   job/instance pair. Workers pushes container-health every 15 minutes;
+#   25 minutes (1.6× interval) is the staleness threshold.
+#
+# Two distinct failure modes are covered:
+#   PushgatewayStale     — workers pushed recently but now has gone quiet
+#                          (workers process dead, crashed, or network split)
+#   WorkersMetricsAbsent — the Pushgateway series itself is missing
+#                          (Pushgateway restarted and lost state, or workers
+#                          never successfully pushed even once)
+#
+# Related code: packages/workers/src/skills/container-health.ts
+#               packages/workers/src/lib/push-metrics.ts (push path)
+
+groups:
+  - name: open-brain-workers-staleness
+    interval: 1m
+    rules:
+      - alert: PushgatewayStale
+        # Fires when workers has not pushed to Pushgateway for >25 minutes.
+        # The container-health skill pushes every 15 minutes; 25 minutes = ~1.6×
+        # the push interval, giving one full missed cycle plus a margin before
+        # paging. All Pushover-capable skills live in the workers container, so
+        # a dead workers process silences ALL downstream alerting.
+        expr: time() - push_time_seconds{job="open-brain", instance="workers"} > 1500
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Workers container has not pushed metrics for 25+ minutes — all alerting may be frozen"
+          description: >
+            The workers container last pushed to Pushgateway more than 25 minutes ago.
+            Because Pushgateway retains stale values forever, all container-health and
+            queue-depth metrics are frozen at their last known good state.
+            This means ContainerDown and queue-saturation alerts will NOT fire even if
+            containers are unhealthy or queues are backing up.
+            Immediate checks:
+              docker ps --filter name=open-brain-workers (on homeserver)
+              docker logs open-brain-workers-1 --tail 50
+              docker compose restart workers
+            If workers is running but not pushing, check PUSHGATEWAY_URL in .env.secrets
+            and verify pushgateway container is healthy.
+          runbook: "docs/runbooks/container-health-alert.md"
+
+      - alert: WorkersMetricsAbsent
+        # Fires when the openbrain_container_healthy series is entirely absent.
+        # This is distinct from PushgatewayStale: absent() triggers when
+        # Pushgateway has no record of the metric at all — either workers never
+        # successfully pushed (first-boot failure, misconfigured job label) or
+        # Pushgateway was restarted and lost its in-memory state.
+        # 10-minute for: window absorbs a single Pushgateway restart + workers
+        # re-push cycle (15 min push interval) without false-paging.
+        expr: absent(openbrain_container_healthy{job="open-brain"})
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No container-health metrics received from workers — push pipeline may be down"
+          description: >
+            The openbrain_container_healthy metric is completely absent from Prometheus.
+            This is different from PushgatewayStale (which fires when push_time_seconds
+            exists but is old). WorkersMetricsAbsent fires when Pushgateway has no record
+            of the metric at all, indicating one of:
+              1. Pushgateway restarted and lost all pushed state (most common)
+              2. Workers container has never successfully pushed (boot failure, bad PUSHGATEWAY_URL)
+              3. The job or instance label in push-metrics.ts was changed and no longer
+                 matches job="open-brain"
+            Immediate checks:
+              curl http://pushgateway:9091/metrics | grep openbrain_container_healthy
+              docker logs open-brain-workers-1 --tail 50 | grep -i push
+              docker logs open-brain-pushgateway-1 --tail 20
+          runbook: "docs/runbooks/container-health-alert.md"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,32 @@ volumes:
   grafana_data:
   loki_data:
 
+# Shared Loki logging (PLT-H3 + PE-L5):
+#  - loki-url default = localhost (the Docker log driver runs in the DAEMON, which
+#    can't resolve compose DNS like `loki:3100`; Loki binds 127.0.0.1:3100 per
+#    ADR-0002, so localhost IS daemon-reachable). Homeserver .env LOKI_URL must
+#    also be localhost (not the old external hostname — Loki is loopback-only now).
+#  - mode: non-blocking so a slow/down Loki never back-pressures container stdout.
+x-logging: &default_logging
+  driver: loki
+  options:
+    loki-url: "${LOKI_URL:-http://localhost:3100/loki/api/v1/push}"
+    loki-batch-size: "400"
+    loki-retries: "3"
+    loki-max-backoff: "800ms"
+    loki-timeout: "2s"
+    mode: "non-blocking"
+    max-buffer-size: "4m"
+    loki-pipeline-stages: |
+      - json:
+          expressions:
+            level: level
+            name: name
+            msg: msg
+      - labels:
+          level:
+          name:
+
 services:
   postgres:
     image: pgvector/pgvector:pg16
@@ -36,23 +62,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   redis:
     image: redis:7-alpine
@@ -73,23 +83,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   core-api:
     image: ghcr.io/davistroy/open-brain/core-api:latest
@@ -140,23 +134,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   workers:
     image: ghcr.io/davistroy/open-brain/workers:latest
@@ -204,27 +182,20 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      # Liveness (PLT-H2/M6): confirms the container's node runtime responds — a
+      # dead/hung container fails the exec. The real "workers stopped pushing
+      # metrics" detector is the Prometheus PushgatewayStale / WorkersMetricsAbsent
+      # rules (a wedged event loop can still pass this probe).
+      test: ["CMD-SHELL", "node -e 'process.exit(0)'"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     mem_limit: 1500m
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   slack-bot:
     image: ghcr.io/davistroy/open-brain/slack-bot:latest
@@ -248,27 +219,18 @@ services:
     depends_on:
       core-api:
         condition: service_healthy
+    healthcheck:
+      # Liveness (PLT-M6): node runtime responds. slack-bot is Socket Mode (no HTTP
+      # endpoint to probe); a dead/hung container fails the exec.
+      test: ["CMD-SHELL", "node -e 'process.exit(0)'"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     mem_limit: 1500m
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   voice-pipecat:
     image: ghcr.io/davistroy/open-brain/voice-pipecat:latest
@@ -301,23 +263,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   # Ollama runs as standalone container — connected via scripts/post-compose-up.sh
   # ollama:
@@ -364,23 +310,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   # --- Legacy voice services (kept for fallback until voice-pipecat is validated) ---
 
@@ -405,23 +335,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   voice-capture:
     image: ghcr.io/davistroy/open-brain/voice-capture:latest
@@ -458,23 +372,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   web-next:
     image: ghcr.io/davistroy/open-brain/web-next:latest
@@ -511,28 +409,15 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   cloudflared:
     image: cloudflare/cloudflared:latest
     container_name: open-brain-cloudflared
-    command: tunnel --no-autoupdate --config /etc/cloudflared/tunnel.yaml run
+    # --metrics exposes /ready + /metrics (PLT-H2/M6). No CMD healthcheck: the
+    # cloudflared image is distroless (no shell for CMD-SHELL); tunnel liveness is
+    # covered by the external synthetic monitor (health.troy-davis.com).
+    command: tunnel --no-autoupdate --metrics 127.0.0.1:2000 --config /etc/cloudflared/tunnel.yaml run
     environment:
       # CLOUDFLARE_TUNNEL_TOKEN: set in .env.secrets
       # Retrieve from Bitwarden before starting: bws secret get <open-brain-cloudflare-tunnel-token>
@@ -546,23 +431,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   # Python batch-ingest sidecar — hosts financial-pipeline.py + utility-pipeline.py.
   # Long-lived container; host cron shells in with `docker exec` to run tasks.
@@ -604,23 +473,7 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging
 
   # Utility batch-ingest sidecar — same image as financial-ingest, different
   # config + inbox. Handles utility-pipeline.py (gas, power, water summaries).
@@ -762,20 +615,4 @@ services:
     networks:
       - open-brain
     restart: unless-stopped
-    logging:
-      driver: loki
-      options:
-        loki-url: "${LOKI_URL:-http://loki:3100/loki/api/v1/push}"
-        loki-batch-size: "400"
-        loki-retries: "3"
-        loki-max-backoff: "800ms"
-        loki-timeout: "2s"
-        loki-pipeline-stages: |
-          - json:
-              expressions:
-                level: level
-                name: name
-                msg: msg
-          - labels:
-              level:
-              name:
+    logging: *default_logging

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -124,9 +124,19 @@ curl -s http://localhost:3050/api/health
 
 ### Step 6: Update LOKI_URL in .env.secrets
 
-The 13 application services use `${LOKI_URL:-http://loki:3100/loki/api/v1/push}` as the log driver URL. Once Loki is in compose on the same Docker network, the default `loki:3100` is correct. If `LOKI_URL` was previously set in `.env.secrets` to `http://homeserver.k4jda.net:3100/...`, either remove it (to use the new default) or update it to `http://loki:3100/loki/api/v1/push`.
+**Why `loki:3100` is wrong here.** The Loki Docker log driver runs in the Docker *daemon* context — on the host, not inside any container. The daemon cannot resolve compose-network service DNS names like `loki`. If `LOKI_URL` is set to `http://loki:3100/...`, the driver silently drops every log line (it discards, it does not buffer). Logs appear to be collected but are gone permanently. This failure mode is invisible until you look at Loki and find nothing.
 
-After changing `LOKI_URL`, application containers must be recreated (not just restarted) for the new log driver URL to take effect:
+**The correct value is `http://localhost:3100/loki/api/v1/push`** (equivalently `http://127.0.0.1:3100/...`). Per ADR-0002, Loki binds its published port to `127.0.0.1:3100` on the host. The Docker daemon runs on the same host, so `localhost:3100` is reachable from the daemon-level log driver. The compose default has been updated to reflect this.
+
+Set the following in `.env.secrets` on the homeserver:
+
+```
+LOKI_URL=http://localhost:3100/loki/api/v1/push
+```
+
+If `LOKI_URL` was previously set to the old external hostname (`http://homeserver.k4jda.net:3100/...`), replace it with the value above — the external hostname stops working once Loki is bound loopback-only per ADR-0002.
+
+After changing `LOKI_URL`, application containers must be recreated (not just restarted) for the new log driver URL to take effect — `docker compose restart` does not re-evaluate the `logging:` block:
 
 ```bash
 docker compose up -d --force-recreate


### PR DESCRIPTION
Fourth phase of arch-review v3 remediation (Phase 4 / change set CS-4) — **finishes Wave 1**. Config-only (no app code); takes effect at CI (web-next image) and the batched homeserver deploy (compose healthchecks/logging).

- **PLT-H2** (High) — the workers container is a single point of *alerting* failure: every container-health/queue gauge is pushed from workers to Pushgateway, which retains stale values, so if workers dies all alerts freeze at "healthy". New `config/prometheus/alerts/workers-staleness.yml`: `PushgatewayStale` (no push in 25 min) + `WorkersMetricsAbsent` (`absent()`), both critical. Plus node liveness healthchecks on workers + slack-bot.
- **PLT-H1** (High) — `web-next` (the production UI) was missing from `build-images.yml` (7/8 images), so `docker compose pull` shipped a stale UI or failed. Added with `API_URL` build-arg.
- **PLT-H3/SA-3** (High) + **PE-L5** (Low) — the Loki log driver runs in the Docker daemon, which can't resolve `loki:3100`, so it silently *drops* all logs; observability.md even instructed that broken value. Refactored 13 identical logging blocks → a shared `x-logging` anchor with `loki-url` default = `localhost` (daemon-reachable; Loki binds 127.0.0.1 per ADR-0002) + `mode: non-blocking`; rewrote observability.md Step 6.
- **PLT-M6** (partial) — cloudflared `--metrics 127.0.0.1:2000` (enables /ready); CMD healthcheck deferred (distroless image, no shell — external synthetic monitor covers tunnel liveness).

## Verification
`docker compose config` exit 0 (13 healthchecks; all logging localhost + non-blocking) · prometheus + build-images YAML valid · no TS changed (required checks pass trivially).

## Deploy note (batched with Phases 2+3)
Homeserver `.env` `LOKI_URL` must become `http://localhost:3100/loki/api/v1/push` (the old external hostname stops resolving once Loki binds loopback per Phase 2). `logging:` changes need `--force-recreate`. web-next image builds post-merge on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)