### PR TITLE
fix(deps): bump nodemailer 8→9 in workers (Wave 2 major)

### DIFF
--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -26,7 +26,7 @@
     "drizzle-orm": "^0.45.2",
     "ioredis": "^5.10.0",
     "mammoth": "^1.11.0",
-    "nodemailer": "^8.0.1",
+    "nodemailer": "^9.0.1",
     "openai": "^4.98.0",
     "pdf-parse": "^2.4.5",
     "pino": "^10.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,8 +459,8 @@ importers:
         specifier: ^1.11.0
         version: 1.11.0
       nodemailer:
-        specifier: ^8.0.1
-        version: 8.0.1
+        specifier: ^9.0.1
+        version: 9.0.3
       openai:
         specifier: ^4.98.0
         version: 4.104.0(ws@8.21.0)(zod@3.25.76)
@@ -6778,8 +6778,8 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
-  nodemailer@8.0.1:
-    resolution: {integrity: sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==}
+  nodemailer@9.0.3:
+    resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -16463,7 +16463,7 @@ snapshots:
 
   node-releases@2.0.36: {}
 
-  nodemailer@8.0.1: {}
+  nodemailer@9.0.3: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- Bumps `nodemailer` `^8.0.1` → `^9.0.1` (resolves to `9.0.3`) in `packages/workers/package.json` — the sole runtime-container major in Phase 6 Wave 2 (open-brain security debt remediation, work item 6.3).
- Reviewed the nodemailer 8→9 changelog: the only breaking change is default TLS certificate validation on remote-content fetches (attachment href/path URLs, OAuth2 token endpoints, HTTP/HTTPS proxy CONNECT). `packages/workers/src/services/email.ts` uses plain SMTP with basic auth (`createTransport({host, port, secure, auth})` / `sendMail({from, to, subject, html, text})`) — no attachments, no OAuth2, no proxy — so this does not affect the workers email-send path. No call-site changes required.
- Only `packages/workers/package.json` + `pnpm-lock.yaml` are touched, per the wave's commit-scope constraint.

## Test plan
- [x] `pnpm --filter @open-brain/shared build && pnpm --filter '!@open-brain/shared' -r build` — exit 0
- [x] `pnpm -r lint` (incl. workers `tsc --noEmit` on src + test files) — exit 0
- [x] `pnpm -r test` — all packages pass; workers 57/57 files, 1091/1091 tests; core-api coverage gate intact (workers' dormant coverage floor untouched, no `--coverage` flag in its test script)
- [x] `email.test.ts` + `weekly-brief.test.ts` run in isolation — 2/2 files, 51/51 tests, nodemailer delivery path exercised via mocks
- [x] `bash scripts/test-backup-secrets-redaction.sh` — PASSED
- [x] `bash scripts/test-secrets-roundtrip.sh` — PASSED (6/6)
- [x] Docker integration suite: `docker-compose.test.yml up --wait --build` → core-api integration (8 files/134 tests) + workers integration (`vitest.config.integration.ts`, 2 files passed/1 skipped, 14/16 tests, 2 intentionally skipped per QA-M3) → `down -v` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)