### PR TITLE
fix(scheduler): run repeatable jobs in America/New_York, not UTC (#295)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13944,3 +13944,16 @@ The **`voice_sessions` REST feature** (core-api `routes/voice-sessions.ts` + `se
 
 **Tags:** [observability] [testing]
 **Environment:** laptop dev; workers test+coverage green. No prod change (effect is on the next workers recreate). Executed by Claude (Opus 4.8), user-directed ("tackle anything you can").
+
+---
+
+## Entry 224 — #295: scheduled jobs now run in America/New_York, not UTC (2026-07-16)  [pipeline] [config]
+
+**Objective:** BullMQ defaults to UTC, so on the ET homeserver every repeatable fired ~4–5h early — morning-brief `30 6` fired at **02:30 ET**, not 06:30. **Rollback:** repo-only; `git revert`.
+
+**Fix:** one line at the single registration choke point — `upsertJobScheduler(id, { pattern, tz: 'America/New_York' }, …)` (const `SCHEDULER_TIMEZONE`). Verified against installed **BullMQ 5.70.4** that `upsertJobScheduler`'s repeat opts honor `tz` (`job-scheduler.js:78`). **Clean under the D149 model:** the scheduler key is the stable job id (not a content hash), so `tz` updates each schedule **in place** on the next boot — the WI-8.2 "re-keys every job" worry applied only to the old `.add({repeat})` API. Verified: scheduler-register/reconcile/slots 18 tests; full workers suite 1217 + coverage gate; **`scheduler.ts` held its 100/100/100/100 per-file lock**; `tsc` clean. Slot registry test unaffected (tz-agnostic — it checks minute/hour/dow).
+
+**⚠️ Flag for Troy (WI-8.2, NOT done here):** the fix moves the BullMQ morning cluster (wiki-synthesis `0 6`, daily-connections `10 6`, cost-analysis `20 6`, morning-brief `30 6`, capture-reminder `45 6`, budget-check `0 7`, drift-monitor `15 7`) from ~02:00–03:15 ET onto **06:00–07:15 ET — the same wall-clock as the HOST-cron ingest cluster** (financial `0 6`, utility `30 6`, actual-ingest `0 6`). Different schedulers (no shared slot registry), so it's a **resource-contention** question, not a correctness one — two LLM-heavy jobs (wiki-synthesis, morning-brief) now coincide with the ingest jobs. Mitigating: financial-ingest is idle (Plaid dropped, D138). **Decide whether to re-space the BullMQ morning cluster** (e.g. shift to 05:xx or 08:xx ET); I left the spacing as-is since re-spacing is a deliberate scheduling call, not part of the tz correctness fix.
+
+**Tags:** [pipeline] [config]
+**Environment:** laptop dev; workers 1217 + coverage + scheduler 100% lock green. No prod change (applies on next workers boot; schedules update in place). Executed by Claude (Opus 4.8), user-directed ("tackle anything you can").

--- a/packages/workers/src/scheduler.ts
+++ b/packages/workers/src/scheduler.ts
@@ -29,6 +29,16 @@ interface RegisteredScheduler {
 }
 
 /**
+ * All cron patterns below are interpreted in this timezone (#295). BullMQ defaults
+ * to UTC, so before this the homeserver (America/New_York) fired every job at its
+ * cron-hour UTC — e.g. morning-brief `30 6` fired at 02:30 ET, not 06:30. With the
+ * v5 upsertJobScheduler model the scheduler key is the stable job id (not a
+ * content hash), so setting tz updates each schedule IN PLACE on the next boot —
+ * no re-keyed orphans (that was a concern only under the old `.add({repeat})` API).
+ */
+const SCHEDULER_TIMEZONE = 'America/New_York'
+
+/**
  * Minimal queue surface needed by {@link reconcileRepeatableJobs}. Keeps the
  * function decoupled from Queue's DataType variance and trivially mockable.
  * Uses the v5 Job Scheduler API — `getJobSchedulers()` returns BOTH v5
@@ -110,6 +120,10 @@ export async function reconcileRepeatableJobs(
 /**
  * Registers repeatable BullMQ jobs on their respective queues.
  *
+ * ALL cron patterns are interpreted in America/New_York (`SCHEDULER_TIMEZONE`,
+ * #295) — the "6:00 AM" times below are Eastern, as intended. Before #295 BullMQ
+ * used UTC, so these fired ~4–5h early (morning-brief at 02:30 ET, not 06:30).
+ *
  * Jobs registered:
  * - daily-sweep: 3:00 AM daily (cron: 0 3 * * *) — re-queues stuck pipeline captures
  * - wiki-synthesis:           6:00 AM daily    (cron: 0 6 * * *)    — anchor (unchanged)
@@ -189,11 +203,11 @@ export async function registerScheduledJobs(
     const schedulable = queue as unknown as {
       upsertJobScheduler(
         schedulerId: string,
-        repeat: { pattern: string },
+        repeat: { pattern: string; tz: string },
         template: { name: string; data: DataType },
       ): Promise<unknown>
     }
-    await schedulable.upsertJobScheduler(jobId, { pattern }, { name, data })
+    await schedulable.upsertJobScheduler(jobId, { pattern, tz: SCHEDULER_TIMEZONE }, { name, data })
     const list = registeredByQueue.get(queue) ?? []
     list.push({ id: jobId, pattern })
     registeredByQueue.set(queue, list)


### PR DESCRIPTION
Closes #295.

BullMQ defaults to UTC, so on the ET homeserver every repeatable fired ~4–5h early — **morning-brief `30 6` fired at 02:30 ET**, not 06:30.

**Fix:** one line at the single `upsertJobScheduler` choke point — `{ pattern, tz: 'America/New_York' }`. Verified BullMQ **5.70.4** honors `tz` in repeat opts (`job-scheduler.js:78`). **Clean under the D149 model:** the scheduler key is the stable job id (not a content hash), so `tz` updates each schedule **in place** on the next boot — no re-keyed orphans (the WI-8.2 "re-keys every job" concern applied only to the old `.add({repeat})` API).

**Verified:** scheduler-register/reconcile/slots (18) + full workers suite **1217 + coverage gate**; `scheduler.ts` held its **100/100/100/100** per-file lock; `tsc` clean. Slot-registry test unaffected (tz-agnostic).

## ⚠️ Flagged for a decision (WI-8.2, not done here)
The fix moves the BullMQ morning cluster (wiki-synthesis `0 6`, daily-connections `10 6`, cost-analysis `20 6`, morning-brief `30 6`, capture-reminder `45 6`, budget-check `0 7`, drift-monitor `15 7`) onto **06:00–07:15 ET — the same wall-clock as the host-cron ingest cluster** (financial `0 6`, utility `30 6`, actual-ingest `0 6`). Different schedulers, so it's **resource contention**, not correctness — two LLM-heavy jobs now coincide with ingest. Mitigating: financial-ingest is idle (Plaid dropped). **Decide whether to re-space the BullMQ morning cluster.** I left it as-is (re-spacing is a deliberate scheduling call).

LAB_NOTEBOOK Entry 224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)