### PR TITLE
docs(notebook): Entry 215 — scheduler fix deployed, outage resolved

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13756,3 +13756,25 @@ Every infra Pushover arrives titled **"From Voice Capture"** (the Pushover app i
 
 **Tags:** [debug] [pipeline] [decision]
 **Environment:** worktree dev + real-Redis integration (docker redis:7.4 on 6381) + 5 live BullMQ probe scripts. No prod change this entry (the Entry 212 recreate already happened). Executed by Claude (Opus 4.8), user-directed ("B′").
+
+---
+
+## Entry 215 — DEPLOYED: scheduler fix live, 2-day outage OVER (2026-07-16)  [deploy] [pipeline]
+
+**PR #296 merged (`5e932e4`) → `build-images` rebuilt workers → recreated workers only.** #304 closed.
+
+**The fix proven in the production boot log:** `21 schedulers upserted, 0 orphans removed` — vs the bug's `21 registered / 21 removed ~30ms later`.
+
+**End-to-end proof:** `container-health` (`*/15`), frozen at 15:08 for 2 days, **fired on schedule at the next :45 boundary**; `openbrain_container_healthy` back in Pushgateway; `absent()` → empty ⇒ `WorkersMetricsAbsent` resolves. Longer-cadence jobs registered, will fire at their next boundary.
+
+**Deploy safety (Entry 212's two-gate procedure + an image pull):**
+- CI ran `scheduler-repeat-identity.test.ts` (6 tests) green against **real Redis on GitHub's runner** before merge.
+- Config-diff gate: **0 rendered changes** — the recreate picked up the new IMAGE only. postgres `StartedAt` unchanged; redis unchanged; `captures` = 11,301.
+- **`check-deploy-parity.sh`: exit 1 → exit 0.**
+
+**Incidental finding:** the WI-2.2 `GITEA_TOKEN` compose change rendered to a **0-line delta** — because the homeserver's `.env` DOES carry `GITEA_TOKEN`, so `${GITEA_TOKEN}` resolved to the same value `.env.secrets` provides. Confirms the clobber is a **DR-only latent bug** (#281), not a live one — exactly as documented. The fix still correctly hardens DR; it just wasn't biting in prod because `.env` happened to have the value.
+
+**Still open (deliberately):** the ingest-sidecar image (WI-1.1 honest-status + WI-1.3 electric-usage-downloader) built clean in CI but is **not yet recreated** — it's a separate, non-urgent deploy (both financial-ingest + utility-ingest together, per D140/Entry 201). And **#292** (deploy `backup.yml`) remains the last piece for #294.
+
+**Tags:** [deploy] [pipeline]
+**Environment:** homeserver. Scope: 1 compose reconciliation + workers image pull + workers recreate. Executed by Claude (Opus 4.8), user-directed ("Merge it").


### PR DESCRIPTION
Records the production deploy that restored scheduling (closes the loop on #304/#217). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKUTavLSvj1NE5cTS7YARu