### PR TITLE
fix(observability): re-push backup-age gauge from container-health (#309)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13931,3 +13931,16 @@ The **`voice_sessions` REST feature** (core-api `routes/voice-sessions.ts` + `se
 
 **Tags:** [docker] [web] [decision]
 **Environment:** laptop dev; verified compose config -q / workers lint+test / web-next tsc. No prod change. Executed by Claude (Opus 4.8), user-directed ("tackle anything you can").
+
+---
+
+## Entry 223 — #309: container-health re-pushes the backup-age gauge (closes the 6h blind window) (2026-07-16)  [observability] [testing]
+
+**Objective:** `openbrain_backup_age_seconds` was absent for up to 6h after any Pushgateway restart (no persistence) because only `pipeline-health` (every 6h) pushed it — and `OpenBrainBackupStale` can't fire on an ABSENT metric (Entry 216's durability finding). **Rollback:** repo-only; `git revert`.
+
+**Fix:** extracted the stat+push into a shared `packages/workers/src/lib/backup-age.ts` (`pushBackupAgeGauge()` — graceful, returns null when the mount is absent) and called it from **`container-health`** (every 15m), so the gauge is refreshed 24×/day instead of 4×. Refactored `pipeline-health.checkBackupAge()` to use the same helper (DRY; it keeps its stale-threshold + Pushover logic). Both call the same `pushMetrics`, so pipeline-health's dead-man's-switch tests pass unchanged through the helper.
+
+**TDD:** 3 helper tests (present→gauge+age, absent→null+no-push, future-mtime→clamp-to-0, each RED first) + a container-health wiring test (mock the helper, assert it's called per run). Verified: 3 target files 46 tests; **full workers suite 1217 tests + coverage gate green**; workers `tsc` clean (dropped the now-unused `stat` import). Purely additive to the metric cadence — no behavior change to the stale logic.
+
+**Tags:** [observability] [testing]
+**Environment:** laptop dev; workers test+coverage green. No prod change (effect is on the next workers recreate). Executed by Claude (Opus 4.8), user-directed ("tackle anything you can").

--- a/packages/workers/src/__tests__/container-health.test.ts
+++ b/packages/workers/src/__tests__/container-health.test.ts
@@ -2,11 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { PushoverService } from '@open-brain/shared'
 import { ContainerHealthSkill, DEFAULT_ENDPOINTS } from '../skills/container-health.js'
 import type { ContainerEndpoint } from '../skills/container-health.js'
+import { pushBackupAgeGauge } from '../lib/backup-age.js'
 
 // Mock pushMetrics to prevent real HTTP calls to Pushgateway during tests
 vi.mock('../lib/push-metrics.js', () => ({
   pushMetrics: vi.fn().mockResolvedValue(undefined),
   buildExposition: vi.fn().mockReturnValue(''),
+}))
+
+// #309: container-health re-pushes the backup-age gauge every run. Mock the
+// shared helper so the wiring is asserted without touching fs/Pushgateway.
+vi.mock('../lib/backup-age.js', () => ({
+  pushBackupAgeGauge: vi.fn().mockResolvedValue(1234),
 }))
 
 // ============================================================
@@ -275,6 +282,14 @@ describe('ContainerHealthSkill', () => {
       const insertCalls = db.insert.mock.calls
       expect(insertCalls.length).toBeGreaterThan(0)
     })
+  })
+})
+
+describe('backup-age gauge (#309)', () => {
+  it('re-pushes the backup-age gauge on every run', async () => {
+    const { skill } = makeSkill()
+    await skill.execute()
+    expect(pushBackupAgeGauge).toHaveBeenCalled()
   })
 })
 

