### PR TITLE
docs: Entry 204 credential sweep + reconcile OPEN_ITEMS to 12 open

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13309,3 +13309,41 @@ AFTER:  DRIFT:  1 of 11                              -> 10/11 OK
 **Lesson:** the previous entry's lesson (a mock fixture agreeing with the code proves nothing) has a sibling here — **`verify-secrets.sh` only ever audited `.env.secrets`, so the `.env` half of the secret surface was never audited by anything at all.** A checker that inspects one of two files reports "1 drift" when the truth is "the stack won't boot."
 **Tags:** [security] [deploy] [decision]
 **Environment:** BWS writes = 4 additive secret creations (ai-work), performed in-container so values never egressed. Map tested against live BWS then reverted on the host. No prod restart, no service touched. Executed by Claude (Opus 4.8), user-directed ("tackle #278").
+
+---
+
+## Entry 204 — Credential-validation sweep: 4 dead integrations found, all reporting success (2026-07-15)  [debug] [pipeline] [security] [api]
+
+**Objective:** Troy asked to validate every email + utility login and file an issue per problem. Deliberately validated by **exercising each login**, not by reading config.
+
+**Result — 4 of 7 surfaces are dead, and every one of them reports success.**
+
+| Surface | Credentials | Pipeline | Issue |
+|---|---|---|---|
+| `troy.davis@hotmail.com` (MSAL) | ✅ silent refresh works | ✅ 20 classified/moved | — |
+| `bond@k4jda.net` (PrivateEmail) | ✅ IMAP **and** SMTP login | ✅ | — |
+| **Gmail** | ❌ `invalid_grant` | ❌ dead since **2026-04-21** | **#282** |
+| Gas South | ✅ | ✅ (Entries 198–200) | — |
+| **Cobb EMC (power)** | ✅ **SmartHub 200 + token** | ❌ **never worked** | **#286** |
+| **Cobb Water** | in BWS, unused | ❌ **401, never worked** | **#285** |
+| **Jetson T1 (LLM)** | ❌ 401 | ❌ dead since **~2026-07-01** | **#283** |
+
+**#283 is the find of the sweep, and it is fleet-wide — not an email bug.** Chasing `Jetson 401` lines in the email log led to `ai_audit_log`: **461 × `401 Invalid API Key`**, with `calls == errors` on **every day since ~07-01** (earlier days succeeded, which dates the change). Two independent callers never learned the Jetson had added auth: `llm-gateway.ts:276` hardcodes `apiKey:'local'` behind the comment *"Local endpoints ignore the key"* — **true when written, false since** — and `email-pipeline.py::classify_by_jetson` sends no header at all. Proved both directions from a container (key never echoed): **without key → 401, with BWS `dev/jetson/llm-api-key` → 200 `"OK"`**. `GET /v1/models` still answers **200 unauthenticated**, which is why the endpoint looks healthy to a casual probe. **Cost impact: none** — `cost_usd` is 0 and no paid chat model appears, so the documented `t1_jetson → t1_fast → t2_quality` fallback is **not** firing (worth understanding: if it ever starts, this is the $100-incident path). **A 100%-failing FREE tier is indistinguishable from an idle one** — that is why two weeks passed unnoticed.
+
+**#286 root cause is worth remembering:** the Dockerfile installs `electric-usage-downloader` from **`typ0/…` — an org that returns 404** — while `utility-config.yaml` has named the real repo (`tedpearson/…`, 51★, v2.4.1) all along. Wrong org **+** wrong version **+** wrong asset format (expects a `.tar.gz`; real assets are raw binaries) **+** a trailing `|| true` binding the whole `&&` chain ⇒ **a green build that ships no binary, for months.** Credentials were never the problem (SmartHub login returns a token). Endpoint taken from the tool's own `internal/app/api.go` (`/services/oauth/auth/v2`), not guessed — my first guess (`/services/oauth2/auth`) 404'd, which is exactly why you read the source.
+
+**#285:** `water_readings` is **empty since day one**. The docstring still claims *"API requires no authentication (confirmed via HAR analysis)"* — true in 2026-04, false now; Entry 047 already knew and the code was never updated.
+
+**THE PATTERN — the actual lesson of this whole session.** #275, #282, #285, #286 all **exit 0 / `status: ok` while doing nothing**:
+- gas → stored bill amounts with NULL therms
+- Gmail → one ERROR line; Hotmail's success carried the run
+- water → `{"status":"ok"}` on a 401
+- power → `{"status":"ok"}` with no binary installed
+
+Four integrations, dead for months, each reporting success. **A pipeline that cannot distinguish "did the work" from "ran without crashing" will hide its own failure indefinitely.** The fix is uniform and cheap: make a no-data outcome flip `status` to `"error"` (as `cmd_gas` now does, #275). Sibling finding: **#284** — ~213 benign 404s per email run from `cleanup_spam()`, which is precisely the noise floor that lets a real error pass unseen.
+
+**Method note (transferable):** every check was an *exercise*, not an inspection — a real Gmail refresh (not "the token file looks old"), a real IMAP+SMTP login, a real SmartHub POST, a real Jetson completion with and without the key. Four of these had config that *looked* fine.
+
+**Docs reconciled:** `OPEN_ITEMS.md` → **12 open**, verified against `gh issue list` (#278 closed → Recently-closed; #281–#286 added).
+**Tags:** [debug] [pipeline] [security] [api]
+**Environment:** Read-only validation across obvm (email cron host), homeserver containers, and live third-party endpoints. No credential values printed, committed, or placed in any issue. Executed by Claude (Opus 4.8), user-directed sweep.

--- a/OPEN_ITEMS.md
+++ b/OPEN_ITEMS.md
@@ -4,7 +4,7 @@
 
 GitHub issues are the single source of truth for all pending work. This file is a quick-reference summary only — close issues there, not here.
 
-Last reconciled: 2026-07-15 (verified against `gh issue list` — 7 open).
+Last reconciled: 2026-07-15 (verified against `gh issue list` — 12 open).
 
 ---
 
@@ -22,11 +22,16 @@ The remaining work is **operator-gated** and tracked in **[`OPERATOR_ACTIONS.md`
 
 ---
 
-## Open issues (7)
+## Open issues (12)
 
 | # | Title | Gate / urgency |
 |---|-------|---------------|
-| [#278](https://github.com/davistroy/open-brain/issues/278) | secrets-map.sh BWS names don't exist (11/14 required) — `load-secrets.sh` would exit 2, **DR path broken** | **New (2026-07-15), HIGH.** Prod is UNAFFECTED (the map is only read on reconcile) — but the documented "rebuild `.env.secrets` after a homeserver rebuild" runbook would write nothing. Confirmed by the repo's own `verify-secrets.sh`: `DRIFT: 11 of 14`. Never caught because `test-secrets-roundtrip.sh` mocks `bws` with the map's OWN names (self-consistent → cannot detect name drift) and no CI job checks real BWS. Needs BWS-project disambiguation (broad token spans 3 projects, D137). Entry 202 / A142. |
+| [#283](https://github.com/davistroy/open-brain/issues/283) | Jetson T1 tier 401s on 100% of calls since ~2026-07-01 | **New (2026-07-15), HIGH — actively degrading.** `llm-gateway.ts:276` hardcodes `apiKey:'local'` ("local endpoints ignore the key" — no longer true); `email-pipeline.py` sends none. 461 × `401 Invalid API Key` in `ai_audit_log`; the 6 classification tasks silently degrade. **No cost leak** (cost_usd 0 — the paid fallback isn't firing). Key exists + verified: BWS `dev/jetson/llm-api-key`. |
+| [#281](https://github.com/davistroy/open-brain/issues/281) | DR gap #2: `.env` is not automated — a rebuilt host cannot start the stack | **New (2026-07-15), HIGH.** `REDIS_PASSWORD` lives only in `.env`; Compose interpolates `${}` from `.env`, never `env_file:`, and `load-secrets.sh` writes only `.env.secrets`. Sibling of #278 (fixed): DR now writes *half* of what's needed. Recovery-only failure. |
+| [#282](https://github.com/davistroy/open-brain/issues/282) | Gmail OAuth dead since 2026-04-21 — `invalid_grant` | **New (2026-07-15).** No Gmail classified/captured in ~3 months; Hotmail masks it so the run still reports success. Almost certainly the OAuth app stuck in "Testing" (7-day refresh expiry, exactly what A31 predicted). Fix = publish the app to "In production", or move Gmail to an App Password over IMAP. **Owner action** (interactive consent). Supersedes OA-12. |
+| [#285](https://github.com/davistroy/open-brain/issues/285) | Cobb Water API returns 401 — auth never implemented | **New (2026-07-15).** `water_readings` has been **empty since day one**. The HAR-era "no authentication required" docstring is now false. Credentials are in BWS but nothing uses them. Fix = the #265 bundle playbook (no HAR needed). |
+| [#286](https://github.com/davistroy/open-brain/issues/286) | Power/Cobb EMC never worked — Dockerfile pulls from a nonexistent repo | **New (2026-07-15).** **Credentials are fine** (SmartHub login → HTTP 200, token). Dockerfile downloads `typ0/electric-usage-downloader` (**404 — org doesn't exist**; config has always said `tedpearson/`), wrong version (0.5.0 vs v2.4.1), wrong asset format, and a trailing `\|\| true` hides the failed download → green build, no binary. `cmd_power_summary` is still a stub. **Decide whether power ingestion is still wanted before investing.** |
+| [#284](https://github.com/davistroy/open-brain/issues/284) | ~213 spurious 404s per email run from Hotmail `cleanup_spam()` | **New (2026-07-15), LOW.** Benign (items already gone) but drowns real errors — the condition that let #275/#282 hide. MS auth itself is healthy. Fix = treat `404 ErrorItemNotFound` as success, like #275's `409`-is-terminal-success. |
 | [#196](https://github.com/davistroy/open-brain/issues/196) | Mobile app deferred scope (PRs #172/#174) | When mobile becomes a priority |
 | [#73](https://github.com/davistroy/open-brain/issues/73)  | P33: Qdrant vector-search evaluation | Scale-gated — fires at ≥50K embeddings |
 | [#72](https://github.com/davistroy/open-brain/issues/72)  | P34: NVIDIA RTX PRO 2000 deployment | Hardware purchase decision |
@@ -42,6 +47,7 @@ The remaining work is **operator-gated** and tracked in **[`OPERATOR_ACTIONS.md`
 
 | # | Closed | Via |
 |---|--------|-----|
+| #278 | 2026-07-15 | secrets-map BWS names corrected + 4 secrets created from live values (PR #280). DR reconcile 11/14-missing → 1/11. Remaining drift row is #281, a different bug. Entry 203 |
 | #275 | 2026-07-15 | gas therms NULL — bill-PDF parser rewritten to anchor on the bill's arithmetic + PyMuPDF added to the sidecar image (PR #276). **Verified in prod: 4/4 bills, 153.6 therms.** Entry 200 |
 | #265 | 2026-07-15 | Gas South login 405/404 — auth repointed at the portal's dedicated auth host + required `ClientId` header (PR #273). Solved from the JS bundle, **no HAR needed**. Verified with real credentials. Entries 198-199 |
 | #200 | 2026-07-14 | Dashboard failure count — honest pipeline-status display, `derivePipelineStatus()` decouples health from stale failures (PR #271). Verified live |


### PR DESCRIPTION
Docs-only. Records the credential-validation sweep and reconciles the registry.

**4 of 7 surfaces are dead — and every one reports success.**

| Surface | Credentials | Pipeline | Issue |
|---|---|---|---|
| `troy.davis@hotmail.com` | ✅ | ✅ | — |
| `bond@k4jda.net` | ✅ IMAP+SMTP | ✅ | — |
| **Gmail** | ❌ `invalid_grant` | dead since **2026-04-21** | #282 |
| Gas South | ✅ | ✅ | — |
| **Cobb EMC** | ✅ **login works** | **never worked** | #286 |
| **Cobb Water** | in BWS, unused | **401, never worked** | #285 |
| **Jetson T1** | ❌ 401 | dead since **~2026-07-01** | #283 |

**#283 is fleet-wide, not an email bug.** 461 × `401 Invalid API Key` in `ai_audit_log`, `calls == errors` every day since ~07-01. `llm-gateway.ts:276` hardcodes `apiKey:'local'` behind *"Local endpoints ignore the key"* — true when written, false since the Jetson added auth. No cost leak (`cost_usd` 0 — the paid fallback isn't firing). A 100%-failing **free** tier is indistinguishable from an idle one.

**#286** is the Dockerfile pulling from `typ0/electric-usage-downloader` (**404 — org does not exist**) while the config has always named `tedpearson/`. Wrong org + wrong version + wrong asset format + `|| true` over the whole `&&` chain = a green build shipping no binary, for months. Credentials were never the problem.

**The pattern (#275/#282/#285/#286):** all exit `status: ok` while doing nothing. A pipeline that cannot distinguish "did the work" from "ran without crashing" hides its own failure indefinitely. #284 is the matching noise floor (~213 benign 404s/run).

Every check was an **exercise, not an inspection** — a real refresh, a real IMAP/SMTP login, a real SmartHub POST, a real Jetson completion with and without the key. Four had config that looked fine.

`OPEN_ITEMS.md`: 7 → **12 open**, verified against `gh issue list`. No credential values appear in any issue or file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)