### PR TITLE
fix(search): align POST temporal_weight default to 0.0 (part of #71)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -13957,3 +13957,12 @@ The **`voice_sessions` REST feature** (core-api `routes/voice-sessions.ts` + `se
 
 **Tags:** [pipeline] [config]
 **Environment:** laptop dev; workers 1217 + coverage + scheduler 100% lock green. No prod change (applies on next workers boot; schedules update in place). Executed by Claude (Opus 4.8), user-directed ("tackle anything you can").
+
+---
+
+## Entry 225 — #71 (partial): fixed the temporal_weight verb inconsistency (2026-07-16)  [api] [search]
+
+**The concrete bug within the #71 tuning epic:** `GET /api/v1/search` defaulted `temporal_weight` to **0.0** (`routes/search.ts:17`) but `POST` defaulted to **0.1** (`schemas/search.ts:24`) — the same endpoint returning different rankings by HTTP verb for an omitted param. The shared contract (`shared/src/types/search.ts:9`) AND CLAUDE.md already document the default as **0.0 (cold start)**, so POST was the lone outlier. Aligned POST → 0.0; updated the test-lock (`search-routes.test.ts:499`, which pinned the 0.1 divergence) to 0.0. slack-bot passes `0.1` explicitly at both call sites → unaffected. Verified: search-routes 34 tests, core-api `tsc` clean. **#71 stays OPEN** — the two other WI-9.1 items (related-captures backend built-but-UI-missing; Hebbian boost hardcoded at `search.ts:328` rather than configurable) are larger and untouched. **Rollback:** repo-only; `git revert`.
+
+**Tags:** [api] [search]
+**Environment:** laptop dev. No prod change. Executed by Claude (Opus 4.8), user-directed ("tackle anything you can").

--- a/packages/core-api/src/__tests__/search-routes.test.ts
+++ b/packages/core-api/src/__tests__/search-routes.test.ts
@@ -496,7 +496,7 @@ describe('POST /api/v1/search', () => {
     expect(searchService.searchWithRelated).not.toHaveBeenCalled()
   })
 
-  it('uses default values for optional fields (limit=10, offset=0, temporal_weight=0.1)', async () => {
+  it('uses default values for optional fields (limit=10, offset=0, temporal_weight=0.0 — #71, matches GET)', async () => {
     const app = createApp({ searchService: searchService as any })
     await app.request('/api/v1/search', {
       method: 'POST',
@@ -508,7 +508,7 @@ describe('POST /api/v1/search', () => {
       'defaults test',
       expect.objectContaining({
         limit: 10,
-        temporalWeight: 0.1,
+        temporalWeight: 0.0,
       }),
     )
   })

--- a/packages/core-api/src/schemas/search.ts
+++ b/packages/core-api/src/schemas/search.ts
@@ -21,7 +21,11 @@ export const searchSchema = z.object({
   brain_views: z.array(z.string()).optional(),
   start_date: z.string().datetime().optional(),
   end_date: z.string().datetime().optional(),
-  temporal_weight: z.number().min(0).max(1).default(0.1),
+  // #71: aligned to the GET default and the documented cold-start default (0.0).
+  // Previously 0.1, so POST and GET returned different rankings for the same
+  // omitted param. Callers wanting temporal decay pass it explicitly (slack-bot
+  // sends 0.1).
+  temporal_weight: z.number().min(0).max(1).default(0.0),
   search_mode: z.enum(SEARCH_MODES).default('hybrid'),
   fts_weight: z.number().min(0).max(1).default(0.5),
   vector_weight: z.number().min(0).max(1).default(0.5),


### PR DESCRIPTION
Addresses the concrete bug within #71 (leaves the epic open).

`GET /api/v1/search` defaulted `temporal_weight` to **0.0** but `POST` defaulted to **0.1** — the same endpoint returning different rankings by HTTP verb for an omitted param. The shared contract (`shared/src/types/search.ts:9`) and CLAUDE.md both document the default as **0.0 (cold start)**, so POST was the lone outlier.

- Aligned POST → `0.0`; updated the test-lock (`search-routes.test.ts:499`) that pinned the divergence.
- slack-bot passes `0.1` explicitly at both call sites → unaffected.
- Verified: search-routes 34 tests, core-api `tsc` clean.

**#71 stays open** — its other WI-9.1 items (related-captures backend built but UI-less; Hebbian boost hardcoded rather than configurable) are larger and untouched.

LAB_NOTEBOOK Entry 225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)