### PR TITLE
fix(web-next): eliminate render-scope new Date()/Date.now() hydration risks (#207)

### DIFF
--- a/packages/web-next/components/board/BoardCard.tsx
+++ b/packages/web-next/components/board/BoardCard.tsx
@@ -20,6 +20,7 @@
  */
 
 import { Check, Clock } from 'lucide-react';
+import { useClientNow } from '@/hooks/useClientNow';
 import type { BoardCommitment } from '@/lib/types';
 
 /** ISO date string "YYYY-MM-DD" → display like "Apr 30" */
@@ -29,9 +30,12 @@ function formatDueDate(isoDate: string): string {
 }
 
 /** True if isoDate is strictly before today (date-only comparison). */
-function isOverdue(isoDate: string | null): boolean {
+function isOverdue(isoDate: string | null, now: number | null): boolean {
   if (!isoDate) return false;
-  const today = new Date();
+  // Pre-mount (SSR + first client render): treat as not-overdue so the stripe/badge
+  // is stable across hydration; recomputes once the client clock is available.
+  if (now === null) return false;
+  const today = new Date(now);
   today.setHours(0, 0, 0, 0);
   const due = new Date(`${isoDate}T00:00:00`);
   return due < today;
@@ -45,9 +49,10 @@ interface BoardCardProps {
 
 export function BoardCard({ commitment, onResolve, resolving = false }: BoardCardProps) {
   const { id, text, due_date, status, entity_name } = commitment;
+  const now = useClientNow();
 
   const resolved = status === 'resolved';
-  const overdue = !resolved && isOverdue(due_date);
+  const overdue = !resolved && isOverdue(due_date, now);
 
   // Left stripe color
   const stripeClass = resolved

--- a/packages/web-next/components/email/DraftCard.tsx
+++ b/packages/web-next/components/email/DraftCard.tsx
@@ -22,15 +22,17 @@
 
 import { useState } from 'react';
 import { Send, Trash2, Clock, Mail } from 'lucide-react';
+import { useClientNow } from '@/hooks/useClientNow';
 import type { EmailDraft, EmailDraftStatus } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatRelative(iso: string): string {
+function formatRelative(iso: string, now: number | null): string {
   const date = new Date(iso);
-  const now = Date.now();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const diffMs = now - date.getTime();
   const diffDays = Math.floor(diffMs / 86_400_000);
 
@@ -91,6 +93,7 @@ export function DraftCard({
   isRejecting = false,
 }: DraftCardProps) {
   const { id, to_address, cc_address, subject, body, status, send_mode, created_at } = draft;
+  const now = useClientNow();
 
   // Two-tap inline confirmation state
   const [sendArmed, setSendArmed] = useState(false);
@@ -172,7 +175,7 @@ export function DraftCard({
           {/* Relative date */}
           <span className="inline-flex items-center gap-[3px] font-mono text-[10px] tracking-[0.04em] text-text-small">
             <Clock size={9} strokeWidth={1.5} />
-            {formatRelative(created_at)}
+            {formatRelative(created_at, now)}
           </span>
         </div>
       </div>

--- a/packages/web-next/components/email/EmailTabs.tsx
+++ b/packages/web-next/components/email/EmailTabs.tsx
@@ -32,6 +32,7 @@ import {
   Mail,
 } from 'lucide-react';
 import { EmptyState, Input } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import { DraftCard } from './DraftCard';
 import { ThreadView } from './ThreadView';
 import { useSendEmailDraft, useRejectEmailDraft } from '@/lib/api/email.hooks';
@@ -59,9 +60,10 @@ interface EmailTabsProps {
 // Date formatters + helpers
 // ---------------------------------------------------------------------------
 
-function formatRelative(iso: string): string {
+function formatRelative(iso: string, now: number | null): string {
   const date = new Date(iso);
-  const now = Date.now();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const diffMs = now - date.getTime();
   const diffDays = Math.floor(diffMs / 86_400_000);
 
@@ -97,6 +99,7 @@ function extractFrom(capture: Capture): string {
 // ---------------------------------------------------------------------------
 
 function InboundCapture({ capture }: { capture: Capture }) {
+  const now = useClientNow();
   const preview = capture.content.length > 200
     ? `${capture.content.slice(0, 200).trimEnd()}…`
     : capture.content;
@@ -125,7 +128,7 @@ function InboundCapture({ capture }: { capture: Capture }) {
           </span>
           <span className="text-cloud-dark opacity-40 text-[10px]">·</span>
           <span className="font-mono text-[10px] tracking-[0.05em] text-text-body-secondary">
-            {formatRelative(capture.created_at)}
+            {formatRelative(capture.created_at, now)}
           </span>
           {capture.brain_view && (
             <>

--- a/packages/web-next/components/email/ThreadView.tsx
+++ b/packages/web-next/components/email/ThreadView.tsx
@@ -21,6 +21,7 @@
 import { useState, useMemo } from 'react';
 import { ChevronDown, ChevronRight, Mail, Inbox } from 'lucide-react';
 import { EmptyState } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import type { Capture } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
@@ -126,9 +127,10 @@ function buildThreads(captures: Capture[]): EmailThread[] {
 // Date formatters
 // ---------------------------------------------------------------------------
 
-function formatRelative(iso: string): string {
+function formatRelative(iso: string, now: number | null): string {
   const date = new Date(iso);
-  const now = Date.now();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const diffMs = now - date.getTime();
   const diffDays = Math.floor(diffMs / 86_400_000);
 
@@ -165,6 +167,7 @@ interface ThreadAccordionProps {
 
 function ThreadAccordion({ thread }: ThreadAccordionProps) {
   const [expanded, setExpanded] = useState(false);
+  const now = useClientNow();
   const { displaySubject, captures, latestAt } = thread;
 
   return (
@@ -198,7 +201,7 @@ function ThreadAccordion({ thread }: ThreadAccordionProps) {
 
         {/* Latest date */}
         <span className="font-mono text-[10px] text-text-small tracking-[0.04em] shrink-0 ml-2">
-          {formatRelative(latestAt)}
+          {formatRelative(latestAt, now)}
         </span>
       </button>
 

--- a/packages/web-next/components/entity/commitments-card.tsx
+++ b/packages/web-next/components/entity/commitments-card.tsx
@@ -3,6 +3,7 @@
 import { toast } from 'sonner';
 import { CheckSquare, Square, ClipboardList } from 'lucide-react';
 import { Card, EmptyState } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import { useCommitmentsForEntity, useResolveCommitment } from '@/lib/api/commitments.hooks';
 import type { BoardCommitment } from '@/lib/types';
 
@@ -18,8 +19,11 @@ function formatDueDate(isoDate: string): string {
 }
 
 /** Returns true if due_date is in the past (overdue). Compares date-only, not time. */
-function isOverdue(isoDate: string): boolean {
-  const today = new Date();
+function isOverdue(isoDate: string, now: number | null): boolean {
+  // Pre-mount (SSR + first client render): treat as not-overdue so the badge is
+  // stable across hydration; recomputes once the client clock is available.
+  if (now === null) return false;
+  const today = new Date(now);
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
   return isoDate < todayStr;
 }
@@ -32,7 +36,8 @@ interface CommitmentRowProps {
 }
 
 function CommitmentRow({ commitment, resolvingId, onResolve }: CommitmentRowProps) {
-  const overdue = commitment.due_date ? isOverdue(commitment.due_date) : false;
+  const now = useClientNow();
+  const overdue = commitment.due_date ? isOverdue(commitment.due_date, now) : false;
   const isResolving = resolvingId === commitment.id;
 
   return (

--- a/packages/web-next/components/financial/ProviderTabs.tsx
+++ b/packages/web-next/components/financial/ProviderTabs.tsx
@@ -21,6 +21,7 @@
 import { useState } from 'react';
 import { DollarSign, Inbox } from 'lucide-react';
 import { EmptyState } from '@/components/design-system/EmptyState';
+import { useClientNow } from '@/hooks/useClientNow';
 import type { Capture } from '@/lib/types';
 import type { ProviderId } from '@/app/(shell)/financial/page';
 
@@ -77,9 +78,10 @@ function estimateAmount(capture: Capture): string | null {
 // Relative time formatter
 // ---------------------------------------------------------------------------
 
-function formatRelative(iso: string): string {
+function formatRelative(iso: string, now: number | null): string {
   const date = new Date(iso);
-  const now = Date.now();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const diffMs = now - date.getTime();
   const diffDays = Math.floor(diffMs / 86_400_000);
 
@@ -95,6 +97,7 @@ function formatRelative(iso: string): string {
 // ---------------------------------------------------------------------------
 
 function CaptureCard({ capture }: { capture: Capture }) {
+  const now = useClientNow();
   const amount = estimateAmount(capture);
   const preview = capture.content.length > 120
     ? `${capture.content.slice(0, 120).trimEnd()}…`
@@ -132,7 +135,7 @@ function CaptureCard({ capture }: { capture: Capture }) {
           <span className="text-cloud-dark opacity-40 text-[10px]">·</span>
           {/* Relative time */}
           <span className="font-mono text-[10px] tracking-[0.05em] uppercase text-text-body-secondary">
-            {formatRelative(capture.created_at)}
+            {formatRelative(capture.created_at, now)}
           </span>
           {/* Pipeline status indicator — only show non-complete states */}
           {capture.pipeline_status !== 'complete' && (

--- a/packages/web-next/components/ingest/RecentUploads.tsx
+++ b/packages/web-next/components/ingest/RecentUploads.tsx
@@ -14,6 +14,7 @@
 import { RefreshCw, FileText, Loader2, AlertCircle } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Pill, EmptyState } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import { useIngestUploads, useReprocessUpload, INGEST_UPLOADS_QUERY_KEY } from '@/lib/api/ingest.hooks';
 import type { FileUploadStatus, ListUploadsResponse } from '@/lib/api-client';
 import { toast } from 'sonner';
@@ -25,10 +26,11 @@ export { INGEST_UPLOADS_QUERY_KEY };
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatDate(iso: string): string {
+function formatDate(iso: string, now: number | null): string {
   const d = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const diffMs = now - d.getTime();
   const diffMins = Math.floor(diffMs / 60_000);
 
   if (diffMins < 1) return 'just now';
@@ -88,6 +90,7 @@ const REFRESH_INTERVAL_MS = 10_000; // 10s polling while any row is non-terminal
 
 export function RecentUploads({ activeUploadId, limit = 20, initialData }: RecentUploadsProps) {
   const queryClient = useQueryClient();
+  const now = useClientNow();
   const { data, isLoading, isError, error } = useIngestUploads(
     { limit },
     {
@@ -259,7 +262,7 @@ export function RecentUploads({ activeUploadId, limit = 20, initialData }: Recen
 
               {/* Uploaded time */}
               <span className="font-mono text-[10.5px] text-[var(--color-text-body-secondary)]">
-                {formatDate(upload.uploaded_at)}
+                {formatDate(upload.uploaded_at, now)}
               </span>
             </div>
           );

--- a/packages/web-next/components/intelligence/SkillCard.tsx
+++ b/packages/web-next/components/intelligence/SkillCard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Play, Loader2, Clock, CheckCircle2, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button, Pill } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import type { IntelligenceEntry } from '@/lib/api-client';
 import { intelligenceApi } from '@/lib/api-client';
 
@@ -15,9 +16,11 @@ import { intelligenceApi } from '@/lib/api-client';
  * Format an ISO timestamp as a human-readable relative string.
  * Returns "Just now", "Xm ago", "Xh ago", or "MMM D".
  */
-function formatRelative(isoString: string | Date): string {
+function formatRelative(isoString: string | Date, now: number | null): string {
   const date = typeof isoString === 'string' ? new Date(isoString) : isoString;
-  const diffMs = Date.now() - date.getTime();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const diffMs = now - date.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
 
   if (diffMin < 2) return 'Just now';
@@ -66,6 +69,7 @@ interface SkillCardProps {
 export function SkillCard({ skill, lastRun, description }: SkillCardProps) {
   const [triggering, setTriggering] = useState(false);
   const [justQueued, setJustQueued] = useState(false);
+  const now = useClientNow();
 
   async function handleTrigger() {
     setTriggering(true);
@@ -106,7 +110,7 @@ export function SkillCard({ skill, lastRun, description }: SkillCardProps) {
     return (
       <Pill tone="success" size="sm">
         <CheckCircle2 size={10} />
-        {formatRelative(lastRun.created_at)}
+        {formatRelative(lastRun.created_at, now)}
       </Pill>
     );
   }

--- a/packages/web-next/components/mobile/MobileResultCard.tsx
+++ b/packages/web-next/components/mobile/MobileResultCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useClientNow } from '@/hooks/useClientNow'
 import type { Capture } from '@/lib/types'
 
 // The API may include a tags array not present in the shared Capture type
@@ -10,8 +11,11 @@ interface MobileResultCardProps {
   score: number
 }
 
-function relativeDate(dateStr: string): string {
-  const diffMs = Date.now() - new Date(dateStr).getTime()
+function relativeDate(dateStr: string, now: number | null): string {
+  const date = new Date(dateStr)
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const diffMs = now - date.getTime()
   const diffSeconds = Math.floor(diffMs / 1000)
   if (diffSeconds < 60) return `${diffSeconds}s ago`
   const diffMinutes = Math.floor(diffSeconds / 60)
@@ -25,6 +29,7 @@ function relativeDate(dateStr: string): string {
 }
 
 export function MobileResultCard({ capture, score }: MobileResultCardProps) {
+  const now = useClientNow()
   const tags = capture.tags ?? []
   const visibleTags = tags.slice(0, 3)
   const extraCount = tags.length - visibleTags.length
@@ -36,7 +41,7 @@ export function MobileResultCard({ capture, score }: MobileResultCardProps) {
       {/* Top row */}
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-[10px] font-mono uppercase text-cloud-dark">
-          {capture.source} · {relativeDate(capture.created_at)}
+          {capture.source} · {relativeDate(capture.created_at, now)}
         </span>
         <span className="rounded-full px-2 py-0.5 text-[10px] font-mono uppercase bg-cloud-light text-slate-light">
           {capture.capture_type}

--- a/packages/web-next/components/search/GroupedResults.tsx
+++ b/packages/web-next/components/search/GroupedResults.tsx
@@ -19,6 +19,7 @@
 import Link from 'next/link';
 import type { SearchResult, CaptureSource } from '@/lib/types';
 import { Pill } from '@/components/design-system/Pill';
+import { useClientNow } from '@/hooks/useClientNow';
 
 // ---------------------------------------------------------------------------
 // Source group definitions
@@ -80,10 +81,11 @@ function scoreTone(score: number): 'success' | 'accent' | 'neutral' {
 }
 
 /** Format ISO date to relative string. */
-function relativeDate(iso: string): string {
+function relativeDate(iso: string, now: number | null): string {
   const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const diffMs = now - date.getTime();
   const diffDays = Math.floor(diffMs / 86_400_000);
 
   if (diffDays === 0) return 'Today';
@@ -106,6 +108,7 @@ function truncate(text: string, maxLength: number): string {
  */
 export function ResultCard({ result }: { result: SearchResult }) {
   const { capture, score } = result;
+  const now = useClientNow();
   const preview = truncate(capture.content, 180);
   const sourceLabel = SOURCE_LABELS[capture.source] ?? capture.source;
 
@@ -155,7 +158,7 @@ export function ResultCard({ result }: { result: SearchResult }) {
           ))}
         </div>
         <span className="font-mono text-[10.5px] tracking-[0.04em] text-text-body-secondary shrink-0">
-          {relativeDate(capture.created_at)}
+          {relativeDate(capture.created_at, now)}
         </span>
       </div>
     </Link>

--- a/packages/web-next/components/slack/ChannelTable.tsx
+++ b/packages/web-next/components/slack/ChannelTable.tsx
@@ -29,6 +29,7 @@ import {
   X,
 } from 'lucide-react';
 import { Card, Button, EmptyState } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import { useArchiveSlackChannel } from '@/lib/api/admin.hooks';
 import type { SlackChannel } from '@/lib/api-client';
 
@@ -56,10 +57,11 @@ interface ChannelTableProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatLastActivity(iso: string | null): string {
+function formatLastActivity(iso: string | null, now: number | null): string {
   if (!iso) return 'Never';
   const date = new Date(iso);
-  const now = Date.now();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   const diffMs = now - date.getTime();
   const diffDays = Math.floor(diffMs / 86_400_000);
 
@@ -524,6 +526,7 @@ interface ChannelRowProps {
 }
 
 function ChannelRow({ channel, threshold, isLast, onArchive }: ChannelRowProps) {
+  const now = useClientNow();
   const inactiveColor = daysInactiveColor(channel.days_inactive, threshold);
   const isHighRisk = channel.days_inactive >= threshold;
 
@@ -562,7 +565,7 @@ function ChannelRow({ channel, threshold, isLast, onArchive }: ChannelRowProps) 
       <div className="flex items-center gap-[5px] text-text-body-secondary">
         <Clock size={11} strokeWidth={1.5} className="shrink-0" />
         <span className="text-[12px] font-light">
-          {formatLastActivity(channel.last_activity)}
+          {formatLastActivity(channel.last_activity, now)}
         </span>
       </div>
 

--- a/packages/web-next/components/system/FlowsTab.tsx
+++ b/packages/web-next/components/system/FlowsTab.tsx
@@ -11,14 +11,17 @@
  */
 
 import { CheckCircle, XCircle, Clock, AlertCircle } from 'lucide-react';
+import { useClientNow } from '@/hooks/useClientNow';
 import type { PipelineFlowEntry } from '@/lib/api-client';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function fmtRelative(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
+function fmtRelative(iso: string, now: number | null): string {
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const diff = now - new Date(iso).getTime();
   const m = Math.floor(diff / 60000);
   const h = Math.floor(m / 60);
   const d = Math.floor(h / 24);
@@ -66,6 +69,7 @@ interface FlowRowProps {
 }
 
 function FlowRow({ flow }: FlowRowProps) {
+  const now = useClientNow();
   return (
     <div className="py-[12px] border-b border-cloud-light last:border-0">
       {/* Header row */}
@@ -87,7 +91,7 @@ function FlowRow({ flow }: FlowRowProps) {
 
         {/* Relative time */}
         <span className="text-[11px] text-text-body-secondary font-light shrink-0">
-          {fmtRelative(flow.created_at)}
+          {fmtRelative(flow.created_at, now)}
         </span>
       </div>
 

--- a/packages/web-next/components/system/OverviewTab.tsx
+++ b/packages/web-next/components/system/OverviewTab.tsx
@@ -17,6 +17,7 @@
 
 import { RefreshCw, Database, Zap, Server, BookOpen } from 'lucide-react';
 import { Button, StatusDot } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import type {
   SystemHealthSnapshot,
   QueueStats,
@@ -54,9 +55,11 @@ function fmtDuration(ms: number | null): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-function fmtRelative(iso: string | null): string {
+function fmtRelative(iso: string | null, now: number | null): string {
   if (!iso) return 'Never';
-  const diff = Date.now() - new Date(iso).getTime();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const diff = now - new Date(iso).getTime();
   const m = Math.floor(diff / 60000);
   const h = Math.floor(m / 60);
   const d = Math.floor(h / 24);
@@ -215,6 +218,7 @@ function QueueDepthRow({ queue }: { queue: QueueStats }) {
 }
 
 function SkillLastRunTable({ runs }: { runs: SkillLastRun[] }) {
+  const now = useClientNow();
   if (runs.length === 0) {
     return (
       <div className="py-[24px] text-center text-[13px] text-text-body-secondary font-light">
@@ -240,7 +244,7 @@ function SkillLastRunTable({ runs }: { runs: SkillLastRun[] }) {
             {fmtDuration(run.duration_ms)}
           </span>
           <span className="shrink-0 text-[11px] text-text-body-secondary font-light">
-            {fmtRelative(run.last_run_at)}
+            {fmtRelative(run.last_run_at, now)}
           </span>
         </div>
       ))}
@@ -257,6 +261,8 @@ interface OverviewTabProps {
 }
 
 export function OverviewTab({ snapshot }: OverviewTabProps) {
+  const now = useClientNow();
+
   function handleRefresh() {
     window.location.reload();
   }
@@ -309,7 +315,7 @@ export function OverviewTab({ snapshot }: OverviewTabProps) {
             )}
             {snapshot.wiki.last_commit_date && (
               <span className="ml-auto text-[11px] text-text-body-secondary font-light shrink-0">
-                {fmtRelative(snapshot.wiki.last_commit_date)}
+                {fmtRelative(snapshot.wiki.last_commit_date, now)}
               </span>
             )}
             {snapshot.wiki.error && (

--- a/packages/web-next/components/system/SkillsTab.tsx
+++ b/packages/web-next/components/system/SkillsTab.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import { Play, Edit2, Check, X, Clock } from 'lucide-react';
 import { Button } from '@/components/design-system';
+import { useClientNow } from '@/hooks/useClientNow';
 import { useTriggerSkill, useUpdateSkillSchedule } from '@/lib/api/skills.hooks';
 import type { SkillRecord } from '@/lib/api-client';
 
@@ -25,9 +26,11 @@ import type { SkillRecord } from '@/lib/api-client';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function fmtRelative(iso: string | null): string {
+function fmtRelative(iso: string | null, now: number | null): string {
   if (!iso) return 'Never';
-  const diff = Date.now() - new Date(iso).getTime();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const diff = now - new Date(iso).getTime();
   const m = Math.floor(diff / 60000);
   const h = Math.floor(m / 60);
   const d = Math.floor(h / 24);
@@ -52,6 +55,7 @@ interface SkillRowProps {
 }
 
 function SkillRow({ skill }: SkillRowProps) {
+  const now = useClientNow();
   const [editingSchedule, setEditingSchedule] = useState(false);
   const [scheduleInput, setScheduleInput] = useState(skill.schedule ?? '');
 
@@ -161,7 +165,7 @@ function SkillRow({ skill }: SkillRowProps) {
           {/* Last run meta */}
           {!editingSchedule && (
             <div className="flex items-center gap-[12px] mt-[4px] text-[11px] text-text-body-secondary font-light">
-              <span>Last run: {fmtRelative(skill.last_run_at)}</span>
+              <span>Last run: {fmtRelative(skill.last_run_at, now)}</span>
               {skill.last_duration_ms !== null && (
                 <span>{fmtDuration(skill.last_duration_ms)}</span>
               )}

--- a/packages/web-next/components/timeline/TimelineClient.tsx
+++ b/packages/web-next/components/timeline/TimelineClient.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
+import { useClientNow } from '@/hooks/useClientNow';
 import { TimelineGroup } from './TimelineGroup';
 import { capturesApi } from '@/lib/api-client';
 import type { Capture, BrainView, CaptureSource } from '@/lib/types';
@@ -66,6 +67,8 @@ function groupCaptures(captures: Capture[]): Array<{ dateKey: string; captures: 
  * Filtered + no results → softer "Nothing here for this filter."
  */
 function TimelineEmptyState({ isFiltered }: { isFiltered: boolean }) {
+  const now = useClientNow();
+
   if (isFiltered) {
     return (
       <div className="px-4 py-12 text-center">
@@ -79,7 +82,11 @@ function TimelineEmptyState({ isFiltered }: { isFiltered: boolean }) {
     );
   }
 
-  const weekday = new Date().toLocaleDateString('en-US', { weekday: 'long' });
+  // Pre-mount (SSR + first client render): neutral placeholder so the empty-state
+  // copy is hydration-stable; the real weekday fills in once the client clock is set.
+  const weekday = now === null
+    ? 'day'
+    : new Date(now).toLocaleDateString('en-US', { weekday: 'long' });
 
   return (
     <div className="px-4 py-16 text-center">

--- a/packages/web-next/components/timeline/TimelineEntry.tsx
+++ b/packages/web-next/components/timeline/TimelineEntry.tsx
@@ -11,11 +11,13 @@
  * Text preview: first ~120 chars of content; truncates with ellipsis.
  * Timestamp: relative (e.g. "3h ago", "14:32"); full ISO on hover via title.
  *
- * The component is a client component because it references browser APIs
- * (Date.now()) for relative formatting — rendered in the timeline feed.
+ * The component is a client component because it needs the client clock for
+ * relative timestamp formatting. It reads the mount-time value via useClientNow()
+ * (null during SSR + first client render) so the timestamp is hydration-stable.
  */
 
 import Link from 'next/link';
+import { useClientNow } from '@/hooks/useClientNow';
 import { SOURCE_ICON_MAP, SOURCE_LABEL_MAP } from '@/lib/source-icons';
 import type { Capture } from '@/lib/types';
 
@@ -49,11 +51,12 @@ const BRAIN_VIEW_LABEL: Record<string, string> = {
  *   - Same week: "Mon 14:32"
  *   - Older:     "Apr 14"
  */
-function formatTimestamp(isoString: string): string {
+function formatTimestamp(isoString: string, now: number | null): string {
   const date = new Date(isoString);
-  const now = new Date();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
-  const diffMs = now.getTime() - date.getTime();
+  const diffMs = now - date.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
   if (diffDays === 0) {
@@ -93,13 +96,14 @@ interface TimelineEntryProps {
 
 export function TimelineEntry({ capture }: TimelineEntryProps) {
   const { source, brain_view, content, created_at, capture_type } = capture;
+  const now = useClientNow();
 
   const Icon = SOURCE_ICON_MAP[source] ?? SOURCE_ICON_MAP.api;
   const sourceLabel = SOURCE_LABEL_MAP[source] ?? source;
   const viewColor = BRAIN_VIEW_COLOR[brain_view] ?? 'bg-cloud-dark';
   const viewLabel = BRAIN_VIEW_LABEL[brain_view] ?? brain_view;
   const preview = buildPreview(content);
-  const timestamp = formatTimestamp(created_at);
+  const timestamp = formatTimestamp(created_at, now);
 
   return (
     <Link

--- a/packages/web-next/components/voice/SessionList.tsx
+++ b/packages/web-next/components/voice/SessionList.tsx
@@ -19,6 +19,7 @@
  */
 
 import { Mic, MicOff, Radio } from 'lucide-react';
+import { useClientNow } from '@/hooks/useClientNow';
 import { useVoiceSessions, useActiveVoiceSessions } from '@/lib/api/voice.hooks';
 import type { VoiceSession } from '@/lib/api-client';
 
@@ -27,10 +28,11 @@ import type { VoiceSession } from '@/lib/api-client';
 // ---------------------------------------------------------------------------
 
 /** Format a session started_at into a compact human-readable string. */
-function formatDate(isoString: string): string {
+function formatDate(isoString: string, now: number | null): string {
   const d = new Date(isoString);
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
+  // Pre-mount (SSR + first client render): stable absolute date, no `now` dependency.
+  if (now === null) return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const diffMs = now - d.getTime();
   const diffDays = Math.floor(diffMs / 86_400_000);
 
   if (diffDays === 0) {
@@ -76,8 +78,9 @@ interface SessionRowProps {
 }
 
 function SessionRow({ session, isActive, isSelected, onClick }: SessionRowProps) {
+  const now = useClientNow();
   const title = sessionTitle(session);
-  const date = formatDate(session.started_at);
+  const date = formatDate(session.started_at, now);
   const duration = formatDuration(session.duration_seconds);
   const turns = session.turn_count ?? 0;
   const captureCount = session.captures_created?.length ?? 0;

--- a/packages/web-next/hooks/useClientNow.ts
+++ b/packages/web-next/hooks/useClientNow.ts
@@ -12,6 +12,10 @@ import { useEffect, useState } from 'react';
 export function useClientNow(): number | null {
   const [now, setNow] = useState<number | null>(null);
   useEffect(() => {
+    // Intentional one-shot mount-detection set: deferring the clock read to an
+    // effect is exactly how we avoid the SSR/client hydration mismatch. Same
+    // accepted pattern as ThemeToggle's mounted-state set.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setNow(Date.now());
   }, []);
   return now;

--- a/packages/web-next/hooks/useClientNow.ts
+++ b/packages/web-next/hooks/useClientNow.ts
@@ -1,0 +1,18 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns Date.now() only after mount (null during SSR + first client render),
+ * so relative-time / "is-today" logic never causes a hydration mismatch.
+ *
+ * Consumers must render a stable placeholder (absolute timestamp, dash, or the
+ * unmodified content) while the value is null, then recompute once it is set —
+ * this keeps the server render and the first client render byte-identical.
+ */
+export function useClientNow(): number | null {
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    setNow(Date.now());
+  }, []);
+  return now;
+}


### PR DESCRIPTION
Closes #207.

## What
Eliminates the 17 remaining render-scope `new Date()` / `Date.now()` calls in `'use client'` components (class (b) from the Phase B hydration audit). Adds a shared `useClientNow()` hook (returns `Date.now()` only after mount → `null` during SSR + first client render). Each date helper now takes `now: number | null` and renders a **stable placeholder** while `null`, so the server render and first client render are byte-identical, then recomputes the relative/is-today value after mount.

## Scope (18 files, +142/-56)
Hook `hooks/useClientNow.ts` + 17 client components (email, ingest, mobile, intelligence, entity, board, voice, system Overview/Skills/Flows, timeline, financial, search, slack).

**Correctly skipped:** RSC files (no `'use client'` — `system/page.tsx`, `dashboard/page.tsx`, `ExtractionsSidebar`, `TimelineGroup`), event-handler-scope `Date.now()` (DangerZone/AdminReset click handlers), and deterministic `new Date(iso)` parses (no `now` dependency → no mismatch).

## Verification (agent worktree, pre-merge)
- `pnpm --filter @open-brain/web-next lint` → exit 0 (18 warnings = existing `--max-warnings` threshold, 0 new)
- `pnpm --filter @open-brain/web-next build` → exit 0 (typecheck passed)
- `pnpm --filter @open-brain/web-next test` → 134/134 passed

Diff independently reviewed; pattern confirmed SSR-safe. Final gate = CI `build-and-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)