### PR TITLE
feat(#301): migrate faster-whisper -> speaches (OpenAI-compatible)

### DIFF
--- a/LAB_NOTEBOOK.md
+++ b/LAB_NOTEBOOK.md
@@ -14224,3 +14224,20 @@ The **`voice_sessions` REST feature** (core-api `routes/voice-sessions.ts` + `se
 
 **Tags:** [decision]
 **Environment:** local (VM); GitHub issues via `gh`. Executed by Claude (Opus 4.8).
+
+## Entry 247 — CS-5/WI-5.1: migrate faster-whisper → speaches (2026-07-18)  [config] [deploy] [decision]
+
+**Objective:** #301/D153 — swap the STT service from `fedirz/faster-whisper-server:0.5.0-cpu` to its OpenAI-compatible successor **speaches** (`ghcr.io/speaches-ai/speaches:latest-cpu`), keeping the compose service NAME `faster-whisper` so `WHISPER_URL` consumers + `container-health.ts:64` probe are untouched. Facts pinned by WI-5.0 (Entry 246) + verified against speaches' own `compose.yaml`/`compose.cpu.yaml`.
+
+**Changes (this PR, branch `feat/301-migrate-speaches`):**
+- `docker-compose.yml` faster-whisper: image swap; env `WHISPER__DEVICE`→`WHISPER__INFERENCE_DEVICE: cpu`, keep `WHISPER__COMPUTE_TYPE: int8`, **drop `WHISPER__MODEL`**, add `PRELOAD_MODELS: '["Systran/faster-whisper-large-v3"]'`. New named volume `hf_hub_cache:/home/ubuntu/.cache/huggingface/hub` (old `whisper_model_cache` retained for rollback, NOT reused → ~3 GB re-download first boot). Bind-mount `config/whisper/model_aliases.json` → FIXED `/home/ubuntu/speaches/model_aliases.json:ro`. Healthcheck → speaches' known-good `curl --fail http://127.0.0.1:8000/health` (its image ships curl; 127.0.0.1 per house rule); `start_period` 120s→**300s** (first-boot model download).
+- New `config/whisper/model_aliases.json` = `{"whisper-1":"Systran/faster-whisper-large-v3"}` → our `model=whisper-1` POST resolves, `transcription.ts` UNCHANGED except the latent default-port fix.
+- `transcription.ts:5` default `…:10300`→`…:8000` (latent bug; prod always sets `WHISPER_URL` so never hit).
+- Doc accuracy: `README.md` + `docs/runbooks/deploy.md` image name (left archived/ADR/TDD historical refs + the unchanged `10300` host-port refs).
+
+**Hypothesis / success criteria:** voice-capture `test` 112/112 + `lint` (tsc) clean + compose YAML parses (all ✅). ON DEPLOY (WI-5.2): container healthy on `/health`, a real iOS-Shortcut capture transcribes via whisper-1→alias→large-v3, `verbose_json` returns text+segments. speaches `verbose_json` is OpenAI-compatible and `transcription.ts` defaults every field but `text`, so a shape mismatch degrades (empty segments), never crashes — live check happens at deploy.
+
+**Merge vs deploy:** merging lands this on `main` ONLY; the running stack is unaffected until the operator `pull` + `up -d --force-recreate --no-deps faster-whisper` (WI-5.2). No auto-deploy from main.
+
+**Rollback:** revert PR → 0.5.0 image + `whisper_model_cache` (retained) + port 10300 default; `--force-recreate`. **Tags:** [config] [deploy] [decision]
+**Environment:** local (VM); branch `feat/301-migrate-speaches` → PR. Executed by Claude (Opus 4.8).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Single `open-brain` Docker network. All services defined in `docker-compose.yml`
 | `open-brain-workers` | build: target=workers | BullMQ workers — embed, classify, extract entities, triggers, skills |
 | `open-brain-slack-bot` | build: target=slack-bot | @slack/bolt Socket Mode — capture + query + commands |
 | `open-brain-voice-capture` | build: target=voice-capture | HTTP endpoint for iOS Shortcut; proxies to faster-whisper |
-| `open-brain-faster-whisper` | fedirz/faster-whisper-server:0.5.0-cpu | Speech-to-text (large-v3, CPU int8) |
+| `open-brain-faster-whisper` | ghcr.io/speaches-ai/speaches:latest-cpu | Speech-to-text (large-v3, CPU int8; #301) |
 | `open-brain-web-next` | build: packages/web-next/Dockerfile | Next.js 16 + Cloudscape + React 19 + TanStack Query — sole UI package; canonical ingress at brain.troy-davis.com |
 | `open-brain-file-ingestion` | build: packages/file-ingestion | FastAPI sidecar — extracts text from PDF/DOCX/XLSX/PPTX/etc. for the document pipeline |
 | `open-brain-financial-ingest` / `utility-ingest` | image: alpine + cron | Hourly Python pullers for financial + utility data; results POST'd to `/api/v1/captures` |

--- a/config/whisper/model_aliases.json
+++ b/config/whisper/model_aliases.json
@@ -1,0 +1,3 @@
+{
+  "whisper-1": "Systran/faster-whisper-large-v3"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ networks:
 volumes:
   postgres_data:
   redis_data:
-  whisper_model_cache:
+  whisper_model_cache:  # #301: retained for rollback to the pre-speaches image
+  hf_hub_cache:         # #301: speaches HF hub cache at /home/ubuntu/.cache/huggingface/hub
   financial_ingest_data:
   utility_ingest_data:
   admin_prewipe_backup:
@@ -357,22 +358,32 @@ services:
   # --- Voice services: iOS Shortcut → voice-capture → faster-whisper batch transcription (the LIVE path) ---
 
   faster-whisper:
-    image: fedirz/faster-whisper-server:0.5.0-cpu
+    # #301/D153: migrated fedirz/faster-whisper-server -> speaches (its OpenAI-compatible
+    # successor: same /v1/audio/transcriptions + /health on :8000). Service NAME kept as
+    # `faster-whisper` so WHISPER_URL consumers + container-health probe stay unchanged.
+    # speaches loads models per-request (no WHISPER__MODEL) — model=whisper-1 resolves via
+    # the model_aliases.json mount; PRELOAD_MODELS warms large-v3 at startup.
+    image: ghcr.io/speaches-ai/speaches:latest-cpu
     container_name: open-brain-faster-whisper
     environment:
-      WHISPER__MODEL: large-v3
-      WHISPER__DEVICE: cpu
+      WHISPER__INFERENCE_DEVICE: cpu
       WHISPER__COMPUTE_TYPE: int8
+      PRELOAD_MODELS: '["Systran/faster-whisper-large-v3"]'
     ports:
       - "127.0.0.1:10300:8000"
     volumes:
-      - whisper_model_cache:/root/.cache/huggingface
+      # New named volume at speaches' non-root HF cache path (container runs as `ubuntu`).
+      # The old whisper_model_cache (/root/.cache) is intentionally NOT reused -> ~3 GB
+      # re-download of large-v3 on first boot; the old volume is retained for rollback.
+      - hf_hub_cache:/home/ubuntu/.cache/huggingface/hub
+      - ./config/whisper/model_aliases.json:/home/ubuntu/speaches/model_aliases.json:ro
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      # speaches' own known-good check (its image ships curl); 127.0.0.1 per house rule.
+      test: ["CMD", "curl", "--fail", "http://127.0.0.1:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 120s
+      start_period: 300s  # first boot downloads ~3 GB large-v3 before /health is ready
     mem_limit: 8g
     cpus: '4'
     networks:

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -21,7 +21,7 @@
 | `open-brain-file-ingestion` | `ghcr.io/davistroy/open-brain/file-ingestion:latest` | `127.0.0.1:8080` |
 | `open-brain-financial-ingest` | `ghcr.io/davistroy/open-brain/ingest-sidecar:latest` | — |
 | `open-brain-utility-ingest` | `ghcr.io/davistroy/open-brain/ingest-sidecar:latest` | — |
-| `open-brain-faster-whisper` | `fedirz/faster-whisper-server:0.5.0-cpu` | `127.0.0.1:10300` |
+| `open-brain-faster-whisper` | `ghcr.io/speaches-ai/speaches:latest-cpu` | `127.0.0.1:10300` |
 | `open-brain-cloudflared` | `cloudflare/cloudflared:2025.6.1` | — |
 
 **12 containers total**, all in this compose project.

--- a/packages/voice-capture/src/services/transcription.ts
+++ b/packages/voice-capture/src/services/transcription.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@open-brain/shared'
 
 const logger = createLogger('voice-transcription')
 
-const WHISPER_URL = process.env.WHISPER_URL ?? 'http://faster-whisper:10300'
+const WHISPER_URL = process.env.WHISPER_URL ?? 'http://faster-whisper:8000'
 const TRANSCRIPTION_TIMEOUT_MS = 120_000 // 2 minutes — large-v3 CPU can be slow
 
 export interface TranscriptionResult {


### PR DESCRIPTION
## What

Migrates the STT service from the unmaintained `fedirz/faster-whisper-server:0.5.0-cpu` to its maintained, OpenAI-compatible successor **speaches** (`ghcr.io/speaches-ai/speaches:latest-cpu`). Same API surface (`/v1/audio/transcriptions`, `/health` on `:8000`), so the compose service name stays **`faster-whisper`** and every `WHISPER_URL` / `container-health` consumer is untouched (**D153**).

WI-5.1 of CS-5, built on the WI-5.0 findings (#359) and verified against speaches' own `compose.yaml` / `compose.cpu.yaml`.

## Changes

- **`docker-compose.yml`** faster-whisper:
  - image → `ghcr.io/speaches-ai/speaches:latest-cpu`
  - `WHISPER__DEVICE` → **`WHISPER__INFERENCE_DEVICE: cpu`**; keep `WHISPER__COMPUTE_TYPE: int8`; **drop `WHISPER__MODEL`** (speaches loads per-request); add **`PRELOAD_MODELS: '["Systran/faster-whisper-large-v3"]'`**
  - new named volume **`hf_hub_cache:/home/ubuntu/.cache/huggingface/hub`** (non-root cache path; old `whisper_model_cache` retained for rollback, not reused → ~3 GB re-download first boot)
  - bind-mount `config/whisper/model_aliases.json` → fixed **`/home/ubuntu/speaches/model_aliases.json:ro`** so `model=whisper-1` resolves with **zero app-code change**
  - healthcheck → speaches' known-good `curl --fail http://127.0.0.1:8000/health`; `start_period` 120s → **300s** (first-boot model download)
- **`config/whisper/model_aliases.json`** (new): `{"whisper-1":"Systran/faster-whisper-large-v3"}`
- **`transcription.ts:5`**: default `WHISPER_URL` port `10300` → `8000` (latent bug — prod always sets `WHISPER_URL`, so never hit)
- **`README.md`** + **`docs/runbooks/deploy.md`**: image name

## Verify

- `pnpm --filter @open-brain/voice-capture test` → **112 passed**
- `pnpm --filter @open-brain/voice-capture lint` (tsc) → clean
- compose YAML parses; alias JSON valid

## Deploy is separate (WI-5.2, operator)

**Merging lands this on `main` only — it does not deploy.** The running stack is unaffected until `pull` + `up -d --force-recreate --no-deps faster-whisper` on the homeserver, which is where the live `verbose_json` end-to-end check happens (drive a real iOS-Shortcut capture). speaches `verbose_json` is OpenAI-compatible and `transcription.ts` defaults every field but `text`, so a mismatch degrades (empty segments), never crashes.

## Rollback

Revert → `fedirz/faster-whisper-server:0.5.0-cpu` + `whisper_model_cache` (retained) + port `10300` default; `--force-recreate`.

Closes #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfdeCmSBCh8ye81rkwd55K