### PR TITLE
feat(observability): alert when an outbound provider is failing (#289)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13354,3 +13354,58 @@ RESULT: SUCCESS — T1 classification is alive
 
 **Tags:** [config] [pipeline] [security] [decision]
 **Environment:** homeserver (workers+core-api recreated; `.env.secrets` backed up) + obvm (0600 env file, crontab backed up, script backed up). postgres/redis untouched. No secret value printed, committed, or placed in an issue. Executed by Claude (Opus 4.8), user-directed.
+
+---
+
+## Entry 206 — #289: the fallback is NOT broken — it saved money. I was wrong 3× getting there (2026-07-15)  [debug] [observability] [decision]
+
+**Objective:** Investigate #289 — "the documented `t1_jetson → t1_fast → t2_quality` fallback never fired for 461 T1 failures." Troy: "pick up #289 now."
+
+**VERDICT: #289's premise is WRONG. The fallback is working exactly as designed, and its refusal to fire is the reason there was no cost leak.** I filed that issue on a hypothesis and the code disagreed. Recording the three wrong turns, because the *method* failure is the transferable part.
+
+**Wrong turn 1 — the same-provider filter (my filed hypothesis).** #289 speculated `sameProviderChain = fullChain.filter(...)` silently emptied the chain. It does not: that filter lives ONLY in `resolveAgentClient` (the agent/tool_use path). Classification goes through `completeWithTierFallback`, a different path with its own gate.
+
+**Wrong turn 2 — "t1_jetson declares no fallback".** Asserted mid-investigation from `grep -A 14`. **False** — and false because *my own #283 comments* had pushed the field outside the window. Parsing the YAML settled it:
+| tier | provider | fallback (ACTUAL) |
+|---|---|---|
+| t0_local | ollama | t1_jetson |
+| **t1_jetson** | openai_compat | **t1_spark** |
+| t1_spark | openai_compat | t1_fast |
+| t1_fast | anthropic | t2_quality |
+The chain exists, is correctly wired, and is not filtered.
+
+**Wrong turn 3 — "`recordOutbound` has ZERO call sites; CLAUDE.md line 39 is FALSE."** I nearly wrote that into an issue. **The call sites exist** — they use the **`timeOutboundCall`** wrapper (which calls `recordOutbound` internally), so grepping the inner function name found nothing:
+```
+embedding.ts:152   timeOutboundCall('openai', 'embedding', …)
+embedding.ts:221   timeOutboundCall('openai', 'embedding_batch', …)
+llm-gateway.ts:512 timeOutboundCall(provider ?? 'openai', 'chat', …)
+llm-gateway.ts:740 timeOutboundCall('anthropic', 'chat', …)
+```
+**CLAUDE.md was right; I was wrong.** Three grep-window/name errors in one day (this + the stale-config near-miss in Entry 205). **`grep -A N` is not a substitute for parsing the artifact, and grepping an inner helper is not a substitute for finding its wrapper.**
+
+**THE ACTUAL ANSWER — `shouldAttemptFallback` (llm-gateway.ts:766), documented *"Only on transient server errors — not on client errors or budget issues"*:**
+```ts
+return /429|500|502|503|rate.limit|overloaded|timeout|ECONNREFUSED|ETIMEDOUT/i.test(msg)
+```
+**401 is deliberately absent.** An auth misconfiguration **fails fast instead of silently escalating to PAID Claude.** Had 401 matched, 461 calls × 2 weeks would have quietly re-routed to `t1_fast` (Haiku) — **precisely the 2026-04-15 $100-incident shape.** The config comment ("*If Jetson is down, fallback chain…*") describes an **outage** — `ECONNREFUSED`/`timeout`, which ARE matched. **Down → falls back. Misconfigured → fails loudly.** That distinction is correct and must not be "fixed". A second mechanism working correctly is what contained the first one's blast radius.
+
+**Why Prometheus showed nothing (also not a bug):** `openbrain_outbound_requests_total` has **no data points in 14 days**, while `openbrain_container_healthy` does — so the workers→Pushgateway→Prometheus path demonstrably works (proved live by triggering `container-health`: `job="open-brain"` metrics appeared immediately). The outbound metric is empty because **IA-M4 shipped in PR #244, deployed ~2026-07-14 — and the last LLM call was 2026-07-13.** The instrumentation is newer than the traffic. Not broken; just never yet exercised.
+
+**THE REAL GAP (narrow, and worth fixing): nothing alerts on it.** `grep -rn outbound config/prometheus/` → **no rule**. So even once the metric flows, a provider stuck at 100% 4xx pages nobody. That is the *entire* reason #283 lived two weeks: **a free tier failing totally is indistinguishable from an idle one** — cost stays $0, no fallback fires (correctly), and the one signal that could show it has no watcher. Note the delivery model (documented in budget.yml): **no Alertmanager** — Prometheus rules are Grafana/Alerts-tab visibility, while real notification is application-layer Pushover from workers skills.
+
+**Fix:** add `config/prometheus/alerts/outbound.yml` — a ratio alert on `status_class=~"4xx|5xx|error"` over total, per `{provider, operation}`. Ratio (not count) is the right shape: it fires on *sustained total failure* regardless of volume, and a zero-traffic idle tier yields `0/0` → no alert, so idleness stays quiet. `for:` long enough to ride out a transient blip.
+
+**Status:** ✅ **RESOLVED — #289 closed as WORKING AS DESIGNED; the real gap (no watcher) fixed with an alert rule.**
+
+**Shipped:** `config/prometheus/alerts/outbound.yml` (2 rules) + `docs/runbooks/outbound-alert.md`.
+- **`OutboundProviderFailing`** (warning): >50% of `{provider, operation}` calls failing over 30m.
+- **`OutboundProviderTotallyFailing`** (critical): **100% failing with real traffic** over 15m — the literal #283 signature (a tier that has not served ONE successful call is broken, not degraded).
+
+**Verified — and the CI gate alone was NOT enough.** `scripts/validate-alert-rules.sh` passed (9/9), but it falls back to `python3 yaml.safe_load()` when promtool is absent (which it is, in CI) → **that checks YAML syntax, not PromQL**. A semantically broken rule would have merged green. So both expressions were executed against the **live Prometheus** API: `status=success` for each. This is the same lesson as #275/#278 one more time — **a passing check that cannot test the thing you changed is not evidence.**
+
+**The runbook leads with the trap that cost two weeks:** `GET /v1/models` answers **200 unauthenticated** while `/chat/completions` 401s, so "the endpoint is up" proves nothing — it documents the real 3-link check (bind-mounted config → env var → an actual completion), and says **use `grep -c`, not `grep -A N`**, since a too-small window produced a wrong answer twice today.
+
+**Honest scope — what this does NOT do:** there is **no Alertmanager** in this deployment (documented in budget.yml), so these rules are **Grafana/Alerts-tab visibility only — they will not page anyone.** Every operational alert that actually reaches Troy's phone is application-layer Pushover from a workers skill. So this rule makes the failure *visible*, not *loud*. Recorded as a known gap in the runbook with the concrete next step (add a check to `pipeline-health`, which already owns the backup dead-man's switch — not wiring Alertmanager). Claiming otherwise would repeat the exact sin this entry is about.
+
+**Tags:** [debug] [observability] [decision]
+**Environment:** Read-only investigation across llm-gateway/config/Prometheus/Pushgateway; live PromQL validation. One prod side-effect: triggered `container-health` (a normal 15m job) to prove the push path. No deploy — the rules ship with the next config sync. Executed by Claude (Opus 4.8), user-directed.

