### PR TITLE
fix(secrets): financial Pushover key names + load-secrets bootstrap-token preservation

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -12924,3 +12924,21 @@ The handoff premise ("financial-ingest is healthy & has the token; diff to find 
 **Status:** utility-ingest infra FIXED + deployed + verified; gas data-fetch deferred to #265. Two regressions logged (OA-17 + PAT note).
 **Tags:** [deploy] [pipeline] [debug] [ci]
 **Environment:** ubuntu-vm + homeserver (root SSH). open-brain prod. Executed by Claude (Opus 4.8), user-directed.
+
+## Entry 193 — Autonomous cluster: financial-ingest drift fix + load-secrets.sh bootstrap-token preservation (OA-4b) (2026-07-14)  [pipeline] [config] [security] [test]
+
+**Objective:** "Do everything you can autonomously." A 3-agent analysis workflow confirmed findings; this entry is the execution.
+
+**(1) financial-ingest IS broken — same class as utility (confirmed via bws key-name check + code read):**
+- **Pushover drift (FIXED, code):** `financial-pipeline.py:757-758` hardcoded `pushover-user-key`/`pushover-api-token`, but BW has `PUSHOVER_USER_KEY`/`PUSHOVER_API_TOKEN`. Renamed the two literals. (This failure was SILENT — wrapped in `try/except SystemExit` → "Pushover secrets not found — skipping", so alerts were dropped, not hard-failing.)
+- **Plaid ABSENT (operator-gated):** `plaid-client-id`/`plaid-secret`/`plaid-access-tokens` do NOT exist in the BW vault under any name. `config/financial/plaid-config.yaml` `bitwarden_keys` updated to the canonical uppercase names `PLAID_CLIENT_ID`/`PLAID_SECRET`/`PLAID_ACCESS_TOKENS` (ready-but-inert). **financial `--sync` will keep hard-exiting(1) at `init_plaid()` until Troy PROVISIONS those 3 secrets in BW** (tokens = a JSON blob `{"amex":"access-...","chase":"..."}`). → operator action. Code fix ships in the `ingest-sidecar` image; the final `pull + recreate financial-ingest` is deferred until Plaid is provisioned (no point recreating a still-blocked service).
+
+**(2) load-secrets.sh bootstrap-token preservation (OA-4b, durable fix):** `load-secrets.sh` does a FULL rewrite of `.env.secrets` from `secrets-map.sh`; `BWS_ACCESS_TOKEN` is (by design) not in the map, so every reconcile dropped it — the recurring root cause of the utility/financial outages. Fix: capture any existing `^BWS_ACCESS_TOKEN=` line before the atomic write and re-emit it into the new file (2 insertions, reconcile-path only; `--force`/`--target-dir` covered). Added roundtrip test **case 6.6** (append a sentinel token → `--force` rewrite → assert preserved exactly once). **`scripts/test-secrets-roundtrip.sh` now PASSES 7/7** locally. This closes OA-4b (the durable half).
+
+**Validation:** `py_compile` + `ruff` (financial-pipeline) pass; `bash -n` (load-secrets + test) pass; plaid-config YAML valid; roundtrip 7/7.
+
+**Deferred to Troy:** provision the 3 Plaid secrets in BW as `PLAID_CLIENT_ID`/`PLAID_SECRET`/`PLAID_ACCESS_TOKENS` → then recreate financial-ingest to finish. (Least-privilege dedicated BW token — OA-4a — still stands.)
+
+**Status:** code fixes done + locally validated → PR. financial functional recovery gated on Plaid provisioning.
+**Tags:** [pipeline] [config] [security] [test]
+**Environment:** ubuntu-vm. open-brain `main`. Executed by Claude (Opus 4.8) under ultracode, user-directed.

--- a/config/financial/plaid-config.yaml
+++ b/config/financial/plaid-config.yaml
@@ -50,9 +50,12 @@ accounts:
 # Bitwarden secret references (retrieved via bws CLI)
 # These are the Bitwarden Secrets Manager secret names, NOT the values
 bitwarden_keys:
-  client_id_key: "plaid-client-id"
-  secret_key: "plaid-secret"
-  tokens_key: "plaid-access-tokens"
+  # Canonical Bitwarden names (UPPERCASE_UNDERSCORE, matching GAS_SOUTH_*/PUSHOVER_*).
+  # NOTE: these 3 secrets must still be PROVISIONED in Bitwarden — they do not exist
+  # under any name yet. tokens is a JSON blob: {"amex":"access-...","chase":"...", ...}
+  client_id_key: "PLAID_CLIENT_ID"
+  secret_key: "PLAID_SECRET"
+  tokens_key: "PLAID_ACCESS_TOKENS"
 
 # Open Brain capture API
 capture_api:

--- a/scripts/financial-pipeline.py
+++ b/scripts/financial-pipeline.py
@@ -754,8 +754,8 @@ def send_pushover_alert(cfg: dict, title: str, message: str, priority: int = 0) 
     import urllib.request
 
     try:
-        user_key = get_bws_secret("pushover-user-key")
-        api_token = get_bws_secret("pushover-api-token")
+        user_key = get_bws_secret("PUSHOVER_USER_KEY")
+        api_token = get_bws_secret("PUSHOVER_API_TOKEN")
     except SystemExit:
         log.warning("send_pushover_alert: Pushover secrets not found in Bitwarden — skipping")
         return False

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -308,6 +308,14 @@ fi
 # -----------------------------------------------------------------------------
 # Reconcile: write atomically.
 # -----------------------------------------------------------------------------
+# Preserve the Bitwarden BOOTSTRAP token across the rewrite (OA-4b). BWS_ACCESS_TOKEN
+# authenticates the bws CLI itself, so by design it is NOT a BWS secret (absent from
+# secrets-map.sh). A full rewrite would otherwise drop any manually-added
+# `BWS_ACCESS_TOKEN=` line — the recurring utility/financial-ingest outage.
+PRESERVED_BOOTSTRAP_TOKEN=""
+if [[ -f "${ENV_SECRETS_FILE}" ]]; then
+  PRESERVED_BOOTSTRAP_TOKEN="$(grep -m1 '^BWS_ACCESS_TOKEN=' "${ENV_SECRETS_FILE}" 2>/dev/null || true)"
+fi
 TMP_ENV_SECRETS="$(mktemp -p "${TARGET_DIR}" .env.secrets.tmp.XXXXXX)"
 chmod 0600 "${TMP_ENV_SECRETS}"
 
@@ -351,6 +359,12 @@ chmod 0600 "${TMP_ENV_SECRETS}"
     if [[ "$smtp_port_emit" == "yes" ]]; then
       echo "SMTP_PORT=${SMTP_PORT_DEFAULT}"
     fi
+  fi
+
+  if [[ -n "${PRESERVED_BOOTSTRAP_TOKEN}" ]]; then
+    echo ""
+    echo "# --- Bootstrap token (preserved from prior file; NOT in BWS, OA-4b) ---"
+    echo "${PRESERVED_BOOTSTRAP_TOKEN}"
   fi
 } > "${TMP_ENV_SECRETS}"
 

