### PR TITLE
fix(llm): authenticate the Jetson T1 tier via api_key_env (#283)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13309,3 +13309,26 @@ AFTER:  DRIFT:  1 of 11                              -> 10/11 OK
 **Lesson:** the previous entry's lesson (a mock fixture agreeing with the code proves nothing) has a sibling here — **`verify-secrets.sh` only ever audited `.env.secrets`, so the `.env` half of the secret surface was never audited by anything at all.** A checker that inspects one of two files reports "1 drift" when the truth is "the stack won't boot."
 **Tags:** [security] [deploy] [decision]
 **Environment:** BWS writes = 4 additive secret creations (ai-work), performed in-container so values never egressed. Map tested against live BWS then reverted on the host. No prod restart, no service touched. Executed by Claude (Opus 4.8), user-directed ("tackle #278").
+
+---
+
+## Entry 205 — #283 fix: Jetson T1 auth — tier-scoped `api_key_env` + email-pipeline header (2026-07-15)  [config] [pipeline] [security] [decision]
+
+**Objective:** Close #283 — the Jetson (T1) tier has 401'd on **100% of calls since ~2026-07-01** (461 × `401 Invalid API Key` in `ai_audit_log`; `calls == errors` every day). The Jetson added API-key auth; **two independent callers never learned.** Troy: "Take 283 and fix it."
+
+**Root cause (already proven, Entry 204):** `llm-gateway.ts:276` hardcodes `apiKey: 'local'` behind the comment *"Local endpoints ignore the key but SDK requires non-empty"* — **true when written, false since the Jetson added auth**; and `email-pipeline.py::classify_by_jetson` sends **no `Authorization` header at all**. Live-proved both directions from a container: **no key → 401; BWS `dev/jetson/llm-api-key` → 200 `"OK"`.**
+
+**Design decisions:**
+- **`api_key_env` (a VAR NAME), not `api_key` (a value), in `ai-routing.yaml`.** `config/` is committed to a PUBLIC repo — a key must never live there (CLAUDE.md: all secrets in Bitwarden). The tier declares which env var holds its key; the gateway resolves it at call time. Keeps the tier self-describing without the config knowing any secret.
+- **Tier-scoped, not global.** A single `JETSON_API_KEY` read inside the gateway would break the moment a second `openai_compat` endpoint needs a *different* key (Spark already exists as one). Resolving per-tier is the same cost and doesn't have that cliff.
+- **`'local'` stays as the fallback, not the default.** Genuinely keyless endpoints (ollama, and Spark today — `spark-llm` shows **0 errors**, so it needs no key) still work untouched. Only tiers that *declare* `api_key_env` change behaviour → blast radius is exactly t1_jetson.
+- **REQUIRED, not OPTIONAL, in `secrets-map.sh`.** The secret exists in BWS, and its absence **silently kills T1** — which is the entire bug. OPTIONAL ("written if present, silently skipped if not") would re-create the failure mode this fix exists to remove. Cost: `.env.secrets` must carry it or `verify-secrets` drift goes 1→2 — acceptable, since deploying it is part of this change.
+- **email-pipeline reads `JETSON_API_KEY` from the env, NOT bws.** The VM has **no `bws` CLI and no `.env`** (verified — its only credentials are the MSAL/Gmail token-cache files). Adding bws + a machine token to the VM is real operator surface for one key; an env var the cron provides is smaller and reversible.
+
+**Hypothesis / success criteria:** after deploy, `ai_audit_log` shows `qwen3.5-4b` calls with **`errors = 0`** (today: 100%), and the next email run logs a non-zero `llm=` classification count instead of `Jetson 401` + `llm=0, unclass=10`. **Falsifiable:** if 401s persist, the key is wrong/rotated, not the wiring.
+
+**Explicitly NOT in scope:** why the documented `t1_jetson → t1_fast → t2_quality` fallback never fired. It *should* have sent these to paid Claude — and did not (`cost_usd` 0, no paid chat model in 30d). That is lucky (no $100-incident repeat) but it means the fallback chain is **also** broken, and a working T1 will now mask it again. Filed as a separate follow-up; fixing both at once would confound the verification.
+
+**Rollback:** `git revert`; the gateway falls back to `'local'` when `api_key_env` is absent/unset, so reverting the config alone restores exact prior behaviour. No migration, no data. Prod impact limited to workers/core-api recreate.
+
+**Status:** IN PROGRESS — see result below.

--- a/config/ai-routing.yaml
+++ b/config/ai-routing.yaml
@@ -97,6 +97,11 @@ model_tiers:
     provider: openai_compat
     model: "qwen3.5-4b"
     base_url: "http://192.168.10.58:8080/v1"
+    # The Jetson requires a bearer token on /chat/completions (note /v1/models is
+    # still open, so the endpoint LOOKS healthy unauthenticated). This names the env
+    # var holding the key — never the key itself; this file is in a public repo.
+    # Value: BWS `dev/jetson/llm-api-key` -> JETSON_API_KEY in .env.secrets. (#283)
+    api_key_env: JETSON_API_KEY
     max_completion_tokens: 256
     timeout_ms: 5000
     cost_per_1k_input: 0    # Free local GPU -- explicit 0 keeps budget accounting non-blind

--- a/deploy/.env.secrets.template
+++ b/deploy/.env.secrets.template
@@ -35,6 +35,17 @@ REDIS_PASSWORD=
 OPENAI_API_KEY=
 
 # -----------------------------------------------------------------------------
+# Jetson T1 (local classification LLM)
+# -----------------------------------------------------------------------------
+# Used by: workers + core-api (via the t1_jetson tier's api_key_env in
+#          config/ai-routing.yaml) and scripts/email-pipeline.py on obvm.
+# The Jetson requires a bearer token on /chat/completions. Note /v1/models stays
+# open, so an unauthenticated probe makes the endpoint look healthy — it is not.
+# Without this, the whole T1 tier 401s silently and classification degrades (#283).
+# Bitwarden: dev/jetson/llm-api-key
+JETSON_API_KEY=
+
+# -----------------------------------------------------------------------------
 # MCP / Admin Authentication
 # -----------------------------------------------------------------------------
 # Used by: core-api (Bearer token for MCP endpoint + admin endpoints)

--- a/packages/shared/src/services/__tests__/llm-gateway.test.ts
+++ b/packages/shared/src/services/__tests__/llm-gateway.test.ts
@@ -17,6 +17,7 @@ function mkTier(overrides: Partial<ModelTierEntry> & { model: string; provider: 
     provider: overrides.provider,
     model: overrides.model,
     base_url: overrides.base_url,
+    api_key_env: overrides.api_key_env,
     max_completion_tokens: overrides.max_completion_tokens ?? 4096,
     timeout_ms: overrides.timeout_ms ?? 60_000,
     fallback: overrides.fallback ?? null,
@@ -112,6 +113,71 @@ describe('LLMGatewayService.resolveAgentClient', () => {
     )
 
     expect(() => gateway.resolveAgentClient('unknown_task')).toThrow(ModelResolverError)
+  })
+
+  // -------------------------------------------------------------------------
+  // #283 — openai_compat tier auth.
+  //
+  // The Jetson added a bearer requirement on /chat/completions and the gateway
+  // kept sending a hardcoded apiKey:'local' ("local endpoints ignore the key").
+  // Result: 401 on 100% of T1 calls for two weeks, invisible because a totally
+  // failing FREE tier looks exactly like an idle one (cost stays $0, and
+  // /v1/models still answers 200 unauthenticated).
+  //
+  // getClientForTier is private; reached via bracket access because the apiKey it
+  // puts on the client IS the behaviour under test.
+  // -------------------------------------------------------------------------
+  function clientFor(tier: ModelTierEntry, tierKey: string): { apiKey: string } {
+    const gateway = new LLMGatewayService(
+      makeConfigService({ [tierKey]: tier }, {}),
+      makeDb().db,
+      makeTemplateCache(),
+      makeAnthropicClient(),
+      null,
+      null,
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (gateway as any).getClientForTier(tier, tierKey, 'openai') as { apiKey: string }
+  }
+
+  it('sends the tier api_key_env value as the bearer key (#283)', () => {
+    process.env.TEST_JETSON_KEY_283 = 'sk-jetson-secret'
+    const tier = mkTier({
+      model: 'qwen3.5-4b',
+      provider: 'openai_compat',
+      base_url: 'http://jetson:8080/v1',
+      api_key_env: 'TEST_JETSON_KEY_283',
+    })
+
+    expect(clientFor(tier, 't1_jetson_withkey').apiKey).toBe('sk-jetson-secret')
+    delete process.env.TEST_JETSON_KEY_283
+  })
+
+  it("falls back to 'local' when a tier declares api_key_env but it is unset (#283)", () => {
+    delete process.env.TEST_MISSING_KEY_283
+    const tier = mkTier({
+      model: 'qwen3.5-4b',
+      provider: 'openai_compat',
+      base_url: 'http://jetson:8080/v1',
+      api_key_env: 'TEST_MISSING_KEY_283',
+    })
+
+    // Still constructs (the SDK requires a non-empty key) — the gateway warns
+    // rather than throwing, so an unset key degrades exactly like before instead
+    // of taking the process down.
+    expect(clientFor(tier, 't1_jetson_nokey').apiKey).toBe('local')
+  })
+
+  it("keeps 'local' for keyless openai_compat tiers that declare no api_key_env (#283)", () => {
+    // Spark is genuinely keyless today (0 errors in ai_audit_log) — this pins
+    // that the fix's blast radius is only tiers that opt in.
+    const tier = mkTier({
+      model: 'qwen-35b',
+      provider: 'openai_compat',
+      base_url: 'http://spark:8000',
+    })
+
+    expect(clientFor(tier, 't1_spark_keyless').apiKey).toBe('local')
   })
 
   it('excludes cross-provider tiers from the fallback chain', () => {

--- a/packages/shared/src/services/llm-gateway.ts
+++ b/packages/shared/src/services/llm-gateway.ts
@@ -271,15 +271,36 @@ export class LLMGatewayService {
       if (cached) return cached
 
       const normalizedURL = tier.base_url.endsWith('/v1') ? tier.base_url : `${tier.base_url}/v1`
+
+      // Resolve the tier's key from the env var it names. Keys are never in
+      // config (public repo) — the tier only declares WHICH var holds it.
+      //
+      // `'local'` remains the fallback for genuinely keyless endpoints, but is
+      // no longer the default: it was hardcoded here behind "local endpoints
+      // ignore the key", which stopped being true when the Jetson added auth and
+      // 401'd 100% of T1 calls for two weeks without anyone noticing (#283). A
+      // free tier failing totally looks exactly like an idle one.
+      const apiKey = tier.api_key_env ? process.env[tier.api_key_env] : undefined
+      if (tier.api_key_env && !apiKey) {
+        logger.warn(
+          { tierKey, apiKeyEnv: tier.api_key_env },
+          `Tier '${tierKey}' declares api_key_env='${tier.api_key_env}' but it is unset — ` +
+            `requests will be sent unauthenticated and will fail if the endpoint requires a key`,
+        )
+      }
+
       const client = new OpenAI({
         baseURL: normalizedURL,
-        apiKey: 'local',  // Local endpoints ignore the key but SDK requires non-empty
+        apiKey: apiKey || 'local',  // SDK requires non-empty; 'local' = keyless endpoint
         timeout: tier.timeout_ms,
         maxRetries: 0,  // Fail fast — let the fallback chain handle retries
       })
 
       this.tierClientCache.set(tierKey, client)
-      logger.info({ tierKey, baseUrl: normalizedURL }, `Created cached client for tier '${tierKey}'`)
+      logger.info(
+        { tierKey, baseUrl: normalizedURL, authenticated: Boolean(apiKey) },
+        `Created cached client for tier '${tierKey}'`,
+      )
       return client
     }
 

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -96,6 +96,17 @@ export const ModelTierEntrySchema = z.object({
   provider: z.enum(['anthropic', 'litellm', 'ollama', 'openai', 'openai_compat', 'deepseek']),
   model: z.string(),
   base_url: z.string().optional(),
+  /**
+   * Name of the env var holding this tier's API key — NOT the key itself.
+   * `config/` is committed to a public repo, so a value must never appear here
+   * (all secrets live in Bitwarden; see CLAUDE.md).
+   *
+   * Omit for genuinely keyless endpoints (ollama, and Spark today). When set,
+   * the gateway sends the env var's value as the bearer token instead of the
+   * placeholder `'local'`. Introduced by #283: the Jetson added auth and the
+   * hardcoded `'local'` 401'd 100% of T1 calls for two weeks, silently.
+   */
+  api_key_env: z.string().optional(),
   max_completion_tokens: z.number(),
   timeout_ms: z.number(),
   fallback: z.string().nullable().default(null),

--- a/scripts/email-pipeline.py
+++ b/scripts/email-pipeline.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import re
 import sqlite3
 import subprocess
@@ -619,8 +620,21 @@ def classify_by_jetson(
     email: dict[str, Any],
     cfg: dict[str, Any],
 ) -> tuple[str, float, str] | None:
-    """T1: Jetson LLM classification. Returns (category, confidence, 'jetson')."""
+    """T1: Jetson LLM classification. Returns (category, confidence, 'jetson').
+
+    The Jetson requires a bearer token on /chat/completions (`JETSON_API_KEY`,
+    Bitwarden `dev/jetson/llm-api-key`). Note `/v1/models` is still served
+    unauthenticated, so the endpoint looks healthy to a casual probe while every
+    completion 401s — which is exactly how this went unnoticed for two weeks
+    (#283). Without the key every email silently falls through to unclassified.
+    """
     jcfg: dict[str, Any] = cfg.get("jetson", {})
+    api_key = os.environ.get("JETSON_API_KEY", "")
+    if not api_key:
+        log.warning(
+            "JETSON_API_KEY not set — Jetson classification will 401 and every email "
+            "will fall through to unclassified. Set it from Bitwarden dev/jetson/llm-api-key."
+        )
     cats = sorted(cfg["_categories"])
     prompt = (
         f"Classify this email into exactly one of these categories:\n{json.dumps(cats)}\n\n"
@@ -640,8 +654,15 @@ def classify_by_jetson(
                 "max_completion_tokens": jcfg.get("max_completion_tokens", 256),
                 "temperature": jcfg.get("temperature", 0.1),
             },
+            headers={"Authorization": f"Bearer {api_key}"} if api_key else {},
             timeout=jcfg.get("timeout", 90),
         )
+        if resp.status_code == 401:
+            log.error(
+                "Jetson 401 Invalid API Key — JETSON_API_KEY is missing or stale. "
+                "All classification is falling through to unclassified. (#283)"
+            )
+            return None
         if resp.status_code != 200:
             log.warning(f"Jetson {resp.status_code}: {resp.text[:200]}")
             return None

--- a/scripts/lib/secrets-map.sh
+++ b/scripts/lib/secrets-map.sh
@@ -29,7 +29,7 @@ fi
 unset _bash_major
 
 # -----------------------------------------------------------------------------
-# REQUIRED secrets (11) — must be present in BWS or reconcile fails.
+# REQUIRED secrets (12) — must be present in BWS or reconcile fails.
 # Map: BWS_SECRET_NAME -> ENV_VAR_NAME
 #
 # The BWS-name column is NOT a convention — it is whatever the secret is
@@ -56,6 +56,10 @@ declare -A REQUIRED_SECRETS=(
   ["PUSHOVER_USER_KEY"]="PUSHOVER_USER_KEY"
   ["GITEA_TOKEN"]="GITEA_TOKEN"
   ["open-brain-cloudflare-tunnel-token"]="CLOUDFLARE_TUNNEL_TOKEN"
+  # REQUIRED, not optional: the secret exists in BWS, and its absence silently
+  # kills the whole T1 tier (#283 — 401 on 100% of calls for two weeks, unnoticed
+  # because a totally-failing FREE tier looks identical to an idle one).
+  ["dev/jetson/llm-api-key"]="JETSON_API_KEY"
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The Jetson added a bearer requirement on `/chat/completions` and **two independent callers never learned**. Every T1 call has 401'd since ~2026-07-01 — **461 × `401 Invalid API Key`** in `ai_audit_log`, with `calls == errors` every single day.

It stayed invisible for two weeks because **a totally-failing FREE tier looks exactly like an idle one**: `cost_usd` stays 0, nothing alerts, and `/v1/models` is *still served unauthenticated* so the endpoint looks healthy to a casual probe.

## Two fixes

**1. `llm-gateway.ts` hardcoded `apiKey: 'local'`** behind the comment *"Local endpoints ignore the key but SDK requires non-empty"* — true when written, false since. Tiers now declare **`api_key_env`**: the *name* of the env var holding the key, never the key itself, because `config/` is a **public repo**.

- `'local'` stays the **fallback**, not the default → genuinely keyless endpoints (ollama; Spark, which shows **0 errors**) are untouched. Blast radius = exactly the tiers that opt in.
- Resolved **per-tier**, not one global `JETSON_API_KEY` — a global breaks the moment a second `openai_compat` endpoint needs a different key, and Spark already exists as one.
- An unset-but-declared key **warns and degrades** rather than throwing, so a missing key can never take the process down.

**2. `email-pipeline.py::classify_by_jetson` sent no `Authorization` header at all** → every email fell through to unclassified (`llm=0, unclass=10` of 20 today). Now sends the key and reports a 401 as an **ERROR naming the cause** instead of a generic warning.

`JETSON_API_KEY` added to `secrets-map.sh` (**REQUIRED**) + `.env.secrets.template` — the 3-step lockstep. Required is deliberate: the secret exists in BWS, and *"silently skipped if absent"* is precisely the failure mode this fix removes.

## Verification
- **Live, from a container** (key never echoed): no key → **401**; BWS `dev/jetson/llm-api-key` → **200 `"OK"`**.
- **3 new gateway tests, proven red-green** — restoring the old hardcoded `'local'` makes the `api_key_env` test **fail (×)**; the fix makes it pass. The other two pin that an unset key and a keyless tier both still degrade to `'local'`.
- shared **371/371**, workers + core-api `tsc` clean, ruff clean, secrets round-trip **7/7** (its keyset derives from the map, so the new REQUIRED entry flows through automatically).

## Deploy (after merge)
1. Add `JETSON_API_KEY` to `.env.secrets` (backup first), recreate `workers` + `core-api`.
2. Provide it to the `obvm` email cron — **the VM has no `bws` CLI and no `.env`** (its only credentials are the MSAL/Gmail token caches), which is exactly why this reads an env var rather than calling bws.
3. **Success = `ai_audit_log` shows `qwen3.5-4b` with `errors = 0`** (today: 100%), and the next email run logs a non-zero `llm=` count.

## Not in scope — filed separately
The `t1_jetson → t1_fast → t2_quality` fallback **never fired** for any of those 461 failures. That is *why* there was no cost leak (lucky), but it means the fallback chain is **also broken** — and a working T1 will mask it again. Fixing both at once would confound this verification.

LAB_NOTEBOOK Entry 205. Closes #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)