--- a/config/prometheus/alerts/outbound.yml
+++ b/config/prometheus/alerts/outbound.yml
@@ -1,0 +1,75 @@
+# Prometheus alert rules — outbound dependency health (LLM + embeddings)
+# Metric source: openbrain_outbound_requests_total{provider, operation, status_class}
+#   - core-api: scrape registry at core-api:3000/metrics
+#   - workers:  pushed to Pushgateway (piggybacked on container-health / pipeline-health)
+# Recorded via timeOutboundCall() at 4 sites: llm-gateway.ts (openai-compatible chat,
+# anthropic messages) and embedding.ts (embedding, embedding_batch).
+#
+# WHY THIS EXISTS (#289 / #283): the Jetson T1 tier returned 401 on 100% of calls for
+# two weeks and nobody noticed. Every other safeguard behaved correctly and none of
+# them could surface it:
+#   - the tier fallback deliberately does NOT fire on 401 (auth errors are not
+#     transient — see shouldAttemptFallback), which is what PREVENTED a silent
+#     escalation to paid Claude. Correct, but silent.
+#   - the budget alerts never fired, because a FREE tier failing costs $0.
+#   - ai_audit_log recorded all 461 errors — but nothing reads it for alerting.
+# A totally-failing free tier is indistinguishable from an idle one. This rule is
+# the missing watcher.
+#
+# WHY A RATIO, NOT A COUNT: it fires on sustained *total* failure regardless of call
+# volume, and an idle tier yields 0/0 (no series) rather than a false alarm. A raw
+# count would page on a burst of retries and stay quiet on a low-volume tier that is
+# 100% broken — exactly backwards for this failure mode.
+#
+# ALERT DELIVERY MODEL: no Alertmanager is configured (prometheus.yml has no
+# alerting: block). These rules surface in the Prometheus Alerts tab and Grafana
+# panels only — they do NOT dispatch notifications. Operational push notifications
+# come from application-layer code in workers (PushoverService). If this class of
+# outage needs to reach a phone, that belongs in a skill, not here.
+
+groups:
+  - name: open-brain-outbound
+    interval: 5m
+    rules:
+      - alert: OutboundProviderFailing
+        # >50% of calls to a provider/operation failing over 30m. Catches a
+        # misconfigured or dead dependency that costs nothing and therefore trips
+        # no budget alert.
+        expr: >
+          sum by (provider, operation) (rate(openbrain_outbound_requests_total{status_class=~"4xx|5xx|error"}[30m]))
+          /
+          sum by (provider, operation) (rate(openbrain_outbound_requests_total[30m]))
+          > 0.5
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.provider }}/{{ $labels.operation }} failing {{ $value | humanizePercentage }} of calls"
+          description: >
+            More than half of outbound {{ $labels.operation }} calls to
+            {{ $labels.provider }} have failed for 30m. A free tier (openai_compat =
+            Jetson/Spark) can fail 100% at zero cost, so budget alerts will NOT catch
+            this. Check ai_audit_log for the error text, and remember /v1/models may
+            still answer 200 unauthenticated while completions 401 (#283).
+          runbook: "docs/runbooks/outbound-alert.md"
+
+      - alert: OutboundProviderTotallyFailing
+        # 100% failure with real traffic = the #283 signature. Separate, louder rule:
+        # a tier that has not served a single successful call is broken, not degraded.
+        expr: >
+          sum by (provider, operation) (rate(openbrain_outbound_requests_total{status_class=~"4xx|5xx|error"}[15m]))
+          /
+          sum by (provider, operation) (rate(openbrain_outbound_requests_total[15m]))
+          >= 1
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.provider }}/{{ $labels.operation }} — 100% of calls failing"
+          description: >
+            Every outbound {{ $labels.operation }} call to {{ $labels.provider }} has
+            failed for 15m — no successful call at all. This is the #283 signature
+            (Jetson 401 Invalid API Key on every request for two weeks). Verify the
+            tier's api_key_env in config/ai-routing.yaml resolves in the running
+            container, and that the key itself is still valid.
+          runbook: "docs/runbooks/outbound-alert.md"

