### PR TITLE
fix(utility): parse gas therms from the bill's arithmetic row + ship PyMuPDF (#275)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13128,3 +13128,23 @@ RETURNED: None
 **Layer tally for this saga (Entries 190→199):** 1 BWS token missing → 2 secret-naming drift → 3 auth API changed (#265) → **4 PDF dep missing**. Each fix exposed the next. The generalizable lesson: **an integration blocked at step 1 hides every later step's bugs** — "fixed the blocker" is never the same as "the feature works," and only an end-to-end credentialed run can tell you which layer you're actually on. Estimating remaining work from the current error message systematically under-counts.
 **Tags:** [deploy] [pipeline] [debug] [api]
 **Environment:** homeserver (Unraid), `open-brain-utility-ingest` only (image `0e23f95c`→`282bec2e`). No prod Postgres writes (cmd_gas is SQLite-only). postgres/redis/core-api/workers untouched. Executed by Claude (Opus 4.8), user-directed.
+
+---
+
+## Entry 200 — #275: gas therms parse — add PyMuPDF + validate the never-run regexes against a real bill (2026-07-15)  [pipeline] [debug] [docker] [config]
+
+**Objective:** Close #275 — make `--gas` populate `therms`/`ccfs`/`therm_factor`/`rate_per_therm` instead of NULL. Troy authorized **PyMuPDF (AGPL-3.0 accepted — self-hosted single-user)**, i.e. option 1 in #275 (add the dep; `ingest-repair.py` already imports `fitz`, so it's the established choice) over option 2 (rewrite on pdfplumber).
+
+**Hypothesis (deliberately pessimistic):** adding the dependency is necessary but **NOT sufficient**. `_parse_gas_bill_pdf`'s regexes have **never executed against a real bill** — they were written blind and the gas path has been unreachable its whole life (Entries 190–199 layers 1–4). Reading them, at least one looks wrong by construction:
+- `r"(\d+\.?\d*)\s*therms?\b"` takes the **FIRST** `therms` match anywhere in the document. A real bill mentions "therms" in rate tables, prior-period comparisons, and marketing copy — first-match is very unlikely to be the billed usage.
+- `r"(\d+)\s*CCFs?\b"` is integer-only (`\d+`, no decimal) and also first-match.
+- `therm_factor` expects the literal `therm factor`/`conversion factor` label; Gas South may print something else entirely.
+**Predicted outcome:** dep lands, parse still returns wrong/None values → the regexes need rewriting against the real text. **Success = therms match the number a human reads off the bill**, not merely "not None".
+
+**Method:** (1) obtain the REAL text of a real bill — the only way to settle this. `docker exec` the running `open-brain-utility-ingest`, ad-hoc `pip install PyMuPDF` (**ephemeral container-layer only, wiped by the next recreate — the real dep goes in the Dockerfile**), re-use the script's own `_gas_south_login`/download path to pull one bill, dump the text, and inspect ONLY the CCF/therm/rate-bearing lines. (2) Rewrite the regexes to anchor on the bill's actual labels. (3) `docker/ingest-sidecar/Dockerfile:56` += `PyMuPDF`. (4) PR → merge → rebuild → pull + `up -d --force-recreate --no-deps utility-ingest`. (5) Re-run `--gas` and check the values against the bill by eye. (6) Backfill the 4 rows already stored ( `--gas` skips existing dates → needs a delete or explicit re-parse).
+
+**Data-handling note:** a gas bill is **personal financial data** (account number, service address, amounts). It stays on the homeserver / in local scratch — **never** pasted into a GitHub issue/PR/commit, and only the minimal label-bearing excerpts are surfaced.
+
+**Rollback:** ad-hoc pip install is erased by any recreate (or `docker compose up -d --force-recreate --no-deps utility-ingest` on the current image `282bec2e`). Code = `git revert`. Parse changes are pure-function + SQLite-only (`cmd_gas` posts NO captures, writes no prod Postgres) → blast radius is the `gas_readings` table in the `utility_ingest_data` volume; wrong values are deletable + re-fetchable.
+
+**Status:** IN PROGRESS — see result below.

--- a/docker/ingest-sidecar/Dockerfile
+++ b/docker/ingest-sidecar/Dockerfile
@@ -51,11 +51,17 @@ RUN ARCH="$(uname -m)" && case "$ARCH" in \
     chmod +x /usr/local/bin/electric-usage-downloader && \
     rm -rf /tmp/eud.tar.gz /tmp/LICENSE /tmp/README.md 2>/dev/null || true
 
-# Pipeline dependencies. Kept minimal — pdfplumber etc. deliberately excluded
-# until a script actually needs them. Adding a package here is cheap.
+# Pipeline dependencies. Kept minimal — a package earns its place by being
+# imported by a script that actually runs. Adding one here is cheap.
+#
+# PyMuPDF: utility-pipeline.py parses Gas South bill PDFs for therms. It was
+# missing for the entire life of the gas path — unnoticed because auth was
+# broken upstream, so the parse never ran and therms silently stored as NULL
+# (#275). AGPL-3.0, accepted for this self-hosted single-user deployment.
 RUN pip install --no-cache-dir \
       requests==2.32.3 \
-      PyYAML==6.0.2
+      PyYAML==6.0.2 \
+      PyMuPDF==1.28.0
 
 # Defaults for in-container paths. Overrideable via compose environment.
 ENV PYTHONUNBUFFERED=1 \

--- a/docker/ingest-sidecar/tests/test_gas_bill_parse.py
+++ b/docker/ingest-sidecar/tests/test_gas_bill_parse.py
@@ -1,0 +1,173 @@
+"""Unit tests for ``scripts/lib/gas_bill_parse.py``.
+
+These defend **#275** — gas bills stored a dollar amount but NULL therms for the
+entire life of the gas path.
+
+Two failures stacked:
+
+* The parser's regexes (``(\\d+)\\s*CCFs?``, first-match ``(\\d+\\.?\\d*)\\s*therms?``)
+  assumed the label sits next to its number, which is how the **web portal**
+  renders the bill — but PyMuPDF extracts the PDF's usage TABLE as a flat run of
+  standalone lines, headers first, values after. The labels are never adjacent to
+  the numbers, so all four regexes matched nothing on every real bill.
+* The miss degraded to a WARNING, so the run still exited 0 with ``status: ok``
+  while silently storing NULL usage. Nobody could see it, and the gas path was
+  unreachable behind three upstream blockers anyway (LAB_NOTEBOOK 190-199), so
+  the parser was never once executed against a real bill before shipping.
+
+``TABLE_TEXT`` below reproduces the real extracted layout (values from the
+2026-07-06 bill, verified against the live portal). ``test_rejects_portal_style_text``
+pins the specific wrong assumption so it cannot come back.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/lib is not packaged; make `import lib.gas_bill_parse` resolve from the
+# repo root regardless of pytest's cwd (mirrors conftest's trigger_server hack).
+_SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from lib.gas_bill_parse import parse_gas_bill_text, parse_usage_rows  # noqa: E402
+
+# Exactly how PyMuPDF emits the "How We Calculated Your Gas Charges" table:
+# every column header first, then the value row. 63 - 43 = 20 x 1.033 = 20.66
+# x 0.65 = 13.43 — the real 2026-07-06 bill.
+TABLE_TEXT = """How We Calculated Your Gas Charges
+Meter Start
+Meter End
+Days of
+Service
+Beginning
+Read
+Ending
+Read
+CCFs
+Used
+Therm
+Factor
+Therms
+Used
+Rate per
+Therm
+Gas
+Charges
+06/01/2026
+06/30/2026
+29
+43
+63
+=
+20
+X
+1.033
+=
+20.66
+X
+0.65
+=
+13.43
+"""
+
+
+def test_parses_real_bill_layout():
+    """The canonical case: the layout that made every old regex return None."""
+    result = parse_gas_bill_text(TABLE_TEXT)
+
+    assert result["ccfs"] == 20.0
+    assert result["therm_factor"] == 1.033
+    assert result["therms"] == 20.66
+    assert result["rate_per_therm"] == 0.65
+
+
+def test_rejects_portal_style_text():
+    """Label-adjacent text is the PORTAL's rendering, not the PDF's.
+
+    The old regexes were written against this shape. Asserting we find nothing
+    here documents that adjacency is not what the PDF gives us — if a future
+    change "fixes" the parser by matching this, it has regressed to #275.
+    """
+    portal_text = "Usage: 20 CCFs at therm factor 1.033 = 20.66 therms @ $0.65/therm"
+
+    assert parse_gas_bill_text(portal_text) == {
+        "ccfs": None,
+        "therm_factor": None,
+        "therms": None,
+        "rate_per_therm": None,
+    }
+
+
+def test_missing_usage_returns_none_not_zero():
+    """A bill with no usage row yields None. cmd_gas treats None as a failure;
+    a 0.0 would silently look like 'used no gas' and store a real-looking row."""
+    result = parse_gas_bill_text("Statement\nAmount Due\n73.03\nThank you\n")
+
+    assert result == {
+        "ccfs": None,
+        "therm_factor": None,
+        "therms": None,
+        "rate_per_therm": None,
+    }
+
+
+@pytest.mark.parametrize(
+    ("ccfs", "factor", "therms", "rate", "charges"),
+    [
+        (20, 1.033, 20.66, 0.65, 13.43),  # 2026-07-06
+        (31, 1.023, 31.71, 0.65, 20.62),  # 2026-06-04
+        (32, 1.031, 32.99, 0.65, 21.44),  # 2026-05-05
+        (66, 1.034, 68.24, 0.65, 44.36),  # 2026-04-03
+    ],
+)
+def test_all_four_real_bills(ccfs, factor, therms, rate, charges):
+    """Every real bill available when #275 was fixed, verified live end-to-end."""
+    text = f"=\n{ccfs}\nX\n{factor}\n=\n{therms}\nX\n{rate}\n=\n{charges}\n"
+    result = parse_gas_bill_text(text)
+
+    assert result["ccfs"] == float(ccfs)
+    assert result["therms"] == therms
+    assert result["therm_factor"] == factor
+    assert result["rate_per_therm"] == rate
+
+
+def test_rejects_row_whose_arithmetic_does_not_reconcile():
+    """The self-check is the guard against a silent column remap.
+
+    If Gas South reorders the table, the regex may still match but the numbers
+    land in the wrong fields. Wrong usage is worse than none, so the row is
+    dropped rather than stored.
+    """
+    # 20 x 1.033 = 20.66, not 99.99 — therms cannot belong to this row.
+    bogus = "=\n20\nX\n1.033\n=\n99.99\nX\n0.65\n=\n64.99\n"
+
+    assert parse_usage_rows(bogus) == []
+    assert parse_gas_bill_text(bogus)["therms"] is None
+
+
+def test_multi_row_bill_sums_usage_and_derives_effective_rate():
+    """A mid-cycle rate change splits the bill into two rows; usage is the total."""
+    two_rows = (
+        "=\n10\nX\n1.0\n=\n10.0\nX\n0.50\n=\n5.0\n"  # 10 therms @ $0.50
+        "=\n30\nX\n1.0\n=\n30.0\nX\n0.70\n=\n21.0\n"  # 30 therms @ $0.70
+    )
+    result = parse_gas_bill_text(two_rows)
+
+    assert result["ccfs"] == 40.0
+    assert result["therms"] == 40.0
+    # Effective rate = total charges / total therms = 26.0 / 40.0 — not either
+    # row's rate, and consistent with the summed usage.
+    assert result["rate_per_therm"] == 0.65
+
+
+def test_tolerates_thousands_separators():
+    """Reads/CCFs cross 1,000 on a big month; "1,043" must not parse as 1.0."""
+    text = "=\n1,000\nX\n1.0\n=\n1,000.0\nX\n0.65\n=\n650.0\n"
+    result = parse_gas_bill_text(text)
+
+    assert result["ccfs"] == 1000.0
+    assert result["therms"] == 1000.0

--- a/scripts/lib/gas_bill_parse.py
+++ b/scripts/lib/gas_bill_parse.py
@@ -1,0 +1,166 @@
+"""Gas South bill usage parser — pure text -> usage numbers, no PDF library.
+
+Extracted from utility-pipeline.py's ``_parse_gas_bill_pdf`` (#275) so the
+parsing logic is unit-testable with zero third-party dependencies. The caller
+owns PDF text extraction (PyMuPDF); this module owns the text -> numbers step.
+
+Why the original label-based regexes could never work
+-----------------------------------------------------
+The bill's "How We Calculated Your Gas Charges" section is a TABLE. PyMuPDF's
+``get_text()`` emits it as a flat sequence of standalone lines — every column
+header first, then every value — so a label is NEVER adjacent to its number::
+
+    CCFs          <- header
+    Used
+    Therm
+    Factor
+    Therms
+    Used
+    ...
+    06/01/2026    <- values start here
+    06/30/2026
+    29
+    43
+    63
+    =
+    20            <- CCFs Used
+    X
+    1.033         <- Therm Factor
+    =
+    20.66         <- Therms Used
+    X
+    0.65          <- Rate per Therm
+    =
+    13.43         <- Gas Charges
+
+Patterns like ``(\\d+)\\s*CCFs?`` assume "20 CCFs" adjacency — true of the web
+portal's rendering, false of the extracted PDF text. They matched nothing, and
+because the miss degraded to a WARNING the bill amount still stored fine with
+usage silently NULL.
+
+What we anchor on instead
+-------------------------
+The value row carries its own arithmetic, which is far more stable than any
+label text::
+
+    Ending - Beginning = CCFs x ThermFactor = Therms x Rate = GasCharges
+              63 - 43  =  20  x   1.033     = 20.66  x 0.65 =   13.43
+
+We match that ``= N X N = N X N = N`` shape and then re-check the arithmetic,
+so a column-order change breaks loudly instead of silently yielding wrong
+numbers. Verified against 4 real bills (2026-04 .. 2026-07); all arithmetic
+self-checks passed.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Relative tolerance for the self-check. The bill rounds each column to 2dp, so
+# recomputing from rounded inputs drifts slightly; 1% absorbs rounding without
+# tolerating a genuine column mix-up.
+_ARITHMETIC_TOLERANCE = 0.01
+
+_NUM = r"[\d,]+(?:\.\d+)?"
+
+# The usage row's arithmetic: "= <ccfs> X <factor> = <therms> X <rate> = <charges>".
+# Values arrive newline-separated (see module docstring), so \s* spans lines.
+_USAGE_ROW_RE = re.compile(
+    rf"=\s*(?P<ccfs>{_NUM})"
+    rf"\s*[Xx]\s*(?P<factor>{_NUM})"
+    rf"\s*=\s*(?P<therms>{_NUM})"
+    rf"\s*[Xx]\s*(?P<rate>{_NUM})"
+    rf"\s*=\s*(?P<charges>{_NUM})"
+)
+
+EMPTY_RESULT: dict[str, Any] = {
+    "ccfs": None,
+    "therm_factor": None,
+    "therms": None,
+    "rate_per_therm": None,
+}
+
+
+def _to_float(raw: str) -> float:
+    """Parse a bill number, tolerating thousands separators ("1,043" -> 1043.0)."""
+    return float(raw.replace(",", ""))
+
+
+def _close(actual: float, expected: float) -> bool:
+    """Relative comparison that stays sane when expected is 0."""
+    if expected == 0:
+        return abs(actual) < 0.01
+    return abs(actual - expected) / abs(expected) <= _ARITHMETIC_TOLERANCE
+
+
+def parse_usage_rows(text: str) -> list[dict[str, float]]:
+    """Return every usage row found, each self-checked against its own arithmetic.
+
+    A bill normally has exactly one row, but can carry more than one when the
+    rate changes mid-cycle. Rows whose arithmetic does not reconcile are dropped
+    and logged — a mismatch means the column mapping is wrong, and wrong usage
+    numbers are worse than none.
+    """
+    rows: list[dict[str, float]] = []
+
+    for match in _USAGE_ROW_RE.finditer(text):
+        row = {name: _to_float(value) for name, value in match.groupdict().items()}
+
+        if not _close(row["ccfs"] * row["factor"], row["therms"]):
+            log.warning(
+                "Gas bill usage row rejected — ccfs x factor != therms "
+                f"({row['ccfs']} x {row['factor']} != {row['therms']}). "
+                "Bill layout may have changed."
+            )
+            continue
+        if not _close(row["therms"] * row["rate"], row["charges"]):
+            log.warning(
+                "Gas bill usage row rejected — therms x rate != charges "
+                f"({row['therms']} x {row['rate']} != {row['charges']}). "
+                "Bill layout may have changed."
+            )
+            continue
+
+        rows.append(row)
+
+    return rows
+
+
+def parse_gas_bill_text(text: str) -> dict[str, Any]:
+    """Extract ``ccfs`` / ``therm_factor`` / ``therms`` / ``rate_per_therm`` from bill text.
+
+    Values are None when no usable row is found, which the caller must treat as a
+    failure rather than a zero — see utility-pipeline's cmd_gas.
+
+    Multi-row bills are summed. Factor and rate are then reported as the
+    *effective* values implied by the totals (therms/ccfs and charges/therms)
+    rather than an arbitrary row's, so they stay consistent with the summed usage.
+    """
+    rows = parse_usage_rows(text)
+    if not rows:
+        return dict(EMPTY_RESULT)
+
+    total_ccfs = sum(r["ccfs"] for r in rows)
+    total_therms = sum(r["therms"] for r in rows)
+    total_charges = sum(r["charges"] for r in rows)
+
+    if len(rows) == 1:
+        factor: float | None = rows[0]["factor"]
+        rate: float | None = rows[0]["rate"]
+    else:
+        log.info(
+            f"Gas bill has {len(rows)} usage rows — summing usage, deriving effective factor/rate"
+        )
+        factor = round(total_therms / total_ccfs, 4) if total_ccfs else None
+        rate = round(total_charges / total_therms, 4) if total_therms else None
+
+    return {
+        "ccfs": total_ccfs,
+        "therm_factor": factor,
+        "therms": round(total_therms, 2),
+        "rate_per_therm": rate,
+    }

--- a/scripts/utility-pipeline.py
+++ b/scripts/utility-pipeline.py
@@ -44,6 +44,10 @@ import yaml
 # local invocations.
 from lib.capture_api import post_capture as _post_capture_unwrapped  # noqa: E402
 
+# Gas bill text -> usage numbers. Pure/stdlib-only and unit-tested separately
+# (docker/ingest-sidecar/tests/test_gas_bill_parse.py) — see #275.
+from lib.gas_bill_parse import parse_gas_bill_text  # noqa: E402
+
 # CS3.9 --json-output support: wrap post_capture so the ingest sidecar
 # (docker/ingest-sidecar/trigger_server.py) can read a JSON summary as the
 # final stdout line. Passthrough when --json-output is not set.
@@ -419,19 +423,25 @@ def _gas_south_login(cfg: dict[str, Any]) -> str | None:
 
 
 def _parse_gas_bill_pdf(pdf_content: bytes) -> dict[str, Any]:
-    """Extract CCFs, therm factor, and therms from a Gas South bill PDF.
+    """Extract CCFs, therm factor, therms, and rate from a Gas South bill PDF.
 
     Returns dict with keys: ccfs, therm_factor, therms, rate_per_therm.
-    Missing values are None.
+    Missing values are None — callers must treat that as a failure, not a zero.
+
+    This function owns only PDF -> text; the text -> numbers step lives in
+    ``lib.gas_bill_parse`` so it can be unit-tested without a PDF library. See
+    that module for why the original label-adjacency regexes never matched (#275).
     """
-    result = {"ccfs": None, "therm_factor": None, "therms": None, "rate_per_therm": None}
+    result = dict(parse_gas_bill_text(""))  # canonical empty shape
 
     try:
         import fitz  # PyMuPDF
     except ImportError:
-        log.warning(
+        # PyMuPDF is a hard dependency of the image (ingest-sidecar Dockerfile).
+        # If it is missing, the environment is broken — not a soft "no data" case.
+        log.error(
             "PyMuPDF (fitz) not installed — cannot parse gas bill PDFs. "
-            "Install with: pip install PyMuPDF"
+            "It is expected in the ingest-sidecar image; rebuild it. (#275)"
         )
         return result
 
@@ -453,42 +463,18 @@ def _parse_gas_bill_pdf(pdf_content: bytes) -> dict[str, Any]:
                 os.unlink(tmp_path)  # type: ignore[possibly-unbound]
         return result
 
-    # Extract CCFs: look for patterns like "66 CCFs" or "66 CCF"
-    ccf_match = re.search(r"(\d+)\s*CCFs?\b", full_text, re.IGNORECASE)
-    if ccf_match:
-        result["ccfs"] = float(ccf_match.group(1))  # type: ignore[typeddict-item]
+    result = parse_gas_bill_text(full_text)
 
-    # Extract therm factor: "1.034" near "therm factor" or "conversion"
-    factor_match = re.search(
-        r"(?:therm\s*factor|conversion\s*factor)[:\s]*(\d+\.?\d*)",
-        full_text,
-        re.IGNORECASE,
-    )
-    if factor_match:
-        result["therm_factor"] = float(factor_match.group(1))  # type: ignore[typeddict-item]
-
-    # Extract therms: "68.24 therms" or total therms line
-    therms_match = re.search(r"(\d+\.?\d*)\s*therms?\b", full_text, re.IGNORECASE)
-    if therms_match:
-        result["therms"] = float(therms_match.group(1))  # type: ignore[typeddict-item]
-
-    # Extract rate per therm: "$0.65/therm" or "0.65 per therm"
-    rate_match = re.search(
-        r"\$?(\d+\.?\d*)\s*(?:/\s*therm|per\s*therm)",
-        full_text,
-        re.IGNORECASE,
-    )
-    if rate_match:
-        result["rate_per_therm"] = float(rate_match.group(1))  # type: ignore[typeddict-item]
-
-    # If we have CCFs and factor but no therms, calculate
-    if result["ccfs"] and result["therm_factor"] and not result["therms"]:
-        result["therms"] = round(result["ccfs"] * result["therm_factor"], 2)  # type: ignore[typeddict-item,arg-type,operator]
-
-    log.info(
-        f"  PDF parsed: CCFs={result['ccfs']}, factor={result['therm_factor']}, "
-        f"therms={result['therms']}, rate={result['rate_per_therm']}"
-    )
+    if result["therms"] is None:
+        log.warning(
+            "  PDF yielded no usable usage row — bill stored WITHOUT therms. "
+            "The bill layout may have changed (#275)."
+        )
+    else:
+        log.info(
+            f"  PDF parsed: CCFs={result['ccfs']}, factor={result['therm_factor']}, "
+            f"therms={result['therms']}, rate={result['rate_per_therm']}"
+        )
     return result
 
 
@@ -557,13 +543,17 @@ def cmd_gas(cfg: dict[str, Any], conn: sqlite3.Connection) -> None:
 
     new_count = 0
     skip_count = 0
+    no_usage_count = 0
 
     for activity in activities:
         activity_type = activity.get("ActivityType") or activity.get("activityType") or ""
         activity_date = activity.get("ActivityDate") or activity.get("activityDate") or ""
         activity_amount = activity.get("ActivityAmount") or activity.get("activityAmount") or 0
         bill_url = activity.get("Url") or activity.get("url") or ""
-        activity.get("BillSegmentInfo") or activity.get("billSegmentInfo")
+        # NB: the API's BillSegmentInfo carries only segment dates + dollar
+        # amounts — no CCFs/therms — so usage must come from the bill PDF.
+        # (Checked against the live API while fixing #275; a discarded
+        # `activity.get("BillSegmentInfo")` used to sit here implying otherwise.)
 
         # Only process bill records (skip payments, adjustments)
         if "bill" not in activity_type.lower() and "statement" not in activity_type.lower():
@@ -631,8 +621,21 @@ def cmd_gas(cfg: dict[str, Any], conn: sqlite3.Connection) -> None:
         therms_str = f", {therms_val:.1f} therms" if therms_val else ", therms N/A"
         log.info(f"  {activity_date}: ${bill_amount:.2f}{therms_str}")
 
+        # Usage is the point of this pipeline — a reading with only a dollar
+        # amount is a failure, not a success. Surfacing it in the JSON summary
+        # flips `status` to "error" so the sidecar/cron cannot report a clean run
+        # while silently storing NULL therms, which is exactly how #275 hid.
+        if therms_val is None:
+            no_usage_count += 1
+            _JSON_ERRORS.append(f"gas bill {activity_date}: no usage parsed from PDF")
+
     conn.commit()
     log.info(f"Gas: {new_count} new readings stored, {skip_count} already existed")
+    if no_usage_count:
+        log.error(
+            f"Gas: {no_usage_count} of {new_count} new readings have NO usage data "
+            "— bill amounts stored but therms are NULL (#275)"
+        )
 
 
 # ── Power (Cobb EMC — stub) ─────────────────────────────────────────────────


### PR DESCRIPTION
Gas readings stored a dollar amount with **NULL therms** — we recorded what the gas *cost* but not how much was *used*. Two stacked failures, both invisible until #265 made the gas path reachable for the first time in its life.

## 1. PyMuPDF was never in the image
`import fitz` failed, and the parse degraded to a WARNING. Added — **AGPL-3.0, accepted for this self-hosted single-user deployment** (`ingest-repair.py` already imports `fitz`). Pinned to **1.28.0**, the version actually verified against real bills rather than a guess.

## 2. The regexes could never have matched anyway
Even with the dependency present, all four returned `None` on all four real bills. They assumed label adjacency (`(\d+)\s*CCFs?` → "20 CCFs"), which is how the **web portal** renders the bill. The PDF's usage **table** extracts as a flat run of standalone lines — every header first, then every value — so a label is never next to its number:

```
CCFs / Used / Therm / Factor / Therms / Used ...   <- headers
06/01/2026 / 06/30/2026 / 29 / 43 / 63 / = / 20 / X / 1.033 / = / 20.66 ...   <- values
```

Telling detail: the old docstring's examples (`66 CCFs`, `68.24 therms`) are **exactly** the 2026-04-03 bill — written from the portal UI, never once run against a PDF.

## The fix — anchor on the row's own arithmetic
Far more stable than label text, and self-validating:

```
Ending - Beginning = CCFs x ThermFactor = Therms x Rate = GasCharges
          63 - 43  =  20  x   1.033     = 20.66  x 0.65 =   13.43
```

Each row is re-checked against that arithmetic and **dropped if it does not reconcile** — a future column remap fails loudly instead of silently storing wrong usage. Multi-row bills (mid-cycle rate change) sum usage and derive the effective factor/rate.

Parsing moved to `scripts/lib/gas_bill_parse.py` — **pure stdlib**, so it unit-tests with no PDF library and no network. `utility-pipeline` keeps PDF→text; the lib owns text→numbers.

## Unparseable bills are now loud
Previously a WARNING, so a run storing only dollar amounts still reported `status: ok` — precisely how this hid. Now appends to the JSON summary `errors`, flipping `status` to `"error"`.

## Also
Removed a discarded `activity.get("BillSegmentInfo")` expression (the pre-existing Pyright "unused expression"). Checked against the live API: it carries only segment dates + amounts, **no usage**, so it was never a viable therms source. Replaced with a comment recording that.

## Verification
- **10 new unit tests + 23/23 sidecar suite** green in a clean `python:3.12` container (as CI runs it); `ruff check` + `format` clean; `py_compile` OK.
- **The real `_parse_gas_bill_pdf` run end-to-end against all 4 real bills — 4/4 parsed**, every arithmetic self-check OK:

| Bill | CCFs | Factor | Therms | Rate |
|---|---|---|---|---|
| 2026-07-06 | 20 | 1.033 | **20.66** | 0.65 |
| 2026-06-04 | 31 | 1.023 | **31.71** | 0.65 |
| 2026-05-05 | 32 | 1.031 | **32.99** | 0.65 |
| 2026-04-03 | 66 | 1.034 | **68.24** | 0.65 |

Post-merge: rebuild → redeploy `utility-ingest` → re-run `--gas` → backfill the 4 existing NULL rows. LAB_NOTEBOOK Entry 200.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)