--- a/scripts/test-secrets-roundtrip.sh
+++ b/scripts/test-secrets-roundtrip.sh
@@ -412,6 +412,30 @@ else
     ok "6.5: verify-secrets reports DRIFT row + exit 1"
 fi
 
+echo ""
+echo "[6.6] Bootstrap BWS_ACCESS_TOKEN line preserved across --force rewrite (OA-4b)"
+reset_app_dir
+run_capture 6.6a bash "${REPO_ROOT}/scripts/load-secrets.sh" --target-dir "${APP_DIR}"
+if (( RC != 0 )); then
+  fail "6.6a: initial write exited ${RC} (expected 0)"
+fi
+BOOTSTRAP_SENTINEL="bootstrap-preserve-me-0123"
+printf 'BWS_ACCESS_TOKEN=%s\n' "${BOOTSTRAP_SENTINEL}" >> "${APP_DIR}/.env.secrets"
+run_capture 6.6b bash "${REPO_ROOT}/scripts/load-secrets.sh" --force --target-dir "${APP_DIR}"
+if (( RC != 0 )); then
+  fail "6.6b: --force exited ${RC} (expected 0)"
+elif ! grep -q "^BWS_ACCESS_TOKEN=${BOOTSTRAP_SENTINEL}\$" "${APP_DIR}/.env.secrets"; then
+  fail "6.6b: bootstrap BWS_ACCESS_TOKEN line not preserved after --force"
+else
+  n=$(grep -cE '^BWS_ACCESS_TOKEN=' "${APP_DIR}/.env.secrets" || true)
+  if (( n != 1 )); then
+    fail "6.6b: expected exactly 1 BWS_ACCESS_TOKEN line, found ${n}"
+  else
+    assert_no_secret_leak "${OUT_FILE}" "6.6b-stdout" && \
+      ok "6.6: bootstrap token preserved exactly once across --force rewrite"
+  fi
+fi
+
 # -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Two autonomous fixes (LAB_NOTEBOOK Entry 193):

1. **financial-ingest drift** (same class as the utility gas fix): rename `pushover-user-key`/`pushover-api-token` -> `PUSHOVER_USER_KEY`/`PUSHOVER_API_TOKEN`; point plaid-config `bitwarden_keys` at the canonical uppercase names. **Plaid secrets still must be provisioned in BW (operator)** before financial `--sync` works.
2. **load-secrets.sh (OA-4b)**: preserve an existing `BWS_ACCESS_TOKEN` across the full `.env.secrets` rewrite — the recurring root cause of the ingest outages. New roundtrip test 6.6; suite 7/7.

Validated: py_compile + ruff + bash -n + roundtrip 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)