### PR TITLE
fix(docker): un-hide scripts/actual from the build context (#311 build fix)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,14 @@ scripts/
 !scripts/utility-pipeline.py
 !scripts/lib/
 !scripts/lib/**
+# actual-ingest sidecar (#311) — re-include exactly what docker/actual-sidecar/
+# Dockerfile COPYs (NOT test/ or node_modules; node_modules stays excluded above).
+# Without these, `scripts/` above hides scripts/actual and the COPY fails at build.
+!scripts/actual/package.json
+!scripts/actual/package-lock.json
+!scripts/actual/actual-daily.mjs
+!scripts/actual/lib/
+!scripts/actual/lib/**
 
 # Test files (not needed in production image)
 **/__tests__/

--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13896,3 +13896,18 @@ Bringing prod current is the riskiest op class (a postgres/redis-adjacent recrea
 
 **Tags:** [deploy] [docker] [decision]
 **Environment:** laptop dev; no prod change. Executed by Claude (Opus 4.8), user-directed ("go").
+
+---
+
+## Entry 221 — the actual-ingest image STILL couldn't build: `.dockerignore` hid `scripts/actual` (2026-07-16)  [docker] [debug] [deploy]
+
+**Caught by WATCHING the build, not assuming it.** Merging #318 wired `actual-ingest` into `build-images`; its first-ever build on main **FAILED**: `COPY scripts/actual/lib` → `"/scripts/actual/lib": not found`. Root cause: `.dockerignore` excludes all of `scripts/` and re-includes only specific paths (`financial-pipeline.py`, `utility-pipeline.py`, `scripts/lib/**`) — `scripts/actual/**` was never negated, so it's absent from the build context. **A second-order #311 defect**, invisible until the image actually built (there was no local build in #311 — the exact gap Entry 200's rule exists to close).
+
+**Fix:** negate exactly what the Dockerfile COPYs — `package.json`, `package-lock.json`, `actual-daily.mjs`, `lib/**` (NOT `test/` or `node_modules`, which stays excluded). **Then BUILT IT LOCALLY** (Entry 200's rule, applied this time): image builds; `/app/lib` has all 5 `.mjs`; `@actual-app/api` present; the entrypoint runs and exits 1 with `missing required env ACTUAL_SERVER_URL` — the wiring works.
+
+**Blast note:** the failed run pushed core-api…ingest-sidecar (steps before actual-ingest) but NOT web-next (after it) — a partial push. Since #299/#300/#302 changed zero app TS, the images are code-identical anyway (D140), but the run is RED + `notify-failure` fired. This hotfix re-greens main and rebuilds actual-ingest + web-next.
+
+**Lesson (again, sharper):** a Dockerfile `COPY` is only proven by an actual build; `.dockerignore` is a silent second gate that a Dockerfile read cannot reveal. Build every new image locally before wiring it into `build-images`.
+
+**Tags:** [docker] [debug] [deploy]
+**Environment:** laptop dev + local `docker build` (image `actual-ingest:localtest`, built + entrypoint-verified). Executed by Claude (Opus 4.8), user-directed ("go").


### PR DESCRIPTION
Hotfix — main's `build-images` is RED after #318 wired `actual-ingest`: its first build failed with `COPY scripts/actual/lib` → `"/scripts/actual/lib": not found`.

**Cause:** `.dockerignore` excludes all of `scripts/` and re-includes only `financial-pipeline.py`, `utility-pipeline.py`, `scripts/lib/**`. `scripts/actual/**` was never negated → absent from the build context. A second-order #311 defect, invisible until the image actually built (no local build was done in #311).

**Fix:** negate exactly what `docker/actual-sidecar/Dockerfile` COPYs — `package.json`, `package-lock.json`, `actual-daily.mjs`, `lib/**` (not `test/` or `node_modules`).

**Proven locally this time** (`docker build`): image builds; `/app/lib` has all 5 `.mjs`; `@actual-app/api` present; entrypoint exits 1 with `missing required env ACTUAL_SERVER_URL` — wiring works. Re-greens `build-images` and rebuilds actual-ingest + web-next.

LAB_NOTEBOOK Entry 221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)