### PR TITLE
fix(secrets): correct secrets-map BWS names — DR reconcile goes from exit-2 to 10/11 (#278)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13277,3 +13277,35 @@ DRIFT: 11 of 14 required secret(s) missing from BWS or .env.secrets.
 **Status:** ✅ **DOCUMENTED + FILED** (issue + A142 + OA note). Docs reconciled: `OPEN_ITEMS.md` (8→**6** open issues — verified against `gh issue list`; #265/#275/#200 moved to Recently-closed), `OPERATOR_ACTIONS.md` (OA-4(c) corrected to "merged but not live until 2026-07-15"), Decision Log (**D139** PyMuPDF/AGPL, **D140** in-sync=code-not-digests), Action Items (**A140** financial Pushover unexercised, **A141** 5 stale pip/docker Dependabot PRs, **A142** this).
 **Tags:** [security] [debug] [ci] [decision]
 **Environment:** Read-only investigation (BWS key NAMES only — no values printed; `verify-secrets.sh` is inspection-only). No code, prod, or BWS changes. Executed by Claude (Opus 4.8) during a user-directed docs reconcile.
+
+---
+
+## Entry 203 — #278 fix: BWS names corrected + 4 secrets created from live values; found a SECOND DR gap (`.env`) (2026-07-15)  [security] [deploy] [decision]
+
+**Objective:** Fix #278 — `secrets-map.sh`'s BWS names matched nothing, so `load-secrets.sh` would exit 2 and the documented DR rebuild would write nothing.
+
+**Investigation — grouping BWS by PROJECT is what made this tractable** (`bws secret list` + `bws project list`, names only): **ai-work** (68) holds open-brain's secrets, **litellm** (25), **personal** (3). Two things fell out immediately:
+1. **The `open-brain-*` prefix is NOT bureaucratic — it is load-bearing.** The machine token spans all 3 projects and lookups are by `.key` alone, so **bare names COLLIDE**: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY` each exist **twice** across projects, and `GITEA_TOKEN` exists **twice inside ai-work** (same value — benign today, but a rotation would update one and silently strand the other). A unique prefix is the only way to be certain you get open-brain's copy.
+2. **Remapping to a plausible existing name would have been WRONG.** litellm holds `slack-bot-token`, `CLOUDFLARE_TUNNEL_TOKEN`, `POSTGRES_PASSWORD` — those are a **different service's** credentials (litellm's own tunnel/DB). Name-similarity would have wired the wrong secret into prod. This is exactly why #278 said "not a drive-by."
+
+**Method — capture the LIVE values, don't guess.** `financial-ingest` uniquely has BOTH `BWS_ACCESS_TOKEN` (bws CLI) AND every `.env.secrets` value in its env, so the whole operation ran **inside one container**: values never touched a shell, a command line, or a transcript. Dry-run first; existence-checked (never overwrite); reported names + status only. The running container's env is the only *unambiguous* source of truth for what open-brain actually uses.
+
+**Created in BWS (ai-work), additive, none pre-existing:** `open-brain-postgres-password`, `open-brain-slack-bot-token`, `open-brain-slack-app-token`, `open-brain-cloudflare-tunnel-token`.
+**Remapped in `secrets-map.sh`** (BWS-name side only — the ENV-var side is what consumers read and MUST NOT move; avoids duplicating a live credential): `open-brain-pushover-app-token`→**`PUSHOVER_API_TOKEN`**, `open-brain-pushover-user-key`→**`PUSHOVER_USER_KEY`**, `dev/open-brain/gitea-token`→**`GITEA_TOKEN`** (safe only because those keys are unambiguous today — recorded in the header).
+**Demoted/removed from REQUIRED:** `SLACK_USER_TOKEN` → OPTIONAL (an `xoxp-` channel-cleanup token that is **not set in prod and not in BWS** — requiring it failed every reconcile for an *unconfigured* feature); `PUSHOVER_TOKEN`/`PUSHOVER_USER` **deleted** (legacy aliases that exist nowhere; `pushover-notify.sh` treats them as a *fallback*, never a requirement). Header count corrected **13→11** (the array had always held 14 — nobody had audited the block).
+
+**Result — measured with the repo's own read-only tool, not asserted:**
+```
+BEFORE: DRIFT: 11 of 14 required secret(s) missing   -> load-secrets.sh exits 2, writes NOTHING
+AFTER:  DRIFT:  1 of 11                              -> 10/11 OK
+```
+
+**THE REMAINING 1 IS A SECOND, INDEPENDENT DR GAP — `REDIS_PASSWORD` lives in `.env`, which NOTHING automates.** Compose interpolates `--requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}` and `REDIS_URL` **from `.env`** — and `${}` interpolation reads `.env`/the shell, **NOT `env_file:`**. Verified: `.env` = `{CLOUDFLARE_TUNNEL_TOKEN, GITEA_TOKEN, GRAFANA_ADMIN_PASSWORD, LOKI_URL, MORNING_BRIEF_SLACK_CHANNEL, POSTGRES_PASSWORD, REDIS_PASSWORD}`; `.env.secrets` (21 vars) has **no** `REDIS_PASSWORD`. `load-secrets.sh` writes **only `.env.secrets`** → after a real rebuild `.env` is absent → **`docker compose` fails hard on the `:?` guard and the ENTIRE STACK cannot start.** So fixing the map moves DR from "writes nothing" to "writes half of what's needed." Filed separately — it is a different defect than #278's invented names. (Also worth noting: `.env` holds 5 REAL secrets, which sits awkwardly with the CLAUDE.md rule *".env files: non-sensitive config and placeholders only."*)
+
+**Redis auth verified GOOD along the way** (the drift row could have implied otherwise): an unauthenticated `redis-cli PING` returns `NOAUTH Authentication required` — `requirepass` is genuinely enforced in prod.
+
+**Rollback:** `git revert` the map commit; the 4 new BWS secrets are additive and deletable by name (nothing was overwritten — existence-checked first). Host tree was restored after testing; the fix lands via PR, never by hand-editing the deploy tree.
+
+**Lesson:** the previous entry's lesson (a mock fixture agreeing with the code proves nothing) has a sibling here — **`verify-secrets.sh` only ever audited `.env.secrets`, so the `.env` half of the secret surface was never audited by anything at all.** A checker that inspects one of two files reports "1 drift" when the truth is "the stack won't boot."
+**Tags:** [security] [deploy] [decision]
+**Environment:** BWS writes = 4 additive secret creations (ai-work), performed in-container so values never egressed. Map tested against live BWS then reverted on the host. No prod restart, no service touched. Executed by Claude (Opus 4.8), user-directed ("tackle #278").

--- a/scripts/lib/secrets-map.sh
+++ b/scripts/lib/secrets-map.sh
@@ -29,8 +29,20 @@ fi
 unset _bash_major
 
 # -----------------------------------------------------------------------------
-# REQUIRED secrets (13) — must be present in BWS or reconcile fails.
+# REQUIRED secrets (11) — must be present in BWS or reconcile fails.
 # Map: BWS_SECRET_NAME -> ENV_VAR_NAME
+#
+# The BWS-name column is NOT a convention — it is whatever the secret is
+# literally called in Bitwarden. Verify with `bws secret list`, never assume
+# (#278: 11 of 14 required names here were invented and matched nothing, so
+# load-secrets.sh would have exit-2'd on any real DR rebuild).
+#
+# Most open-brain secrets use the `open-brain-*` prefix, which is deliberate:
+# the machine token spans 3 projects and bare names COLLIDE across them
+# (ANTHROPIC_API_KEY/OPENAI_API_KEY/GOOGLE_API_KEY each exist twice). A
+# lookup is by `.key` alone, so a unique prefix is the only way to be sure
+# you get open-brain's copy. PUSHOVER_*/GITEA_TOKEN are mapped bare only
+# because those keys are unambiguous today.
 # -----------------------------------------------------------------------------
 declare -A REQUIRED_SECRETS=(
   ["open-brain-postgres-password"]="POSTGRES_PASSWORD"
@@ -40,13 +52,10 @@ declare -A REQUIRED_SECRETS=(
   ["open-brain-admin-api-key"]="ADMIN_API_KEY"
   ["open-brain-slack-bot-token"]="SLACK_BOT_TOKEN"
   ["open-brain-slack-app-token"]="SLACK_APP_TOKEN"
-  ["open-brain-slack-user-token"]="SLACK_USER_TOKEN"
-  ["open-brain-pushover-app-token"]="PUSHOVER_APP_TOKEN"
-  ["open-brain-pushover-user-key"]="PUSHOVER_USER_KEY"
-  ["dev/open-brain/gitea-token"]="GITEA_TOKEN"
+  ["PUSHOVER_API_TOKEN"]="PUSHOVER_APP_TOKEN"
+  ["PUSHOVER_USER_KEY"]="PUSHOVER_USER_KEY"
+  ["GITEA_TOKEN"]="GITEA_TOKEN"
   ["open-brain-cloudflare-tunnel-token"]="CLOUDFLARE_TUNNEL_TOKEN"
-  ["open-brain-pushover-token"]="PUSHOVER_TOKEN"
-  ["open-brain-pushover-user"]="PUSHOVER_USER"
 )
 
 # -----------------------------------------------------------------------------
@@ -55,6 +64,10 @@ declare -A REQUIRED_SECRETS=(
 # load-secrets.sh to also emit SMTP_PORT=$SMTP_PORT_DEFAULT (a non-secret).
 # -----------------------------------------------------------------------------
 declare -A OPTIONAL_SECRETS=(
+  # SLACK_USER_TOKEN: demoted from REQUIRED (#278). It is an xoxp- user token
+  # for Slack channel cleanup; it is NOT set in prod and does not exist in BWS,
+  # so requiring it made every reconcile fail for an unconfigured feature.
+  ["open-brain-slack-user-token"]="SLACK_USER_TOKEN"
   ["OPENCLAW_DEEPGRAM_API_KEY"]="DEEPGRAM_API_KEY"
   ["OPENCLAW_ANTHROPIC_API_KEY"]="ANTHROPIC_API_KEY"
   ["open-brain-smtp-host"]="SMTP_HOST"

--- a/scripts/test-secrets-roundtrip.sh
+++ b/scripts/test-secrets-roundtrip.sh
@@ -114,24 +114,30 @@ export BWS_ACCESS_TOKEN="mock-token-not-used"
 # This is the source of truth for what mock BWS exposes per test case.
 # -----------------------------------------------------------------------------
 KEYSET_FILE="${WORK_DIR}/bws-keyset.txt"
-cat > "${KEYSET_FILE}" <<'EOF'
-open-brain-postgres-password
-open-brain-redis-password
-open-brain-openai-api-key
-open-brain-mcp-api-key
-open-brain-admin-api-key
-open-brain-slack-bot-token
-open-brain-slack-app-token
-open-brain-slack-user-token
-open-brain-pushover-app-token
-open-brain-pushover-user-key
-dev/open-brain/gitea-token
-open-brain-cloudflare-tunnel-token
-open-brain-pushover-token
-open-brain-pushover-user
-OPENCLAW_DEEPGRAM_API_KEY
-OPENCLAW_ANTHROPIC_API_KEY
-EOF
+
+# Derive the mock's REQUIRED keyset FROM secrets-map.sh instead of duplicating it.
+#
+# This list used to be a hardcoded literal, which made it a second source of
+# truth that rots silently: #278 corrected 11 BWS names and every test here
+# broke, because the fixture still asserted the old ones.
+#
+# IMPORTANT — what this fixture can and cannot prove. Deriving the keyset means
+# the mock now agrees with the map BY CONSTRUCTION, so these tests verify the
+# MECHANISM (parse, write, 0600, hash sidecar, clobber rules) and never the
+# NAMES. They are structurally incapable of catching drift between the map and
+# the REAL Bitwarden store — which is exactly how #278 hid: a fully green suite
+# asserted nothing about the thing that was broken. Catching that needs a
+# recorded real-BWS key inventory (names only, no values), which is the
+# remaining #278 DoD item. Do not mistake this file's green for "DR works".
+# shellcheck source=lib/secrets-map.sh
+source "${REPO_ROOT}/scripts/lib/secrets-map.sh"
+{
+  printf '%s\n' "${!REQUIRED_SECRETS[@]}"
+  # Two optional keys the fixture exercises; the rest are intentionally absent
+  # so the "optional missing is silently skipped" path stays covered.
+  printf '%s\n' "OPENCLAW_DEEPGRAM_API_KEY" "OPENCLAW_ANTHROPIC_API_KEY"
+} > "${KEYSET_FILE}"
+
 export MOCK_BWS_KEYSET="${KEYSET_FILE}"
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the primary defect in #278. **Measured with the repo's own read-only tool, not asserted:**

```
BEFORE: DRIFT: 11 of 14 required secret(s) missing   -> load-secrets.sh exits 2, writes NOTHING
AFTER:  DRIFT:  1 of 11                              -> 10/11 OK
```

## What made it tractable — and what it killed
Grouping BWS by **project** (`bws project list`): ai-work (68), litellm (25), personal (3). Two things fell out:

1. **The `open-brain-*` prefix is load-bearing, not bureaucratic.** The machine token spans all 3 projects and lookups are by `.key` alone, so **bare names collide**: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` each exist **twice**, and `GITEA_TOKEN` exists **twice inside ai-work** (same value today — but a rotation would update one and silently strand the other).
2. **Remapping to a plausible existing name would have been WRONG.** litellm holds `slack-bot-token`, `CLOUDFLARE_TUNNEL_TOKEN`, `POSTGRES_PASSWORD` — a **different service's** credentials (its own tunnel/DB). Name-similarity would have wired the wrong secret into prod. This is exactly the "not a drive-by" risk #278 called out.

## Method — capture live values, never guess
`financial-ingest` uniquely has **both** the bws CLI and every `.env.secrets` value in its env, so the whole operation ran **inside that one container**: secret values never touched a shell, a command line, or a transcript. Dry-run first, existence-checked (no overwrites), names-only output. The running container's env is the only unambiguous source of truth for what open-brain actually uses.

**Created in BWS** (ai-work; additive, none pre-existing): `open-brain-postgres-password`, `open-brain-slack-bot-token`, `open-brain-slack-app-token`, `open-brain-cloudflare-tunnel-token`.

**Remapped here** (BWS-name side only — the ENV-var side is what consumers read and must not move; avoids duplicating a live credential):

| was (invented) | now (real) |
|---|---|
| `open-brain-pushover-app-token` | `PUSHOVER_API_TOKEN` |
| `open-brain-pushover-user-key` | `PUSHOVER_USER_KEY` |
| `dev/open-brain/gitea-token` | `GITEA_TOKEN` |

**Demoted/removed from REQUIRED:** `SLACK_USER_TOKEN` → OPTIONAL (an `xoxp-` channel-cleanup token neither set in prod nor present in BWS — requiring it failed every reconcile for an *unconfigured* feature); `PUSHOVER_TOKEN`/`PUSHOVER_USER` deleted (legacy aliases existing nowhere; `pushover-notify.sh` treats them as a *fallback*). Header count corrected **13 → 11** (the array always held 14).

## The remaining 1 is a different bug — filed separately
**`REDIS_PASSWORD` lives in `.env`, which nothing automates.** Compose interpolates `--requirepass ${REDIS_PASSWORD:?...}` from **`.env`** — `${}` reads `.env`/the shell, **not `env_file:`** — while `load-secrets.sh` writes only `.env.secrets`. After a real rebuild `.env` is absent and the **entire stack fails the `:?` guard**. So this PR moves DR from *"writes nothing"* to *"writes half of what's needed"*; the other half needs its own fix.

Redis auth verified good in passing: an unauthenticated `PING` returns `NOAUTH Authentication required`.

LAB_NOTEBOOK Entry 203. Refs #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)