--- a/packages/workers/src/lib/__tests__/backup-age.test.ts
+++ b/packages/workers/src/lib/__tests__/backup-age.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the two side effects: fs.stat (the manifest) and the Pushgateway push.
+vi.mock('node:fs/promises', () => ({ stat: vi.fn() }))
+vi.mock('../push-metrics.js', () => ({ pushMetrics: vi.fn().mockResolvedValue(undefined) }))
+
+import { stat } from 'node:fs/promises'
+import { pushMetrics } from '../push-metrics.js'
+import type { MetricLine } from '../push-metrics.js'
+import { pushBackupAgeGauge } from '../backup-age.js'
+
+const statMock = stat as unknown as ReturnType<typeof vi.fn>
+const pushMock = pushMetrics as unknown as ReturnType<typeof vi.fn>
+
+function backupGaugePush(): MetricLine | undefined {
+  const calls = pushMock.mock.calls as [MetricLine[]][]
+  const hit = calls.find(([metrics]) => metrics.some((m) => m.name === 'openbrain_backup_age_seconds'))
+  return hit?.[0].find((m) => m.name === 'openbrain_backup_age_seconds')
+}
+
+describe('pushBackupAgeGauge', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('pushes openbrain_backup_age_seconds (gauge) and returns the age when the manifest exists', async () => {
+    statMock.mockResolvedValue({ mtime: new Date(Date.now() - 3_600_000) }) // 1h old
+    const age = await pushBackupAgeGauge('/x/manifest.json')
+    expect(age).toBeGreaterThanOrEqual(3595)
+    expect(age).toBeLessThanOrEqual(3605)
+    const gauge = backupGaugePush()
+    expect(gauge).toBeTruthy()
+    expect(gauge?.type).toBe('gauge')
+    expect(gauge?.value).toBe(age)
+  })
+
+  it('returns null and does NOT push when the manifest is absent', async () => {
+    statMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    const age = await pushBackupAgeGauge('/missing/manifest.json')
+    expect(age).toBeNull()
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+
+  it('clamps a future mtime to a non-negative age', async () => {
+    statMock.mockResolvedValue({ mtime: new Date(Date.now() + 60_000) }) // clock skew
+    const age = await pushBackupAgeGauge('/x/manifest.json')
+    expect(age).toBe(0)
+  })
+})

--- a/packages/workers/src/lib/backup-age.ts
+++ b/packages/workers/src/lib/backup-age.ts
@@ -1,0 +1,50 @@
+import { stat } from 'node:fs/promises'
+import { logger } from '@open-brain/shared'
+import { pushMetrics } from './push-metrics.js'
+
+/**
+ * Default location of the latest-backup manifest — the `${BACKUP_ROOT}/latest`
+ * symlink target, bind-mounted read-only into the workers container at
+ * `/backup-latest` (docker-compose.yml workers volumes).
+ */
+export const DEFAULT_BACKUP_MANIFEST_PATH = '/backup-latest/manifest.json'
+
+/**
+ * Stat the latest backup manifest and push the `openbrain_backup_age_seconds`
+ * gauge to Pushgateway. Returns the age in seconds, or `null` when the manifest
+ * is absent/unreadable (mount not deployed yet, local dev, CI).
+ *
+ * GRACEFUL: never throws — a missing manifest logs at debug and returns null;
+ * the push itself swallows its own errors (push-metrics).
+ *
+ * #309: this is pushed by BOTH `pipeline-health` (every 6h) AND `container-health`
+ * (every 15m). Pushgateway has no persistence, so after a Pushgateway restart the
+ * gauge would be ABSENT for up to 6h if only pipeline-health pushed it — and
+ * `OpenBrainBackupStale` cannot fire on an absent metric. The 15-minute cadence
+ * from container-health closes that blind window.
+ */
+export async function pushBackupAgeGauge(
+  manifestPath: string = process.env.BACKUP_LATEST_PATH ?? DEFAULT_BACKUP_MANIFEST_PATH,
+): Promise<number | null> {
+  let mtimeMs: number
+  try {
+    const stats = await stat(manifestPath)
+    mtimeMs = stats.mtime.getTime()
+  } catch (err) {
+    logger.debug({ err, manifestPath }, '[backup-age] manifest unavailable — skipping gauge push')
+    return null
+  }
+
+  const ageSeconds = Math.max(0, Math.floor((Date.now() - mtimeMs) / 1000))
+
+  await pushMetrics([
+    {
+      name: 'openbrain_backup_age_seconds',
+      value: ageSeconds,
+      help: 'Seconds since the latest backup manifest (scripts/backup.sh) was last written',
+      type: 'gauge',
+    },
+  ])
+
+  return ageSeconds
+}

--- a/packages/workers/src/skills/container-health.ts
+++ b/packages/workers/src/skills/container-health.ts
@@ -5,6 +5,7 @@ import { BaseSkill } from './base-skill.js'
 import type { BaseResult, BaseSkillOpts } from './types.js'
 import { pushMetrics } from '../lib/push-metrics.js'
 import type { MetricLine } from '../lib/push-metrics.js'
+import { pushBackupAgeGauge } from '../lib/backup-age.js'
 
 // ============================================================
 // Types
@@ -143,6 +144,13 @@ export class ContainerHealthSkill extends BaseSkill<ContainerHealthOptions, Cont
 
     // Step 2.5: Push container health metrics to Pushgateway
     await this.pushContainerMetrics(checks)
+
+    // Step 2.6: Re-push the backup-age gauge on this 15-min cadence (#309).
+    // Pushgateway has no persistence; after a restart the gauge would be ABSENT
+    // for up to 6h if only pipeline-health (every 6h) pushed it — and
+    // OpenBrainBackupStale cannot fire on an absent metric. Graceful/no-op if the
+    // /backup-latest mount is absent.
+    await pushBackupAgeGauge()
 
     // Step 3: Check for consecutive failures and send alerts
     const alertsSent: string[] = []

--- a/packages/workers/src/skills/pipeline-health.ts
+++ b/packages/workers/src/skills/pipeline-health.ts
@@ -1,9 +1,9 @@
 import { Queue } from 'bullmq'
 import type { ConnectionOptions } from 'bullmq'
-import { stat } from 'node:fs/promises'
 import type { Database, PipelineEventStage } from '@open-brain/shared'
 import { logger } from '@open-brain/shared'
 import { pushMetrics } from '../lib/push-metrics.js'
+import { pushBackupAgeGauge, DEFAULT_BACKUP_MANIFEST_PATH } from '../lib/backup-age.js'
 import type { MetricLine } from '../lib/push-metrics.js'
 import { BaseSkill } from './base-skill.js'
 import type { BaseResult, BaseSkillOpts } from './types.js'
@@ -128,7 +128,6 @@ const DEFAULT_WAITING_THRESHOLD = 100
  * Default max age (93600s = 26h) mirrors config/prometheus/alerts/backup.yml
  * (backup.sh runs daily; 26h = one full day + a 2h grace margin).
  */
-const DEFAULT_BACKUP_MANIFEST_PATH = '/backup-latest/manifest.json'
 const DEFAULT_BACKUP_MAX_AGE_SECONDS = 93600
 
 // ============================================================
@@ -446,25 +445,13 @@ export class PipelineHealthSkill extends BaseSkill<PipelineHealthOptions, Pipeli
     const envMaxAge = process.env.BACKUP_MAX_AGE_SECONDS ? Number(process.env.BACKUP_MAX_AGE_SECONDS) : NaN
     const maxAgeSeconds = Number.isFinite(envMaxAge) && envMaxAge > 0 ? envMaxAge : DEFAULT_BACKUP_MAX_AGE_SECONDS
 
-    let mtimeMs: number
-    try {
-      const stats = await stat(manifestPath)
-      mtimeMs = stats.mtime.getTime()
-    } catch (err) {
-      logger.debug({ err, manifestPath }, '[pipeline-health] backup manifest unavailable — skipping backup-age check')
+    // Stat the manifest + push the openbrain_backup_age_seconds gauge (shared
+    // helper — container-health re-pushes it every 15m so it survives a
+    // Pushgateway restart, #309). Returns null when the manifest is absent.
+    const ageSeconds = await pushBackupAgeGauge(manifestPath)
+    if (ageSeconds === null) {
       return { ageSeconds: null, stale: false, maxAgeSeconds }
     }
-
-    const ageSeconds = Math.max(0, Math.floor((Date.now() - mtimeMs) / 1000))
-
-    await pushMetrics([
-      {
-        name: 'openbrain_backup_age_seconds',
-        value: ageSeconds,
-        help: "Seconds since the latest backup manifest (scripts/backup.sh) was last written",
-        type: 'gauge',
-      },
-    ])
 
     const stale = ageSeconds > maxAgeSeconds
     if (stale) {


### PR DESCRIPTION
Closes #309.

`openbrain_backup_age_seconds` was absent for up to 6h after any Pushgateway restart (no persistence) because only `pipeline-health` (every 6h) pushed it — and `OpenBrainBackupStale` **cannot fire on an absent metric** (Entry 216's durability finding).

**Fix:** extracted the stat+push into a shared `lib/backup-age.ts` (`pushBackupAgeGauge()` — graceful, returns null when the `/backup-latest` mount is absent) and call it from **`container-health` (every 15m)** → gauge refreshed 24×/day instead of 4×, closing the blind window. Refactored `pipeline-health.checkBackupAge()` to use the same helper (DRY; it keeps its stale-threshold + Pushover logic; both call the same `pushMetrics`, so its dead-man's-switch tests pass unchanged).

**TDD:** 3 helper tests (present→gauge, absent→null+no-push, future-mtime→clamp) + a container-health wiring test, each RED first. Verified: full workers suite **1217 tests + coverage gate green**; `tsc` clean (dropped the now-unused `stat` import). Additive to the metric cadence — no change to the stale logic.

LAB_NOTEBOOK Entry 223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)