--- a/docs/runbooks/outbound-alert.md
+++ b/docs/runbooks/outbound-alert.md
@@ -1,0 +1,86 @@
+# Runbook: Outbound Dependency Failing
+
+**Alerts:** `OutboundProviderFailing` (warning), `OutboundProviderTotallyFailing` (critical)
+**Metric:** `openbrain_outbound_requests_total{provider, operation, status_class}`
+**Rule file:** `config/prometheus/alerts/outbound.yml`
+**Recorded by:** `timeOutboundCall()` at 4 sites — `llm-gateway.ts` (openai-compatible `chat`, anthropic `chat`) and `embedding.ts` (`embedding`, `embedding_batch`)
+**Delivery:** Prometheus Alerts tab / Grafana only — **no Alertmanager** in this deployment. There is currently **no Pushover path** for this alert (see Gaps).
+
+---
+
+## Alert conditions
+
+| Alert | Threshold | Severity |
+|-------|-----------|----------|
+| `OutboundProviderFailing` | >50% of calls to a `{provider, operation}` failing, sustained 30m | warning |
+| `OutboundProviderTotallyFailing` | 100% failing (zero successes) with real traffic, sustained 15m | critical |
+
+**Why this exists (#289):** the Jetson T1 tier returned `401 Invalid API Key` on **100% of calls for two weeks** (#283) and nothing surfaced it. Every other safeguard behaved *correctly* and none could see it:
+
+- **The tier fallback deliberately does not fire on 401.** `shouldAttemptFallback` matches only transient errors (`429|5xx|timeout|ECONNREFUSED`). An auth error is a permanent misconfiguration, so failing fast is right — it is exactly what stopped 461 calls silently escalating to paid Claude (the 2026-04-15 $100 incident shape). Correct, but silent.
+- **Budget alerts never fired**, because a **free** tier failing costs **$0**.
+- **`ai_audit_log` recorded all 461 errors** — but nothing reads it for alerting.
+
+**A totally-failing free tier is indistinguishable from an idle one.** This rule is the missing watcher.
+
+**Why a ratio, not a count:** it fires on sustained *total* failure regardless of call volume, and an idle tier yields `0/0` (no series) instead of a false alarm. A raw count would page on a burst of retries yet stay quiet on a low-volume tier that is 100% broken — backwards for this failure mode.
+
+---
+
+## Triage
+
+1. **Identify the provider/operation** from the alert labels. `provider=openai_compat` means a local tier (Jetson `t1_jetson` or Spark `t1_spark`); `openai`/`anthropic` are paid.
+
+2. **Get the actual error text** — the metric only carries a `status_class`. The detail is in the DB:
+   ```sql
+   SELECT model, task_type, left(error, 80) AS err, COUNT(*), MAX(created_at)
+   FROM ai_audit_log
+   WHERE error IS NOT NULL AND created_at > now() - interval '1 hour'
+   GROUP BY 1,2,3 ORDER BY 4 DESC;
+   ```
+
+3. **If `4xx` on a local tier — suspect auth first.** This is the #283 signature.
+   > ⚠️ **`GET /v1/models` still answers `200` unauthenticated while `/chat/completions` 401s.** A "the endpoint is up" probe proves nothing. Test a real completion:
+   ```bash
+   # 401 without the key, 200 with it → the key is the problem, not the endpoint
+   docker exec open-brain-workers node -e '
+     fetch("http://192.168.10.58:8080/v1/chat/completions", {
+       method: "POST",
+       headers: { "Content-Type": "application/json", Authorization: "Bearer " + process.env.JETSON_API_KEY },
+       body: JSON.stringify({ model: "qwen3.5-4b", messages: [{role:"user",content:"say ok"}], max_completion_tokens: 8 }),
+     }).then(async r => console.log(r.status, (await r.text()).slice(0,80)))'
+   ```
+   Then verify the wiring, which has three links — check each, do not assume:
+   ```bash
+   # 1. does the container SEE api_key_env? (config/ is BIND-MOUNTED — the image is not enough)
+   docker exec open-brain-workers grep -c api_key_env /app/config/ai-routing.yaml
+   # 2. is the env var actually set in the process?
+   docker exec open-brain-workers sh -c 'test -n "$JETSON_API_KEY" && echo SET || echo MISSING'
+   # 3. (above) does a real completion succeed with it?
+   ```
+   **Use `grep -c`, not `grep -A N`** — a too-small window has twice produced a wrong answer here (Entries 205/206).
+
+4. **If `5xx`/`error` on a local tier — it is an outage, not a misconfiguration.** The fallback chain (`t1_jetson → t1_spark → t1_fast → t2_quality`) *does* fire on these, so work should still be completing via Spark. Confirm the box is up; expect `t1_fast` (paid Haiku) to start costing money if Spark is down too — watch `openbrain_budget_spent_usd`.
+
+5. **If `4xx` on `openai`/`anthropic`** — expired/revoked key or quota. Check the provider dashboard; `429` should be self-healing via fallback.
+
+---
+
+## Fixing
+
+- **Stale/missing tier key:** the value lives in Bitwarden (`dev/jetson/llm-api-key` → `JETSON_API_KEY`). Add it to `.env.secrets` (back it up first; **Unraid has no python3** — use bash/jq), then `docker compose up -d --force-recreate --no-deps workers core-api`.
+- **Config change:** `config/ai-routing.yaml` is **bind-mounted into 5 services**, so a new image is *not* enough — update the host copy with `git checkout origin/main -- config/ai-routing.yaml` **as root** (as `claude` the fetch fails locking root-owned refs and silently leaves the OLD file in place).
+- After the fix, confirm recovery in the data, not by eye:
+  ```sql
+  SELECT model, COUNT(*) FILTER (WHERE error IS NOT NULL) AS errors, COUNT(*) AS calls
+  FROM ai_audit_log WHERE created_at > now() - interval '30 minutes' GROUP BY 1;
+  ```
+  `errors = 0` is the DoD.
+
+---
+
+## Gaps (known)
+
+- **No Pushover path.** These rules are Grafana-visible only. Every other operational alert that reaches a phone does so from a workers skill (`PushoverService`). If this class of outage should page, add a check to `pipeline-health` (which already owns the backup dead-man's switch) rather than wiring Alertmanager.
+- **Workers' outbound metrics piggyback** on `container-health` (15m) / `pipeline-health` (6h) pushes — they are not exported on their own schedule. If both skills stop running, this metric goes stale silently; `workers-staleness.yml` is the backstop for that.
+- **The metric is in-process.** A workers restart resets the histogram, so a short post-restart window can under-report.


### PR DESCRIPTION
**#289's premise was wrong, and the investigation is the finding: the tier fallback is working exactly as designed — and its refusal to fire is *why there was no cost leak*.**

## The actual answer
`shouldAttemptFallback` matches only transient errors:
```ts
/429|500|502|503|rate.limit|overloaded|timeout|ECONNREFUSED|ETIMEDOUT/i
```
**401 is deliberately absent.** So the Jetson's auth failure **failed fast instead of silently escalating 461 calls to paid Claude** — the 2026-04-15 $100-incident shape. The config comment (*"if Jetson is down, fallback chain…"*) describes an **outage** (`ECONNREFUSED`/`timeout`), which **is** matched.

**Down → falls back. Misconfigured → fails loudly.** That distinction is correct and is not being "fixed".

## Also disproved (I was wrong 3×)
| I claimed | Reality |
|---|---|
| the same-provider filter empties the chain | that filter is only on the **agent** path; classification uses `completeWithTierFallback` |
| `t1_jetson` declares no `fallback` | it declares `t1_spark` — my `grep -A 14` window was too small (**my own #283 comments pushed it out**) |
| `recordOutbound` has **zero** call sites; CLAUDE.md is FALSE | **4 sites exist** via the `timeOutboundCall` wrapper — I grepped the inner function. **CLAUDE.md was right.** |

Prometheus is empty only because IA-M4 shipped ~07-14 and the last LLM call was 07-13. The push path demonstrably works (proved live by triggering `container-health`).

## The real gap — narrow, and this fixes it
**Nothing watches the metric.** A free tier failing 100% is indistinguishable from an idle one: cost stays $0, no fallback fires (correctly), and `ai_audit_log` recorded all 461 errors that nothing reads.

- **`OutboundProviderFailing`** (warning) — >50% of `{provider, operation}` failing over 30m
- **`OutboundProviderTotallyFailing`** (critical) — **100% failing with real traffic** over 15m, the literal #283 signature

**A ratio, not a count:** fires on sustained *total* failure regardless of volume, and an idle tier yields `0/0` → no series → no false alarm. A count would page on a retry burst and stay silent on a low-volume tier that is fully broken.

## Verification — the CI gate alone was not enough
`scripts/validate-alert-rules.sh` passes **9/9**, but it falls back to `python3 yaml.safe_load()` when promtool is absent (which it is, in CI) — **that checks YAML syntax, not PromQL**. A semantically broken rule would have merged green. So both expressions were **executed against the live Prometheus API** → `status=success`. Same lesson as #275/#278: *a passing check that cannot test the thing you changed is not evidence.*

## Honest scope
**No Alertmanager is configured** (documented in budget.yml), so these rules are **Grafana/Alerts-tab visible — they will not page anyone.** Real notification is application-layer Pushover from workers skills. This makes the failure *visible*, not *loud*. Recorded as a known gap in the runbook with the concrete next step (add a check to `pipeline-health`, which already owns the backup dead-man's switch — not wiring Alertmanager).

The runbook leads with the trap that cost two weeks: **`/v1/models` answers 200 unauthenticated while completions 401**, so "the endpoint is up" proves nothing.

LAB_NOTEBOOK Entry 206. Closes #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)